### PR TITLE
BUG: indent zfile.close() appropriately + minor spell checks

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -76,7 +76,7 @@ def write_zfile(file_handle, data, compress=1):
     """Write the data in the given file as a Z-file.
 
     Z-files are raw data compressed with zlib used internally by joblib
-    for persistence. Backward compatibility is not garantied. Do not
+    for persistence. Backward compatibility is not guarantied. Do not
     use for external purposes.
     """
     file_handle.write(_ZFILE_PREFIX)
@@ -95,7 +95,7 @@ def write_zfile(file_handle, data, compress=1):
 class NDArrayWrapper(object):
     """ An object to be persisted instead of numpy arrays.
 
-        The only thing this object does, is to carrus the filename in wich
+        The only thing this object does, is to carry the filename in which
         the array has been persisted, and the array subclass.
     """
     def __init__(self, filename, subclass):
@@ -250,7 +250,7 @@ class NumpyPickler(pickle.Pickler):
             zfile = open(self._filename, 'wb')
             write_zfile(zfile,
                         self.file.getvalue(), self.compress)
-        zfile.close()
+            zfile.close()
 
 
 class NumpyUnpickler(Unpickler):


### PR DESCRIPTION
There is more of unittests failing remaining (or do they pass for you?)

> python setup.py test
> ...
> # .............................FF.................
> ## FAIL: joblib.test.test_numpy_pickle.test_numpy_persistence
> 
> Traceback (most recent call last):
>   File "/usr/lib/pymodules/python2.7/nose/case.py", line 187, in runTest
>     self.test(*self.arg)
>   File "/home/yoh/deb/gits/joblib/joblib/test/test_numpy_pickle.py", line 148, in test_numpy_persistence
>     nose.tools.assert_equal(len(filenames), len(obj) + 1)
> AssertionError: 1 != 2
> -------------------- >> begin captured stdout << ---------------------
> Failed to save <type 'numpy.ndarray'> to .npy file:
> Traceback (most recent call last):
>   File "/home/yoh/deb/gits/joblib/joblib/numpy_pickle.py", line 238, in save
>     obj, filename = self._write_array(obj, filename)
>   File "/home/yoh/deb/gits/joblib/joblib/numpy_pickle.py", line 210, in _write_array
>     write_zfile(zfile, state[-1],
> UnboundLocalError: local variable 'state' referenced before assignment

--------------------- >> end captured stdout << ----------------------
# 
## FAIL: joblib.test.test_numpy_pickle.test_memmap_persistence(False,)

Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/nose/case.py", line 187, in runTest
    self.test(*self.arg)
AssertionError: False is not true
