### PR TITLE
[MRG] FIX #94: memoryview are less robust on Python 3.2

### DIFF
--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -155,10 +155,12 @@ class NumpyHasher(Hasher):
             # Compute a hash of the object:
             try:
                 self._hash.update(self._getbuffer(obj))
-            except (TypeError, BufferError):
+            except (TypeError, BufferError, ValueError):
                 # Cater for non-single-segment arrays: this creates a
                 # copy, and thus aleviates this issue.
                 # XXX: There might be a more efficient way of doing this
+                # Python 3.2's memoryview raise a ValueError instead of a
+                # TypeError or a BufferError
                 self._hash.update(self._getbuffer(obj.flatten()))
 
             # We store the class, to be able to distinguish between

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -128,6 +128,17 @@ def test_hash_numpy():
 
 
 @with_numpy
+def test_hash_numpy_noncontiguous():
+    a = np.asarray(np.arange(6000).reshape((1000, 2, 3)),
+                   order='F')[:, :1, :]
+    b = np.ascontiguousarray(a)
+    nose.tools.assert_not_equal(hash(a), hash(b))
+
+    c = np.asfortranarray(a)
+    nose.tools.assert_not_equal(hash(a), hash(c))
+
+
+@with_numpy
 def test_hash_memmap():
     """ Check that memmap and arrays hash identically if coerce_mmap is
         True.


### PR DESCRIPTION
This fixes the travis failure we observed on Python 3.2. I will merge if travis is green on this PR.
