### PR TITLE
Add threading-based backend to joblib.Parallel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,35 @@
 Latest changes
 ===============
 
+Release 0.8.0-dev
+-----------------
+
+2013-12-05
+Olivier Grisel
+
+    ENH: add a threading based backend to Parallel
+
+    This is low overhead alternative backend to the default multiprocessing
+    backend that is suitable when calling compiled extensions that release
+    the GIL.
+
+
+Author: Dan Stahlke <dan@stahlke.org>
+Date:   2013-11-08
+
+    FIX: use safe_repr to print arg vals in trace
+
+    This fixes a problem in which extremely long (and slow) stack traces would
+    be produced when function parameters are large numpy arrays.
+
+
+2013-09-10
+Olivier Grisel
+
+    ENH: limit memory copy with Parallel by leveraging numpy.memmap when
+    possible
+
+
 Release 0.7.1
 ---------------
 

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -3,6 +3,9 @@
 Embarrassingly parallel for loops
 =================================
 
+Common usage
+============
+
 Joblib provides a simple helper class to write parallel for loops using
 multiprocessing. The core idea is to write the code to be executed as a
 generator expression, and convert it to parallel computing::
@@ -48,6 +51,32 @@ function-call syntax.
    **No** code should *run* outside of the "if __name__ == '__main__'"
    blocks, only imports and definitions.
 
+
+Using the threading backend
+===========================
+
+By default :class:`Parallel` uses the Python ``multiprocessing`` module to fork
+separate Python worker processes to execute tasks concurrently on separate
+CPUs. This is a reasonable default for generic Python programs but it induces
+some overhead as the input and output data need to be serialized in a queue for
+communication with the worker processes.
+
+If you know that the function you are calling is based on a compiled extension
+that releases the Python Global Interpreter Lock (GIL) during most of its
+computation then it might be more efficient to use threads instead of Python
+processes as concurrent workers. For instance this is the case if you write the
+CPU intensive part of your code inside a `with nogil`_ block of a Cython
+function.
+
+To use the threads, just pass ``"threading"`` as the value of the ``backend``
+parameter of the :class:`Parallel` constructor:
+
+    >>> Parallel(n_jobs=2, backend="threading")(
+    ...     delayed(sqrt)(i ** 2) for i in range(10))
+    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+
+.. _`with nogil`:: http://docs.cython.org/src/userguide/external_C_code.html#acquiring-and-releasing-the-gil
 
 .. include:: parallel_numpy.rst
 

--- a/doc/parallel_numpy.rst
+++ b/doc/parallel_numpy.rst
@@ -17,6 +17,12 @@ on that file using the ``numpy.memmap`` subclass of ``numpy.ndarray``.
 This makes it possible to share a segment of data between all the
 worker processes.
 
+.. note::
+
+  The following only applies with the default ``"multiprocessing"`` backend. If
+  your code can release the GIL, then using ``backend="threading"`` is even
+  more efficient.
+
 
 Automated array to memmap conversion
 ------------------------------------


### PR DESCRIPTION
This is very useful when calling GIL-releasing compiled extensions as it removes any memory copy and inter-process communication overhead (pickling) induced by the default multiprocessing backend.

I tested it on the bench_covertype with ExtraTrees of scikit-learn with 10 cores. It runs slightly faster (19s instead of 23s with the current master) and furthermore does not do any memory copy.
