### PR TITLE
BUG: a fix toward 2.5 compatibility

### DIFF
--- a/joblib/logger.py
+++ b/joblib/logger.py
@@ -8,6 +8,7 @@ This module needs much love to become useful.
 # Copyright (c) 2008 Gael Varoquaux
 # License: BSD Style, 3 clauses.
 
+from __future__ import with_statement
 
 import time
 import sys


### PR DESCRIPTION
otherwise

```
  File "/tmp/buildd/joblib-0.6.0~b2/joblib/logger.py", line 117
    with open(logfile, 'w') as logfile:
            ^
```
