### PR TITLE
ENH: use np.random, fix doctest

### DIFF
--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -60,6 +60,7 @@ Main features
    inputs and  outputs: Python functions. Joblib can save their
    computation to disk and rerun it only if necessary::
 
+      >>> import numpy as np
       >>> from joblib import Memory
       >>> mem = Memory(cachedir='/tmp/joblib')
       >>> import numpy as np

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -93,7 +93,8 @@ def test_hash_methods():
 def test_hash_numpy():
     """ Test hashing with numpy arrays.
     """
-    arr1 = np.random.random((10, 10))
+    rnd = np.random.RandomState(0)
+    arr1 = rnd.random_sample((10, 10))
     arr2 = arr1.copy()
     arr3 = arr2.copy()
     arr3[0] += 1
@@ -160,7 +161,8 @@ def test_hash_numpy_performance():
         In [26]: %timeit hash(a)
         100 loops, best of 3: 20.8 ms per loop
     """
-    a = np.random.random(1000000)
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample(1000000)
     md5_hash = lambda x: hashlib.md5(np.getbuffer(x)).hexdigest()
 
     relative_diff = relative_time(md5_hash, hash, a)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -325,8 +325,10 @@ def test_memory_numpy():
                             verbose=0)
         memory.clear(warn=False)
         cached_n = memory.cache(n)
+
+        rnd = np.random.RandomState(0)
         for i in range(3):
-            a = np.random.random((10, 10))
+            a = rnd.random_sample((10, 10))
             for _ in range(3):
                 yield nose.tools.assert_true, np.all(cached_n(a) == a)
                 yield nose.tools.assert_equal, len(accumulator), i + 1

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -134,7 +134,8 @@ def test_value_error():
 @with_numpy
 def test_numpy_persistence():
     filename = env['filename']
-    a = np.random.random((10, 2))
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample((10, 2))
     for compress, cache_size in ((0, 0), (1, 0), (1, 10)):
         # We use 'a.T' to have a non C-contiguous array.
         for index, obj in enumerate(((a,), (a.T,), (a, a), [a, a, a])):
@@ -183,7 +184,8 @@ def test_numpy_persistence():
 
 @with_numpy
 def test_memmap_persistence():
-    a = np.random.random(10)
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample(10)
     filename = env['filename'] + str(random.randint(0, 1000))
     numpy_pickle.dump(a, filename)
     b = numpy_pickle.load(filename, mmap_mode='r')
@@ -195,7 +197,8 @@ def test_memmap_persistence():
 def test_masked_array_persistence():
     # The special-case picker fails, because saving masked_array
     # not implemented, but it just delegates to the standard pickler.
-    a = np.random.random(10)
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample(10)
     a = np.ma.masked_greater(a, 0.5)
     filename = env['filename'] + str(random.randint(0, 1000))
     numpy_pickle.dump(a, filename)


### PR DESCRIPTION
I got a random failure while working on the windows build of scikit-learn. It was in the hashing test and I noticed all the joblib tests use np.random so I changed it.

However that test could still be unstable: it seems to test for a time difference and given an old pc with rapidly heating cpu (such as mine) it is not reliable. Gael should know more about this, I'm just leaving this here -- I don't think it can hurt.

Vlad
