### PR TITLE
do not enable Parallel if multiprocessing.synchronize is N/A

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -28,6 +28,15 @@ if multiprocessing:
     except ImportError:
         multiprocessing = None
 
+# 2nd stage: validate that locking is available on the system and
+#            issue a warning if not
+if multiprocessing:
+    try:
+        import multiprocessing.synchronize
+    except ImportError, e:
+        multiprocessing = None
+        warnings.warn('%s.  joblib will operate in serial mode' % (e,))
+
 from .format_stack import format_exc, format_outer_frames
 from .logger import Logger, short_format_time
 from .my_exceptions import TransportableException, _mk_exception


### PR DESCRIPTION
Having finally tracked down not working multiprocessing.cpu_count on kfreebsd debian systems I ended up with
https://buildd.debian.org/status/fetch.php?pkg=statsmodels&arch=kfreebsd-i386&ver=0.4.2-1&stamp=1342080335
(look in the bottom)

So I wondered, shouldn't I just patch joblib also to require 'import multiprocessing.synchronize' to complete correctly for the check of multiprocessing existence
