### PR TITLE
Fix function caching for IPython

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -37,13 +37,14 @@ def get_func_code(func):
     """
     source_file = None
     try:
-        if func.__name__ == '<lambda>':
-            # On recent Python version, inspect is reliable with lambda
-            source_file = func.__code__.co_filename
-            return ''.join(inspect.getsourcelines(func)[0]), source_file, 1
-        # Try to retrieve the source code.
         code = func.__code__
         source_file = code.co_filename
+        if not os.path.exists(source_file):
+            # Use inspect for lambda functions and functions defined in an
+            # interactive shell
+            source_file = code.co_filename
+            return ''.join(inspect.getsourcelines(func)[0]), source_file, 1
+        # Try to retrieve the source code.
         with open(source_file) as source_file_obj:
             first_line = code.co_firstlineno
             # All the lines after the function definition:
@@ -110,8 +111,13 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
             filename = None
         if filename is not None:
             # mangling of full path to filename
-            filename = filename.replace(os.sep, '-')
-            filename = filename.replace(":", "-")
+            parts = filename.split(os.sep)
+            if parts[-1].startswith('<ipython-input'):
+                # function is defined in an IPython session. The filename
+                # will change with every new kernel instance. This hack
+                # always returns the same filename
+                parts[-1] = '__ipython-input__'
+            filename = '-'.join(parts)
             if filename.endswith('.py'):
                 filename = filename[:-3]
             module = module + '-' + filename


### PR DESCRIPTION
When `joblib.Memory` is used with functions defined in an interactive shell, e.g., an IPython notebook, the caching did not work, due to the following reasons:
- The code for getting the function source code did not work correctly.
- The cache directory for storing the function inputs and outputs constantly changed, which caused the function to be re-executed instead of using the cached result.  

This PR fixes both problems. For IPython the name used for the cache directory always ended with something like `<ipython-input-24-58eb75b955d1>`, which changes with every IPython kernel instance. I fixed this by replacing the pattern with `__ipython-input__`. This is a somewhat hackish solution, as functions with the same name and in the same work directory will have the same cache directory. However, I don't think there is a better solution as the function may not be defined in a file at all (it could be defined in an IPython notebook, but the IPython kernel is not aware of this).

I'm not sure how this could be tested, so I haven't added any unit tests so far.
