### PR TITLE
FIX: remaining python 2.5 compatibility issues

### DIFF
--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -150,7 +150,7 @@ def test_error_capture():
         ex = JoblibException
         Parallel(n_jobs=1)(
                     delayed(division)(x, y) for x, y in zip((0, 1), (1, 0)))
-    except Exception as e:
+    except Exception, e:
         ex = e
     nose.tools.assert_false(isinstance(ex, JoblibException))
 

--- a/sphinx_pypi_upload.py
+++ b/sphinx_pypi_upload.py
@@ -120,7 +120,7 @@ class UploadDoc(upload):
             http.putheader('Authorization', auth)
             http.endheaders()
             http.send(body)
-        except socket.error as e:
+        except socket.error, e:
             self.announce(str(e), log.ERROR)
             return
 


### PR DESCRIPTION
Adjusted sphinx_pypi_upload since otherwise
python2.5 setup.py nosetests
would fail to import that file (even though nothing to test) thus
reporting an error

BTW -- I am somewhat ignorant in either there is any difference between

except EXCEPTION as e

and 

except EXCEPTION, e

so would appreciate feedback .  I just know that the later seems to do what is needed in those cases on older and newer pythons
