### PR TITLE
Add a "constant" helper function to avoid unwanted side effects

### DIFF
--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -105,7 +105,7 @@ Main features
 __version__ = '0.7.1'
 
 
-from .memory import Memory
+from .memory import Memory, MemorizedResult
 from .logger import PrintTime
 from .logger import Logger
 from .hashing import hash

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -13,6 +13,7 @@ import re
 import os
 
 from ._compat import _basestring
+from .logger import pformat
 
 
 def get_func_code(func):
@@ -173,9 +174,7 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
         Returns
         -------
         filtered_args: list
-            List of filtered positional arguments.
-        filtered_kwdargs: dict
-            List of filtered Keyword arguments.
+            List of filtered positional and keyword arguments.
     """
     args = list(args)
     if isinstance(ignore_lst, _basestring):
@@ -263,3 +262,41 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
                                                    )))
     # XXX: Return a sorted list of pairs?
     return arg_dict
+
+
+def format_signature(func, *args, **kwargs):
+    # XXX: Should this use inspect.formatargvalues/formatargspec?
+    module, name = get_func_name(func)
+    module = [m for m in module if m]
+    if module:
+        module.append(name)
+        module_path = '.'.join(module)
+    else:
+        module_path = name
+    arg_str = list()
+    previous_length = 0
+    for arg in args:
+        arg = pformat(arg, indent=2)
+        if len(arg) > 1500:
+            arg = '%s...' % arg[:700]
+        if previous_length > 80:
+            arg = '\n%s' % arg
+        previous_length = len(arg)
+        arg_str.append(arg)
+    arg_str.extend(['%s=%s' % (v, pformat(i)) for v, i in kwargs.items()])
+    arg_str = ', '.join(arg_str)
+
+    signature = '%s(%s)' % (name, arg_str)
+    return module_path, signature
+
+
+def format_call(func, args, kwargs, object_name="Memory"):
+    """ Returns a nicely formatted statement displaying the function
+        call with the given arguments.
+    """
+    path, signature = format_signature(func, *args, **kwargs)
+    msg = '%s\n[%s] Calling %s...\n%s' % (80 * '_', object_name,
+                                          path, signature)
+    return msg
+    # XXX: Not using logging framework
+    #self.debug(msg)

--- a/joblib/logger.py
+++ b/joblib/logger.py
@@ -44,6 +44,19 @@ def short_format_time(t):
         return " %5.1fs" % (t)
 
 
+def pformat(obj, indent=0, depth=3):
+    if 'numpy' in sys.modules:
+        import numpy as np
+        print_options = np.get_printoptions()
+        np.set_printoptions(precision=6, threshold=64, edgeitems=1)
+    else:
+        print_options = None
+    out = pprint.pformat(obj, depth=depth, indent=indent)
+    if print_options:
+        np.set_printoptions(**print_options)
+    return out
+
+
 ###############################################################################
 # class `Logger`
 ###############################################################################
@@ -70,16 +83,7 @@ class Logger(object):
     def format(self, obj, indent=0):
         """ Return the formated representation of the object.
         """
-        if 'numpy' in sys.modules:
-            import numpy as np
-            print_options = np.get_printoptions()
-            np.set_printoptions(precision=6, threshold=64, edgeitems=1)
-        else:
-            print_options = None
-        out = pprint.pformat(obj, depth=self.depth, indent=indent)
-        if print_options:
-            np.set_printoptions(**print_options)
-        return out
+        return pformat(obj, indent=indent, depth=self.depth)
 
 
 ###############################################################################

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -27,9 +27,11 @@ import json
 # Local imports
 from .hashing import hash
 from .func_inspect import get_func_code, get_func_name, filter_args
-from .logger import Logger, format_time
+from .func_inspect import format_signature, format_call
+from .logger import Logger, format_time, pformat
 from . import numpy_pickle
 from .disk import mkdirp, rm_subdirs
+from ._compat import _basestring
 
 FIRST_LINE_TEXT = "# first line:"
 
@@ -64,6 +66,229 @@ class JobLibCollisionWarning(UserWarning):
     """
 
 
+def _get_func_fullname(func):
+    """Compute the part of part associated with a function.
+
+    See code of_cache_key_to_dir() for details
+    """
+    modules, funcname = get_func_name(func)
+    modules.append(funcname)
+    return os.path.join(*modules)
+
+
+def _cache_key_to_dir(cachedir, func, argument_hash):
+    """Compute directory associated with a given cache key.
+
+    func can be a function or a string as returned by _get_func_fullname().
+    """
+    parts = [cachedir]
+    if isinstance(func, _basestring):
+        parts.append(func)
+    else:
+        parts.append(_get_func_fullname(func))
+
+    if argument_hash is not None:
+        parts.append(argument_hash)
+    return os.path.join(*parts)
+
+
+def _load_output(output_dir, func, timestamp=None, metadata=None,
+                 mmap_mode=None, verbose=0):
+    """Load output of a computation."""
+    if verbose > 1:
+        signature = ""
+        try:
+            if metadata is not None:
+                args = ", ".join(['%s=%s' % (name, value)
+                                  for name, value
+                                  in metadata['input_args'].items()])
+                signature = "%s(%s)" % (os.path.basename(func),
+                                             args)
+            else:
+                signature = os.path.basename(func)
+        except KeyError:
+            pass
+
+        if timestamp is not None:
+            t = "% 16s" % format_time(time.time() - timestamp)
+        else:
+            t = ""
+
+        if verbose < 10:
+            print('[Memory]%s: Loading %s...' % (t, str(signature)))
+        else:
+            print('[Memory]%s: Loading %s from %s' % (
+                    t, str(signature), output_dir))
+
+    filename = os.path.join(output_dir, 'output.pkl')
+    if not os.path.isfile(filename):
+        raise KeyError(
+            "Non-existing cache value (may have been cleared).\n"
+            "File %s does not exist" % filename)
+    return numpy_pickle.load(filename, mmap_mode=mmap_mode)
+
+
+###############################################################################
+# class `MemorizedResult`
+###############################################################################
+class MemorizedResult(Logger):
+    """Object representing a cached value.
+
+    Attributes
+    ----------
+    cachedir: string
+        path to root of joblib cache
+
+    func: function or string
+        function whose output is cached. The string case is intended only for
+        instanciation based on the output of repr() on another instance.
+        (namely eval(repr(memorized_instance)) works).
+
+    argument_hash: string
+        hash of the function arguments
+
+    mmap_mode: {None, 'r+', 'r', 'w+', 'c'}
+        The memmapping mode used when loading from cache numpy arrays. See
+        numpy.load for the meaning of the different values.
+
+    verbose: int
+        verbosity level (0 means no message)
+
+    timestamp, metadata: string
+        for internal use only
+    """
+    def __init__(self, cachedir, func, argument_hash,
+                 mmap_mode=None, verbose=0, timestamp=None, metadata=None):
+        Logger.__init__(self)
+        if isinstance(func, _basestring):
+            self.func = func
+        else:
+            self.func = _get_func_fullname(func)
+        self.argument_hash = argument_hash
+        self.cachedir = cachedir
+        self.mmap_mode = mmap_mode
+
+        self._output_dir = _cache_key_to_dir(cachedir, self.func,
+                                             argument_hash)
+
+        if metadata is not None:
+            self.metadata = metadata
+        else:
+            self.metadata = {}
+            # No error is relevant here.
+            try:
+                self.metadata = json.load(
+                    open(os.path.join(self._output_dir, 'metadata.json'), 'rb')
+                    )
+            except:
+                pass
+
+        self.duration = self.metadata.get('duration', None)
+        self.verbose = verbose
+        self.timestamp = timestamp
+
+    def get(self):
+        """Read value from cache and return it."""
+        return _load_output(self._output_dir, self.func,
+                            timestamp=self.timestamp,
+                            metadata=self.metadata, mmap_mode=self.mmap_mode,
+                            verbose=self.verbose)
+
+    def clear(self):
+        """Clear value from cache"""
+        shutil.rmtree(self._output_dir, ignore_errors=True)
+
+    def __repr__(self):
+        return ('{class_name}(cachedir="{cachedir}", func="{func}", '
+                'argument_hash="{argument_hash}")'.format(
+                    class_name=self.__class__.__name__,
+                    cachedir=self.cachedir,
+                    func=self.func,
+                    argument_hash=self.argument_hash
+                    ))
+
+    def __reduce__(self):
+        return (self.__class__, (self.cachedir, self.func, self.argument_hash),
+                {'mmap_mode': self.mmap_mode})
+
+
+class NotMemorizedResult(object):
+    """Class representing an arbitrary value.
+
+    This class is a replacement for MemorizedResult when there is no cache.
+    """
+    __slots__ = ('value', 'valid')
+
+    def __init__(self, value):
+        self.value = value
+        self.valid = True
+
+    def get(self):
+        if self.valid:
+            return self.value
+        else:
+            raise KeyError("No value stored.")
+
+    def clear(self):
+        self.valid = False
+        self.value = None
+
+    def __repr__(self):
+        if self.valid:
+            return '{class_name}({value})'.format(
+                class_name=self.__class__.__name__,
+                value=pformat(self.value)
+                )
+        else:
+            return self.__class__.__name__ + ' with no value'
+
+    # __getstate__ and __setstate__ are required because of __slots__
+    def __getstate__(self):
+        return {"valid": self.valid, "value": self.value}
+
+    def __setstate__(self, state):
+        self.valid = state["valid"]
+        self.value = state["value"]
+
+
+###############################################################################
+# class `NotMemorizedFunc`
+###############################################################################
+class NotMemorizedFunc(object):
+    """No-op object decorating a function.
+
+    This class replaces MemorizedFunc when there is no cache. It provides an
+    identical API but does not write anything on disk.
+
+    Attributes
+    ----------
+    func: callable
+        Original undecorated function.
+    """
+    # Should be a light as possible (for speed)
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+    def call_and_shelve(self, *args, **kwargs):
+        return NotMemorizedResult(self.func(*args, **kwargs))
+
+    def __reduce__(self):
+        return (self.__class__, (self.func,))
+
+    def __repr__(self):
+        return '%s(func=%s)' % (
+                    self.__class__.__name__,
+                    self.func
+            )
+
+    def clear(self, warn=True):
+        # Argument "warn" is for compatibility with MemorizedFunc.clear
+        pass
+
+
 ###############################################################################
 # class `MemorizedFunc`
 ###############################################################################
@@ -78,21 +303,24 @@ class MemorizedFunc(Logger):
         ----------
         func : callable
             The original, undecorated, function.
-        cachedir : string
+
+        cachedir: string
             Path to the base cache directory of the memory context.
-        ignore : list or None
+
+        ignore: list or None
             List of variable names to ignore when choosing whether to
             recompute.
-        mmap_mode : {None, 'r+', 'r', 'w+', 'c'}
+
+        mmap_mode: {None, 'r+', 'r', 'w+', 'c'}
             The memmapping mode used when loading from cache
-            numpy arrays. See numpy.load for the meaning of the
-            arguments.
-        compress : boolean, or integer
-            Whether to zip the stored data on disk. If an integer is
-            given, it should be between 1 and 9, and sets the amount
-            of compression. Note that compressed arrays cannot be
-            read by memmapping.
-        verbose : int, optional
+            numpy arrays. See numpy.load for the meaning of the different
+            values.
+
+        compress: boolean
+            Whether to zip the stored data on disk. Note that compressed
+            arrays cannot be read by memmapping.
+
+        verbose: int, optional
             The verbosity flag, controls messages that are issued as
             the function is evaluated.
     """
@@ -128,20 +356,21 @@ class MemorizedFunc(Logger):
                 are reported.
         """
         Logger.__init__(self)
+        self.mmap_mode = mmap_mode
+        self.func = func
+        if ignore is None:
+            ignore = []
+        self.ignore = ignore
+
         self._verbose = verbose
         self.cachedir = cachedir
-        self.func = func
-        self.mmap_mode = mmap_mode
         self.compress = compress
-        if compress and mmap_mode is not None:
+        if compress and self.mmap_mode is not None:
             warnings.warn('Compressed results cannot be memmapped',
                           stacklevel=2)
         if timestamp is None:
             timestamp = time.time()
         self.timestamp = timestamp
-        if ignore is None:
-            ignore = []
-        self.ignore = ignore
         mkdirp(self.cachedir)
         try:
             functools.update_wrapper(self, func)
@@ -149,35 +378,53 @@ class MemorizedFunc(Logger):
             " Objects like ufunc don't like that "
         if inspect.isfunction(func):
             doc = pydoc.TextDoc().document(func
-                                    ).replace('\n', '\n\n', 1)
+                                           ).replace('\n', '\n\n', 1)
         else:
             # Pydoc does a poor job on other objects
             doc = func.__doc__
         self.__doc__ = 'Memoized version of %s' % doc
 
-    def __call__(self, *args, **kwargs):
+    def _cached_call(self, args, kwargs):
+        """Call wrapped function and cache result, or read cache if available.
+
+        This function returns the wrapped function output and some metadata.
+
+        Returns
+        -------
+        output: value or tuple
+            what is returned by wrapped function
+
+        argument_hash: string
+            hash of function arguments
+
+        metadata: dict
+            some metadata about wrapped function call (see _persist_input())
+        """
         # Compare the function code with the previous to see if the
         # function code has changed
-        output_dir, argument_hash = self.get_output_dir(*args, **kwargs)
+        output_dir, argument_hash = self._get_output_dir(*args, **kwargs)
+        metadata = None
         # FIXME: The statements below should be try/excepted
-        if not (self._check_previous_func_code(stacklevel=3) and
+        if not (self._check_previous_func_code(stacklevel=4) and
                                  os.path.exists(output_dir)):
             if self._verbose > 10:
                 _, name = get_func_name(self.func)
                 self.warn('Computing func %s, argument hash %s in '
                           'directory %s'
                         % (name, argument_hash, output_dir))
-            return self.call(*args, **kwargs)
+            out, metadata = self.call(*args, **kwargs)
         else:
             try:
                 t0 = time.time()
-                out = self.load_output(output_dir)
+                out = _load_output(output_dir, _get_func_fullname(self.func),
+                                   timestamp=self.timestamp,
+                                   metadata=metadata, mmap_mode=self.mmap_mode,
+                                   verbose=self._verbose)
                 if self._verbose > 4:
                     t = time.time() - t0
                     _, name = get_func_name(self.func)
                     msg = '%s cache loaded - %s' % (name, format_time(t))
                     print(max(0, (80 - len(msg))) * '_' + msg)
-                return out
             except Exception:
                 # XXX: Should use an exception logger
                 self.warn('Exception while loading results for '
@@ -185,7 +432,33 @@ class MemorizedFunc(Logger):
                           (args, kwargs, traceback.format_exc()))
 
                 shutil.rmtree(output_dir, ignore_errors=True)
-                return self.call(*args, **kwargs)
+                out, metadata = self.call(*args, **kwargs)
+                argument_hash = None
+        return (out, argument_hash, metadata)
+
+    def call_and_shelve(self, *args, **kwargs):
+        """Call wrapped function, cache result and return a reference.
+
+        This method returns a reference to the cached result instead of the
+        result itself. The reference object is small and pickeable, allowing
+        to send or store it easily. Call .get() on reference object to get
+        result.
+
+        Returns
+        -------
+        cached_result: MemorizedResult or NotMemorizedResult
+            reference to the value returned by the wrapped function. The
+            class "NotMemorizedResult" is used when there is no cache
+            activated (e.g. cachedir=None in Memory).
+        """
+        _, argument_hash, metadata = self._cached_call(args, kwargs)
+
+        return MemorizedResult(self.cachedir, self.func, argument_hash,
+            metadata=metadata, verbose=self._verbose - 1,
+            timestamp=self.timestamp)
+
+    def __call__(self, *args, **kwargs):
+        return self._cached_call(args, kwargs)[0]
 
     def __reduce__(self):
         """ We don't store the timestamp when pickling, to avoid the hash
@@ -195,34 +468,44 @@ class MemorizedFunc(Logger):
         return (self.__class__, (self.func, self.cachedir, self.ignore,
                 self.mmap_mode, self.compress, self._verbose))
 
+    def format_signature(self, *args, **kwargs):
+        warnings.warn("MemorizedFunc.format_signature will be removed in a "
+                      "future version of joblib.", DeprecationWarning)
+        return format_signature(self.func, *args, **kwargs)
+
+    def format_call(self, *args, **kwargs):
+        warnings.warn("MemorizedFunc.format_call will be removed in a "
+                      "future version of joblib.", DeprecationWarning)
+        return format_call(self.func, args, kwargs)
+
     #-------------------------------------------------------------------------
     # Private interface
     #-------------------------------------------------------------------------
+
+    def _get_argument_hash(self, *args, **kwargs):
+        return hash(filter_args(self.func, self.ignore,
+                                         args, kwargs),
+                             coerce_mmap=(self.mmap_mode is not None))
+
+    def _get_output_dir(self, *args, **kwargs):
+        """ Return the directory in which are persisted the result
+            of the function called with the given arguments.
+        """
+        argument_hash = self._get_argument_hash(*args, **kwargs)
+        output_dir = os.path.join(self._get_func_dir(self.func),
+                                  argument_hash)
+        return output_dir, argument_hash
+
+    get_output_dir = _get_output_dir  # backward compatibility
 
     def _get_func_dir(self, mkdir=True):
         """ Get the directory corresponding to the cache for the
             function.
         """
-        module, name = get_func_name(self.func)
-        module.append(name)
-        func_dir = os.path.join(self.cachedir, *module)
+        func_dir = _cache_key_to_dir(self.cachedir, self.func, None)
         if mkdir:
             mkdirp(func_dir)
         return func_dir
-
-    def get_output_dir(self, *args, **kwargs):
-        """ Returns the directory in which are persisted the results
-            of the function corresponding to the given arguments.
-
-            The results can be loaded using the .load_output method.
-        """
-        coerce_mmap = (self.mmap_mode is not None)
-        argument_hash = hash(filter_args(self.func, self.ignore,
-                             args, kwargs),
-                             coerce_mmap=coerce_mmap)
-        output_dir = os.path.join(self._get_func_dir(self.func),
-                                  argument_hash)
-        return output_dir, argument_hash
 
     def _write_func_code(self, filename, func_code, first_line):
         """ Write the function code and the filename to a file.
@@ -254,7 +537,7 @@ class MemorizedFunc(Logger):
             return True
 
         # We have differing code, is this because we are referring to
-        # differing functions, or because the function we are referring as
+        # different functions, or because the function we are referring to has
         # changed?
 
         _, func_name = get_func_name(self.func, resolv_alias=False,
@@ -280,8 +563,7 @@ class MemorizedFunc(Logger):
                 num_lines = len(func_code.split('\n'))
                 with open(source_file) as f:
                     on_disk_func_code = f.readlines()[
-                            old_first_line - 1
-                            :old_first_line - 1 + num_lines - 1]
+                        old_first_line - 1:old_first_line - 1 + num_lines - 1]
                 on_disk_func_code = ''.join(on_disk_func_code)
                 possible_collision = (on_disk_func_code.rstrip()
                                       == old_func_code.rstrip())
@@ -293,7 +575,7 @@ class MemorizedFunc(Logger):
                         "'%s' (%s:%i) and '%s' (%s:%i)" %
                         (func_name, source_file, old_first_line,
                         func_name, source_file, first_line)),
-                    stacklevel=stacklevel)
+                                stacklevel=stacklevel)
 
         # The function has changed, wipe the cache directory.
         # XXX: Should be using warnings, and giving stacklevel
@@ -308,7 +590,7 @@ class MemorizedFunc(Logger):
         """ Empty the function's cache.
         """
         func_dir = self._get_func_dir(mkdir=False)
-        if self._verbose and warn:
+        if self._verbose > 0 and warn:
             self.warn("Clearing cache %s" % func_dir)
         if os.path.exists(func_dir):
             shutil.rmtree(func_dir, ignore_errors=True)
@@ -322,60 +604,21 @@ class MemorizedFunc(Logger):
             persist the output values.
         """
         start_time = time.time()
-        output_dir, argument_hash = self.get_output_dir(*args, **kwargs)
-        if self._verbose:
-            print(self.format_call(*args, **kwargs))
+        output_dir, _ = self._get_output_dir(*args, **kwargs)
+        if self._verbose > 0:
+            print(format_call(self.func, args, kwargs))
         output = self.func(*args, **kwargs)
         self._persist_output(output, output_dir)
-        self._persist_input(output_dir, *args, **kwargs)
         duration = time.time() - start_time
-        if self._verbose:
+        metadata = self._persist_input(output_dir, duration, args, kwargs)
+
+        if self._verbose > 0:
             _, name = get_func_name(self.func)
             msg = '%s - %s' % (name, format_time(duration))
             print(max(0, (80 - len(msg))) * '_' + msg)
+        return output, metadata
 
-        return output
-
-    def format_call(self, *args, **kwds):
-        """ Returns a nicely formatted statement displaying the function
-            call with the given arguments.
-        """
-        path, signature = self.format_signature(self.func, *args,
-                            **kwds)
-        msg = '%s\n[Memory] Calling %s...\n%s' % (80 * '_', path, signature)
-        return msg
-        # XXX: Not using logging framework
-        #self.debug(msg)
-
-    def format_signature(self, func, *args, **kwds):
-        # XXX: This should be moved out to a function
-        # XXX: Should this use inspect.formatargvalues/formatargspec?
-        module, name = get_func_name(func)
-        module = [m for m in module if m]
-        if module:
-            module.append(name)
-            module_path = '.'.join(module)
-        else:
-            module_path = name
-        arg_str = list()
-        previous_length = 0
-        for arg in args:
-            arg = self.format(arg, indent=2)
-            if len(arg) > 1500:
-                arg = '%s...' % arg[:700]
-            if previous_length > 80:
-                arg = '\n%s' % arg
-            previous_length = len(arg)
-            arg_str.append(arg)
-        arg_str.extend(['%s=%s' % (v, self.format(i)) for v, i in
-                                    kwds.items()])
-        arg_str = ', '.join(arg_str)
-
-        signature = '%s(%s)' % (name, arg_str)
-        return module_path, signature
-
-    # Make make public
-
+    # Make public
     def _persist_output(self, output, dir):
         """ Persist the given output tuple in the directory.
         """
@@ -388,46 +631,72 @@ class MemorizedFunc(Logger):
         except OSError:
             " Race condition in the creation of the directory "
 
-    def _persist_input(self, output_dir, *args, **kwargs):
+    def _persist_input(self, output_dir, duration, args, kwargs,
+                       this_duration_limit=0.5):
         """ Save a small summary of the call using json format in the
             output directory.
+
+            output_dir: string
+                directory where to write metadata.
+
+            duration: float
+                time taken by hashing input arguments, calling the wrapped
+                function and persisting its output.
+
+            args, kwargs: list and dict
+                input arguments for wrapped function
+
+            this_duration_limit: float
+                Max execution time for this function before issuing a warning.
         """
+        start_time = time.time()
         argument_dict = filter_args(self.func, self.ignore,
                                     args, kwargs)
 
         input_repr = dict((k, repr(v)) for k, v in argument_dict.items())
-        # This can fail do to race-conditions with multiple
+        # This can fail due to race-conditions with multiple
         # concurrent joblibs removing the file or the directory
+        metadata = {"duration": duration, "input_args": input_repr}
         try:
             mkdirp(output_dir)
-            json.dump(
-                input_repr,
-                file(os.path.join(output_dir, 'input_args.json'), 'w'),
-                )
+            json.dump(metadata,
+                      file(os.path.join(output_dir, 'metadata.json'), 'w'),
+                      )
         except:
             pass
-        return input_repr
+
+        this_duration = time.time() - start_time
+        if this_duration > this_duration_limit:
+            # This persistence should be fast. It will not be if repr() takes
+            # time and its output is large, because json.dump will have to
+            # write a large file. This should not be an issue with numpy arrays
+            # for which repr() always output a short representation, but can
+            # be with complex dictionaries. Fixing the problem should be a
+            # matter of replacing repr() above by something smarter.
+            warnings.warn("Persisting input arguments took %.2fs to run.\n"
+                          "If this happens often in your code, it can cause "
+                          "performance problems \n"
+                          "(results will be correct in all cases). \n"
+                          "The reason for this is probably some large input "
+                          "arguments for a wrapped\n"
+                          " function (e.g. large strings).\n"
+                          "THIS IS A JOBLIB ISSUE. If you can, kindly provide "
+                          "the joblib's team with an\n"
+                          " example so that they can fix the problem."
+                          % this_duration, stacklevel=5)
+        return metadata
 
     def load_output(self, output_dir):
         """ Read the results of a previous calculation from the directory
             it was cached in.
         """
-        if self._verbose > 1:
-            t = time.time() - self.timestamp
-            if self._verbose < 10:
-                print('[Memory]% 16s: Loading %s...' % (
-                                    format_time(t),
-                                    self.format_signature(self.func)[0]
-                                    ))
-            else:
-                print('[Memory]% 16s: Loading %s from %s' % (
-                                    format_time(t),
-                                    self.format_signature(self.func)[0],
-                                    output_dir
-                                    ))
-        filename = os.path.join(output_dir, 'output.pkl')
-        return numpy_pickle.load(filename,
-                                 mmap_mode=self.mmap_mode)
+        warnings.warn("MemorizedFunc.load_output is deprecated and will be "
+                      "removed in a future version\n"
+                      "of joblib. A MemorizedResult provides similar features",
+                      DeprecationWarning)
+        # No metadata available here.
+        return _load_output(output_dir, self.func, timestamp=self.timestamp,
+                            mmap_mode=self.mmap_mode, verbose=self._verbose)
 
     # XXX: Need a method to check if results are available.
 
@@ -527,7 +796,7 @@ class Memory(Logger):
             # arguments in decorators
             return functools.partial(self.cache, ignore=ignore)
         if self.cachedir is None:
-            return func
+            return NotMemorizedFunc(func)
         if verbose is None:
             verbose = self._verbose
         if mmap_mode is False:

--- a/joblib/test/__init__.py
+++ b/joblib/test/__init__.py
@@ -1,0 +1,2 @@
+from . import test_memory
+from . import test_hashing

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -10,15 +10,22 @@ import nose
 import tempfile
 import functools
 
-from ..func_inspect import filter_args, get_func_name, get_func_code, \
-        _clean_win_chars
+from ..func_inspect import filter_args, get_func_name, get_func_code
+from ..func_inspect import _clean_win_chars, format_signature
 from ..memory import Memory
+from .common import with_numpy
 
 
 ###############################################################################
 # Module-level functions, for tests
 def f(x, y=0):
     pass
+
+
+def g(x, y=1):
+    """ A module-level function for testing purposes.
+    """
+    return x ** 2 + y
 
 
 def f2(x):
@@ -168,3 +175,18 @@ def test_clean_win_chars():
     mangled_string = _clean_win_chars(string)
     for char in ('\\', ':', '<', '>', '!'):
         nose.tools.assert_false(char in mangled_string)
+
+
+def test_format_signature():
+    # Test signature formatting.
+    path, sgn = format_signature(g, list(range(10)))
+    nose.tools.assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
+    path, sgn = format_signature(g, list(range(10)), y=list(range(10)))
+    nose.tools.assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],'
+                            ' y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
+
+@with_numpy
+def test_format_signature_numpy():
+    """ Test the format signature formatting with numpy.
+    """
+

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -237,6 +237,7 @@ def test_numpy_scalar():
     nose.tools.assert_not_equal(hash(a), hash(b))
 
 
+@nose.tools.with_setup(test_memory_setup_func, test_memory_teardown_func)
 def test_dict_hash():
     # Check that dictionaries hash consistently, eventhough the ordering
     # of the keys is not garanteed
@@ -263,6 +264,7 @@ def test_dict_hash():
                             hash(b))
 
 
+@nose.tools.with_setup(test_memory_setup_func, test_memory_teardown_func)
 def test_set_hash():
     # Check that sets hash consistently, eventhough their ordering
     # is not garanteed

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -8,15 +8,18 @@ Test the memory module.
 
 import shutil
 import os
+import os.path
 from tempfile import mkdtemp
 import pickle
 import warnings
 import io
 import sys
+import time
 
 import nose
 
-from ..memory import Memory, MemorizedFunc
+from ..memory import Memory, MemorizedFunc, NotMemorizedFunc, MemorizedResult
+from ..memory import NotMemorizedResult
 from .common import with_numpy, np
 
 
@@ -37,13 +40,12 @@ def setup_module():
     """ Test setup.
     """
     cachedir = mkdtemp()
-    #cachedir = 'foobar'
     env['dir'] = cachedir
     if os.path.exists(cachedir):
         shutil.rmtree(cachedir)
     # Don't make the cachedir, Memory should be able to do that on the fly
     print(80 * '_')
-    print('test_memory setup')
+    print('test_memory setup (%s)' % env['dir'])
     print(80 * '_')
 
 
@@ -60,7 +62,7 @@ def teardown_module():
     """
     shutil.rmtree(env['dir'], False, _rmtree_onerror)
     print(80 * '_')
-    print('test_memory teardown')
+    print('test_memory teardown (%s)' % env['dir'])
     print(80 * '_')
 
 
@@ -68,7 +70,7 @@ def teardown_module():
 # Helper function for the tests
 def check_identity_lazy(func, accumulator):
     """ Given a function and an accumulator (a list that grows every
-        time the function is called, check that the function can be
+        time the function is called), check that the function can be
         decorated by memory to be a lazy identity.
     """
     # Call each function with several arguments, and check that it is
@@ -436,23 +438,70 @@ def test_persistence():
     # Smoke test that pickling a memory with cachedir=None works
     memory = Memory(cachedir=None, verbose=0)
     pickle.loads(pickle.dumps(memory))
+    g = memory.cache(f)
+    gp = pickle.loads(pickle.dumps(g))
+    gp(1)
 
 
-def test_format_signature():
-    # Test the signature formatting.
-    func = MemorizedFunc(f, cachedir=env['dir'])
-    path, sgn = func.format_signature(f, list(range(10)))
-    yield nose.tools.assert_equal, \
-                sgn, \
-                'f([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])'
-    path, sgn = func.format_signature(f, list(range(10)),
-                                      y=list(range(10)))
-    yield nose.tools.assert_equal, \
-                sgn, \
-        'f([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])'
-
-
-@with_numpy
-def test_format_signature_numpy():
-    """ Test the format signature formatting with numpy.
+def test_call_and_shelve():
+    """Test MemorizedFunc outputting a reference to cache.
     """
+
+    for func, Result in zip((MemorizedFunc(f, env['dir']),
+                             NotMemorizedFunc(f),
+                             Memory(cachedir=env['dir']).cache(f),
+                             Memory(cachedir=None).cache(f),
+                             ),
+                            (MemorizedResult, NotMemorizedResult,
+                             MemorizedResult, NotMemorizedResult)):
+        nose.tools.assert_equal(func(2), 5)
+        result = func.call_and_shelve(2)
+        nose.tools.assert_true(isinstance(result, Result))
+        nose.tools.assert_equal(result.get(), 5)
+
+        result.clear()
+        nose.tools.assert_raises(KeyError, result.get)
+        result.clear()  # Do nothing if there is no cache.
+
+
+def test_memorized_pickling():
+    for func in (MemorizedFunc(f, env['dir']), NotMemorizedFunc(f)):
+        filename = os.path.join(env['dir'], 'pickling_test.dat')
+        result = func.call_and_shelve(2)
+        pickle.dump(result, open(filename, 'wb'))
+        result2 = pickle.load(open(filename, 'rb'))
+        nose.tools.assert_equal(result2.get(), result.get())
+        os.remove(filename)
+
+
+def test_memorized_repr():
+    func = MemorizedFunc(f, env['dir'])
+    result = func.call_and_shelve(2)
+    result2 = eval(repr(result))
+    nose.tools.assert_equal(result.get(), result2.get())
+
+    # Smoke test on deprecated methods
+    func.format_signature(2)
+    func.format_call(2)
+
+    # Smoke test with NotMemorizedFunc
+    func = NotMemorizedFunc(f)
+    repr(func)
+    repr(func.call_and_shelve(2))
+
+    # Smoke test for message output (increase code coverage)
+    func = MemorizedFunc(f, env['dir'], verbose=11, timestamp=time.time())
+    result = func.call_and_shelve(11)
+    result.get()
+
+    func = MemorizedFunc(f, env['dir'], verbose=11)
+    result = func.call_and_shelve(11)
+    result.get()
+
+    func = MemorizedFunc(f, env['dir'], verbose=5, timestamp=time.time())
+    result = func.call_and_shelve(11)
+    result.get()
+
+    func = MemorizedFunc(f, env['dir'], verbose=5)
+    result = func.call_and_shelve(11)
+    result.get()


### PR DESCRIPTION
The most frequent error I have using joblib is caused by deep objects which state changes after function call. This may be innocent in most cases but if the object is used again (typically in a for loop), then it will cause troubles. In this PR, I introduce a "constant" helper which explicitly mark an argument as constant and raises an error in case of side effect.

Code example:

```
memory = Memory(...)
@memory_cache
def evil_function(innocent_dict, iteration):
    innocent_dict['value'] = 2
    print iteration

f = memory.cache(evil_function)
a = dict{'value': 1}

# In the following loop, every call is cached, all number are printed
for i in range(10):
    f(a, i)

a = dict{'value': 1}
# If I run the same code again, only the second call will be computed (1 will be printed)
# This is obviously an unwanted behavior and it is hard to debug in a big script
for i in range(10):
    f(a, i)

a = dict{'value': 1}
# Here, an error is raised in the first loop: I know that my function has an unwanted side-effect
for i in range(10):
    f(constant(a), i)
```
