### PR TITLE
fix 'compress' semantics

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -87,9 +87,9 @@ class MemorizedFunc(Logger):
             The memmapping mode used when loading from cache
             numpy arrays. See numpy.load for the meaning of the
             arguments.
-        compress: boolean
-            Whether to zip the stored data on disk. Note that compressed
-            arrays cannot be read by memmapping.
+        compress: int, optional
+            Compression level in the range 0-9, 0 indicates no compression.
+            Note that compressed arrays cannot be read by memmapping.
         verbose: int, optional
             The verbosity flag, controls messages that are issued as
             the function is evaluated.
@@ -99,7 +99,7 @@ class MemorizedFunc(Logger):
     #-------------------------------------------------------------------------
 
     def __init__(self, func, cachedir, ignore=None, mmap_mode=None,
-                 compress=False, verbose=1, timestamp=None):
+                 compress=0, verbose=1, timestamp=None):
         """
             Parameters
             ----------
@@ -113,6 +113,9 @@ class MemorizedFunc(Logger):
                 The memmapping mode used when loading from cache
                 numpy arrays. See numpy.load for the meaning of the
                 arguments.
+            compress: int, optional
+                Compression level in the range 0-9, 0 indicates no compression.
+                Note that compressed arrays cannot be read by memmapping.
             verbose: int, optional
                 Verbosity flag, controls the debug messages that are issued
                 as functions are evaluated. The higher, the more verbose
@@ -452,7 +455,7 @@ class Memory(Logger):
     # Public interface
     #-------------------------------------------------------------------------
 
-    def __init__(self, cachedir, mmap_mode=None, compress=False, verbose=1):
+    def __init__(self, cachedir, mmap_mode=None, compress=0, verbose=1):
         """
             Parameters
             ----------
@@ -464,9 +467,9 @@ class Memory(Logger):
                 The memmapping mode used when loading from cache
                 numpy arrays. See numpy.load for the meaning of the
                 arguments.
-            compress: boolean
-                Whether to zip the stored data on disk. Note that
-                compressed arrays cannot be read by memmapping.
+            compress: int, optional
+                Compression level in the range 0-9, 0 indicates no compression.
+                Note that compressed arrays cannot be read by memmapping.
             verbose: int, optional
                 Verbosity flag, controls the debug messages that are issued
                 as functions are evaluated.

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -326,11 +326,9 @@ def dump(value, filename, compress=0, cache_size=100):
         The object to store to disk
     filename: string
         The name of the file in which it is to be stored
-    compress: integer for 0 to 9, optional
-        Optional compression level for the data. 0 is no compression.
-        Higher means more compression, but also slower read and
-        write times. Using a value of 3 is often a good compromise.
-        See the notes for more details.
+    compress: int, optional
+        Compression level in the range 0-9, 0 indicates no compression.
+        Note that compressed arrays cannot be read by memmapping.
     cache_size: positive number, optional
         Fixes the order of magnitude (in megabytes) of the cache used
         for in-memory compression. Note that this is just an order of
@@ -353,6 +351,10 @@ def dump(value, filename, compress=0, cache_size=100):
     using compression can significantly slow down loading. In
     addition, compressed files take extra extra memory during
     dump and load.
+
+    Higher values mean more compression, but also slower read and
+    write times. Using a value of 3 is often a good compromise.
+
     """
     if not isinstance(filename, _basestring):
         # People keep inverting arguments, and the resulting error is


### PR DESCRIPTION
The type and semantics of the 'compress' keyword argument were ambiguous. In 
the joblib/memory.py module the type was listed as boolean in the docstring
and as default value for the keyword arguments. However, in
joblib/numpy_pickle.py it turned into an integer which eventually becomes a
compression level for zlib. This never showed up anywhere I guess, since by
virtue of duck typing False was interpreted correctly to mean a compression
level of 0 and True to mean 1.

Make the 'compress' setting uniform across joblib/memory.py and 
joblib/numpy_pickle.py. Adapt the docstrings and the keyword defaults to be 
integers all the way.
