### PR TITLE
Py3K compatibility.

### DIFF
--- a/joblib/my_exceptions.py
+++ b/joblib/my_exceptions.py
@@ -5,7 +5,7 @@ Exceptions
 # Copyright: 2010, Gael Varoquaux
 # License: BSD 3 clause
 
-import exceptions
+import sys
 
 class JoblibException(Exception):
     """ A simple exception with an error message that you can get to.
@@ -65,8 +65,17 @@ def _mk_exception(exception, name=None):
 
 def _mk_common_exceptions():
     namespace = dict()
-    for name in dir(exceptions):
-        obj = getattr(exceptions, name)
+    if sys.version_info[0] == 3:
+        import builtins as _builtin_exceptions
+        common_exceptions = filter(
+            lambda x: x.endswith('Error'),
+            dir(_builtin_exceptions))
+    else:
+        import exceptions as _builtin_exceptions
+        common_exceptions = dir(_builtin_exceptions)
+
+    for name in common_exceptions:
+        obj = getattr(_builtin_exceptions, name)
         if isinstance(obj, type) and issubclass(obj, BaseException):
             try:
                 this_obj, this_name = _mk_exception(obj, name=name)

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -8,7 +8,12 @@ A pickler to save numpy arrays in separate .npy files.
 
 import pickle
 import traceback
-import os
+import sys, os
+
+if sys.version_info[0] == 3:
+    from pickle import _Unpickler as Unpickler
+else:
+    from pickle import Unpickler
 
 ################################################################################
 # Utility objects for persistence.
@@ -66,17 +71,17 @@ class NumpyPickler(pickle.Pickler):
 
 
 
-class NumpyUnpickler(pickle.Unpickler):
+class NumpyUnpickler(Unpickler):
     """ A subclass of the Unpickler to unpickle our numpy pickles.
     """
-    dispatch = pickle.Unpickler.dispatch.copy()
+    dispatch = Unpickler.dispatch.copy()
 
     def __init__(self, filename, mmap_mode=None):
         self._filename = filename
         self.mmap_mode = mmap_mode
         self._dirname  = os.path.dirname(filename)
         self.file = open(filename, 'rb')
-        pickle.Unpickler.__init__(self, self.file)
+        Unpickler.__init__(self, self.file)
         import numpy as np
         self.np = np
 
@@ -89,7 +94,7 @@ class NumpyUnpickler(pickle.Unpickler):
             NDArrayWrapper, by the array we are interested in. We
             replace directly in the stack of pickler.
         """
-        pickle.Unpickler.load_build(self)
+        Unpickler.load_build(self)
         if isinstance(self.stack[-1], NDArrayWrapper):
             nd_array_wrapper = self.stack.pop()
             if self.np.__version__ >= '1.3':


### PR DESCRIPTION
A couple of fixes that 2to3 could not handle. These deal with some of the 
most obscure parts of joblib, hopefully you'll find a more elegant solution.
- in joblib.my_exceptions: exception module has been removed
  somewhere between 3.1 and 3.2, so I just parse the builtins.
- in joblib.numpy_pickle : Unpickler object has no attribute
  dispatch, so I use the private class _Unpickler. I ignore if it
  could be implemented using any of the Unpickler methods [0].

[0] http://docs.python.org/release/3.1.3/library/pickle.html#pickle.Unpickler
