### PR TITLE
[WIP] Streaming zlib compression for the joblib.dump method.

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -72,7 +72,7 @@ def read_zfile(file_handle):
     return data
 
 
-def write_zfile(file_handle, data, compress=1):
+def write_zfile(file_handle, data, compress=1, buffer_size=1024 ** 2):
     """Write the data in the given file as a Z-file.
 
     Z-files are raw data compressed with zlib used internally by joblib
@@ -86,7 +86,18 @@ def write_zfile(file_handle, data, compress=1):
         length = length[:-1]
     # Store the length of the data
     file_handle.write(asbytes(length.ljust(_MAX_LEN)))
-    file_handle.write(zlib.compress(asbytes(data), compress))
+
+    # Stream the data compressed on the fly using a buffer
+    compressor = zlib.compressobj(compress)
+    data = asbytes(data)  # should already be bytes in no pathological cases
+    offset = 0
+    for i in range(len(data) // buffer_size):
+        chunk = data[offset:offset + buffer_size]
+        file_handle.write(compressor.compress(chunk))
+        offset += buffer_size
+    last_chunk = data[offset:]
+    file_handle.write(compressor.compress(last_chunk))
+    file_handle.write(compressor.flush())
 
 
 ###############################################################################


### PR DESCRIPTION
This is a fix for #66 and #51 to avoid copying the data at pickling / compression / dump time.

To decompress I have also a nocopy implementation here:
https://github.com/ogrisel/joblib/commit/569dca33f7ab5409fba288b6e02e9e4cd090d228

However it does not work as numpy's `array.__setstate__` does not accept mutable `bytearray` instances as an alternative to immutable Python 2's `str` or Python 3's `bytes`.

I will work on a patch next week for numpy and then open a new PR that enables the nocopy mode for decompression in joblib when possible if the numpy fix is accepted upstream.