### PR TITLE
Memory depends

### DIFF
--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -296,11 +296,29 @@ object and you ignore the argument passing this object in your cached
 function. In such case, it is necessary to invalidate the cache if the
 function which build the object has been modified.
 `Memory` provides the `depends` list::
-
-   >>> @memory.cache(ignore=['bigobject'], depends=[produceobject])
-   ... def my_func(bigobject, otherarg):
+   >>> def produce_object(param):
+   ...     """A function which builds a big object. 
+   ...        It can be memorized or not, but can be hardly used
+   ...        as a parameter of another memorized function because of 
+   ...        performance issues."""
+   ...     print('Produce the bigobject')
+   ...     return 'bigobject' + str(param)
+   >>> @memory.cache(ignore=['big_object'], depends=[produce_object])
+   ... def my_func_with_dependency(big_object, other_arg):
    ...      """Cache is invalidated if the function produceobject` has been modified"""
-   ...	    print('Called with bigobject = %s, otherarg = %s' % (str(x), str(otherarg))
+   ...	    print('Called with bigobject = %s, otherarg = %s' % (str(big_object), str(other_arg)))
+   >>> big_object1 = produce_object(1)
+   Produce the bigobject
+   >>> big_object2 = produce_object(2)
+   Produce the bigobject
+   >>> my_func_with_dependency(big_object1, 1) # Call the function with one particular parameter
+   Called with bigobject = bigobject1, otherarg = 1
+   >>> my_func_with_dependency(big_object2, 2) # Call with another parameter
+   Called with bigobject = bigobject2, otherarg = 2
+   >>> my_func_with_dependency(big_object1, 1) # Use results from cache
+   >>> # Now we assume the function 'produce_object' has been modified
+   >>> my_func_with_dependency(big_object1, 1) # Call function, cache has been invalidated
+
 
 
 .. _memory_reference:

--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -297,8 +297,9 @@ function. In such case, it is necessary to invalidate the cache if the
 function which build the object has been modified.
 `Memory` provides the `depends` list::
 
-   >>> @memory.cache(ignore=['bigobject'], depends=['produceobject'])
+   >>> @memory.cache(ignore=['bigobject'], depends=[produceobject])
    ... def my_func(bigobject, otherarg):
+   ...      """Cache is invalidated if the function produceobject` has been modified"""
    ...	    print('Called with bigobject = %s, otherarg = %s' % (str(x), str(otherarg))
 
 

--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -287,6 +287,21 @@ change, for instance a debug flag. `Memory` provides the `ignore` list::
     >>> # my_func was not reevaluated
 
 
+Watching other functions
+------------------------
+
+It may be useful to recalculate a function when another function
+has changed. For example another function produces a big and complex 
+object and you ignore the argument passing this object in your cached
+function. In such case, it is necessary to invalidate the cache if the
+function which build the object has been modified.
+`Memory` provides the `depends` list::
+
+   >>> @memory.cache(ignore=['bigobject'], depends=['produceobject'])
+   ... def my_func(bigobject, otherarg):
+   ...	    print('Called with bigobject = %s, otherarg = %s' % (str(x), str(otherarg))
+
+
 .. _memory_reference:
 
 Reference documentation of the `Memory` class

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -93,8 +93,8 @@ class MemorizedFunc(Logger):
         verbose: int, optional
             The verbosity flag, controls messages that are issued as
             the function is revaluated.
-        depends: list of strings
-            A list of functions name it is necessary to observe in order
+        depends: list of functions
+            A list of functions it is necessary to observe in order
             to invalidate the cache (if they changed, cache is invalidated)
 
     """
@@ -123,8 +123,8 @@ class MemorizedFunc(Logger):
             timestamp: float, optional
                 The reference time from which times in tracing messages
                 are reported.
-            depends: list of strings
-                A list of functions name it is necessary to observe in order
+            depends: list of functions
+                A list of functions it is necessary to observe in order
                 to invalidate the cache (if they changed, cache is invalidated)
 
 
@@ -547,8 +547,8 @@ class Memory(Logger):
                 The memmapping mode used when loading from cache
                 numpy arrays. See numpy.load for the meaning of the
                 arguments. By default that of the memory object is used.
-            depends: list of strings
-                A list of functions name it is necessary to observe in order
+            depends: list of functions
+                A list of functions it is necessary to observe in order
                 to invalidate the cache (if they changed, cache is invalidated)
 
             Returns

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -248,8 +248,6 @@ class MemorizedFunc(Logger):
         check_inner = self._check_previous_func_code_inner_function(self.func, stacklevel)
         check_depends = self._check_previous_func_code_depends_functions(stacklevel)
 
-        print 'inner', check_inner
-        print 'depends', check_depends
         return check_inner and check_depends
 
     def _check_previous_func_code_depends_functions(self, stacklevel):
@@ -266,7 +264,6 @@ class MemorizedFunc(Logger):
         for dependency in self.depends:
             no_modifications = no_modifications and \
                     self._check_previous_func_code_inner_function(dependency, stacklevel, prefix=dependency)
-            print dependency, no_modifications
 
         return no_modifications
 

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -64,15 +64,6 @@ class JobLibCollisionWarning(UserWarning):
     """
 
 
-# Dependency managment. TODO find a way to remove this ugly hack
-DEPENDENCIES = {}
-def add_dependency(func):
-    """Add a function which can be a dependency of memorized functions."""
-    if func in DEPENDENCIES:
-        raise JobLibCollisionWarning()
-    DEPENDENCIES[func.__name__] = func
-
-
 ###############################################################################
 # class `MemorizedFunc`
 ###############################################################################
@@ -274,7 +265,7 @@ class MemorizedFunc(Logger):
         #loop over the dependencies and check for each of them
         for dependency in self.depends:
             no_modifications = no_modifications and \
-                    self._check_previous_func_code_inner_function(DEPENDENCIES[dependency], stacklevel, prefix=dependency)
+                    self._check_previous_func_code_inner_function(dependency, stacklevel, prefix=dependency)
             print dependency, no_modifications
 
         return no_modifications

--- a/joblib/test/test_memory_depends.py
+++ b/joblib/test/test_memory_depends.py
@@ -11,10 +11,9 @@ memory=joblib.memory.Memory(verbose=4, cachedir='testdepends')
 def producer(X):
     """produce the big object"""
     print 'Call of producer', X
-    return 10+X+1
+    return 10+X
 
-joblib.memory.add_dependency(producer)
-@memory.cache(ignore=['producee'], depends=['producer'])
+@memory.cache(ignore=['producee'], depends=[producer])
 def cached(producee, label):
     print 'Call cached', label
     return -producee1 

--- a/joblib/test/test_memory_depends.py
+++ b/joblib/test/test_memory_depends.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-:
+
+import joblib.memory
+import shutil
+
+
+
+memory=joblib.memory.Memory(verbose=4, cachedir='testdepends')
+
+def producer(X):
+    """produce the big object"""
+    print 'Call of producer', X
+    return 10+X+1
+
+joblib.memory.add_dependency(producer)
+@memory.cache(ignore=['producee'], depends=['producer'])
+def cached(producee, label):
+    print 'Call cached', label
+    return -producee1 
+
+
+
+producee1 = producer(1)
+producee2 = producer(2)
+
+
+cached1 = cached(producee1, 'lab1')
+cached2 = cached(producee2, 'lab2')
+cached3 = cached(producee1, 'lab1')
+cached3 = cached(producee1, 'lab1')
+cached3 = cached(producee1, 'lab1')
+cached3 = cached(producee1, 'lab1')
+
+
+

--- a/joblib/test/test_memory_depends.sh
+++ b/joblib/test/test_memory_depends.sh
@@ -1,0 +1,13 @@
+rm -rf  testdepends
+
+echo '1st launch'
+python test_memory_depends.py | more
+
+echo 'Wait to launch 2nd launch. All must be read from cache'
+read test
+python test_memory_depends.py | more
+
+echo 'Now modify the dependency. Then observe the cache is invalidated'
+read test
+python test_memory_depends.py | more
+


### PR DESCRIPTION
First version of the _depends_ parameter of the _Memory.cache_ function.

This patch allows to add dependencies to a function to cache.
The cache is invalidated when one of the dependencies has been modified.

i am open to any discussion to improve this first draft (and automatize its testing) in order to include it later in the master.
