### PR TITLE
[MRG] supporting the new Python 3.4 multiprocessing API

### DIFF
--- a/doc/parallel_numpy_fixture.py
+++ b/doc/parallel_numpy_fixture.py
@@ -1,7 +1,7 @@
 """Fixture module to skip memmaping test if numpy is not installed"""
 
 from nose import SkipTest
-from joblib.parallel import multiprocessing
+from joblib.parallel import mp
 from joblib.test.common import setup_autokill
 from joblib.test.common import teardown_autokill
 
@@ -13,7 +13,7 @@ def setup_module(module):
     except ImportError:
         pass
 
-    if numpy is None or multiprocessing is None:
+    if numpy is None or mp is None:
         raise SkipTest('Skipped as numpy or multiprocessing is not available')
 
     setup_autokill(module.__name__)

--- a/joblib/_multiprocessing.py
+++ b/joblib/_multiprocessing.py
@@ -1,0 +1,40 @@
+"""Helper module to factorize the conditional multiprocessing import logic
+
+We use a distinct module to simplify import statements and avoid introducing
+circular dependencies (for instance for the assert_spawning name).
+"""
+import os
+import warnings
+
+
+# Obtain possible configuration from the environment, assuming 1 (on)
+# by default, upon 0 set to None. Should instructively fail if some non
+# 0/1 value is set.
+multiprocessing = int(os.environ.get('JOBLIB_MULTIPROCESSING', 1)) or None
+if multiprocessing:
+    try:
+        import multiprocessing as mp
+        import multiprocessing.pool
+    except ImportError:
+        mp = None
+
+# 2nd stage: validate that locking is available on the system and
+#            issue a warning if not
+if mp is not None:
+    try:
+        _sem = mp.Semaphore()
+        del _sem # cleanup
+    except (ImportError, OSError) as e:
+        mp = None
+        warnings.warn('%s.  joblib will operate in serial mode' % (e,))
+
+
+# 3rd stage: backward compat for the assert_spawning helper
+if mp is not None:
+    try:
+        # Python 3.4+
+        from multiprocessing.context import assert_spawning
+    except ImportError:
+        from multiprocessing.forking import assert_spawning
+else:
+    assert_spawning = None


### PR DESCRIPTION
This is an early pull request to add support the new context-based Python 3.4 multiprocessing API.

This is a both a fix for #98 and #87.

<del>Note that to run the tests with `nosetests` you will need to add a symlink named `nosetests.py` in the same folder as a workaround for [Python issue19946](http://bugs.python.org/issue19946).</del> This issue has been fixed in the dev branch of Python.

<del>Note: I will fix the hashing / save_global bug #97 separately as it's independent of multiprocessing and rebase that branch on top of master once fixed there.</del> (Done)
