### PR TITLE
FIX #72: output_dir kwarg in Memory.cache

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -333,7 +333,7 @@ class MemorizedFunc(Logger):
             print(self.format_call(*args, **kwargs))
         output = self.func(*args, **kwargs)
         self._persist_output(output, output_dir)
-        self._persist_input(output_dir, *args, **kwargs)
+        self._persist_input(output_dir, args, kwargs)
         duration = time.time() - start_time
         if self._verbose:
             _, name = get_func_name(self.func)
@@ -394,7 +394,7 @@ class MemorizedFunc(Logger):
         except OSError:
             " Race condition in the creation of the directory "
 
-    def _persist_input(self, output_dir, *args, **kwargs):
+    def _persist_input(self, output_dir, args, kwargs):
         """ Save a small summary of the call using json format in the
             output directory.
         """

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -500,13 +500,13 @@ def test_format_signature_numpy():
 
 
 def test_persist_with_output_dir_keyword_arg():
-    """
-    Test that "output" keyword argument can be persisted (see issue #72)
-
-    """
+    """Test that "output_dir" keyword argument can be persisted (issue #72)"""
 
     def f(output_dir="thing"):
-        return None
+        return output_dir
 
-    mem = Memory(cachedir="out")
-    mem.cache(f)(output_dir="other/thing")
+    mem = Memory(cachedir=env['dir'])
+    first_result = mem.cache(f)(output_dir="other/thing")
+    cached_result = mem.cache(f)(output_dir="other/thing")
+    nose.tools.assert_equal(first_result, "other/thing")
+    nose.tools.assert_equal(cached_result, "other/thing")


### PR DESCRIPTION
The fix for #72 is simple (as described in the comments of the issue). I will merge the PR if the travis tests are green.
