### PR TITLE
Convert numpy_pickle zfile to use buffered read/write to support large objects

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -36,6 +36,7 @@ _CHUNK_SIZE = 64 * 1024
 ###############################################################################
 # Compressed file with Zlib
 
+
 def _read_magic(file_handle):
     """ Utility to check the magic signature of a file identifying it as a
         Zfile
@@ -59,14 +60,14 @@ def read_zfile(file_handle):
     length = file_handle.read(len(_ZFILE_PREFIX) + _MAX_LEN)
     length = length[len(_ZFILE_PREFIX):]
     length = int(length, 16)
-    decompresser= zlib.decompressobj()
+    decompresser = zlib.decompressobj()
     data = bytearray()
     while True:
         chunk = file_handle.read(_CHUNK_SIZE)
         if not chunk:
             break
         data += decompresser.decompress(chunk)
-    data += decompresser.flush() # Read the remainder
+    data += decompresser.flush()  # Read the remainder
     assert len(data) == length, (
         "Incorrect data length while decompressing %s."
         "The file could be corrupted." % file_handle)
@@ -82,8 +83,9 @@ def write_zfile(file_handle, data, compress=1):
     """
     compresser = zlib.compressobj(compress)
     file_handle.write(_ZFILE_PREFIX)
-    length = hex(len(data)).encode('latin-1')
-    # If python 2.x, we need to remove the trailing 'L' in the hex representation
+    length = hex(len(data)).encode('ascii')
+    # If python 2.x, we need to remove the trailing 'L'
+    # in the hex representation
     length = length.rstrip(b'L')
     # Store the length of the data
     file_handle.write(length.ljust(_MAX_LEN))
@@ -94,7 +96,7 @@ def write_zfile(file_handle, data, compress=1):
         file_handle.write(compresser.compress(chunk))
 
     tail = compresser.flush()
-    if tail: # Write the remainder
+    if tail:  # Write the remainder
         file_handle.write(tail)
 
 
@@ -118,7 +120,7 @@ class NDArrayWrapper(object):
         # Load the array from the disk
         if unpickler.np.__version__ >= '1.3':
             array = unpickler.np.load(filename,
-                            mmap_mode=unpickler.mmap_mode)
+                                      mmap_mode=unpickler.mmap_mode)
         else:
             # Numpy does not have mmap_mode before 1.3
             array = unpickler.np.load(filename)
@@ -126,10 +128,10 @@ class NDArrayWrapper(object):
         # versions of numpy
         if (hasattr(array, '__array_prepare__')
                 and not self.subclass in (unpickler.np.ndarray,
-                                      unpickler.np.memmap)):
+                                          unpickler.np.memmap)):
             # We need to reconstruct another subclass
             new_array = unpickler.np.core.multiarray._reconstruct(
-                    self.subclass, (0,), 'b')
+                self.subclass, (0,), 'b')
             new_array.__array_prepare__(array)
             array = new_array
         return array
@@ -198,7 +200,7 @@ class NumpyPickler(Pickler):
         # Count the number of npy files that we have created:
         self._npy_counter = 0
         Pickler.__init__(self, self.file,
-                                protocol=pickle.HIGHEST_PROTOCOL)
+                         protocol=pickle.HIGHEST_PROTOCOL)
         # delayed import of numpy, to avoid tight coupling
         try:
             import numpy as np
@@ -220,11 +222,11 @@ class NumpyPickler(Pickler):
             # the last entry of 'state' is the data itself
             zfile = open(filename, 'wb')
             write_zfile(zfile, state[-1],
-                                compress=self.compress)
+                        compress=self.compress)
             zfile.close()
             state = state[:-1]
             container = ZNDArrayWrapper(os.path.basename(filename),
-                                            init_args, state)
+                                        init_args, state)
         return container, filename
 
     def save(self, obj):
@@ -233,7 +235,8 @@ class NumpyPickler(Pickler):
             total abuse of the Pickler class.
         """
         if self.np is not None and type(obj) in (self.np.ndarray,
-                                            self.np.matrix, self.np.memmap):
+                                                 self.np.matrix,
+                                                 self.np.memmap):
             size = obj.size * obj.itemsize
             if self.compress and size < self.cache_size * _MEGA:
                 # When compressing, as we are not writing directly to the
@@ -253,8 +256,8 @@ class NumpyPickler(Pickler):
                 self._npy_counter -= 1
                 # XXX: We should have a logging mechanism
                 print('Failed to save %s to .npy file:\n%s' % (
-                        type(obj),
-                        traceback.format_exc()))
+                    type(obj),
+                    traceback.format_exc()))
         return Pickler.save(self, obj)
 
     def close(self):
@@ -296,8 +299,8 @@ class NumpyUnpickler(Unpickler):
         Unpickler.load_build(self)
         if isinstance(self.stack[-1], NDArrayWrapper):
             if self.np is None:
-                raise ImportError('Trying to unpickle an ndarray, '
-                        "but numpy didn't import correctly")
+                raise ImportError("Trying to unpickle an ndarray, "
+                                  "but numpy didn't import correctly")
             nd_array_wrapper = self.stack.pop()
             array = nd_array_wrapper.read(self)
             self.stack.append(array)
@@ -371,9 +374,9 @@ def dump(value, filename, compress=0, cache_size=100):
         # People keep inverting arguments, and the resulting error is
         # incomprehensible
         raise ValueError(
-              'Second argument should be a filename, %s (type %s) was given'
-              % (filename, type(filename))
-            )
+            'Second argument should be a filename, %s (type %s) was given'
+            % (filename, type(filename))
+        )
     try:
         pickler = NumpyPickler(filename, compress=compress,
                                cache_size=cache_size)
@@ -425,8 +428,8 @@ def load(filename, mmap_mode=None):
     if _read_magic(file_handle) == _ZFILE_PREFIX:
         if mmap_mode is not None:
             warnings.warn('file "%(filename)s" appears to be a zip, '
-                    'ignoring mmap_mode "%(mmap_mode)s" flag passed'
-                    % locals(), Warning, stacklevel=2)
+                          'ignoring mmap_mode "%(mmap_mode)s" flag passed'
+                          % locals(), Warning, stacklevel=2)
         unpickler = ZipNumpyUnpickler(filename, file_handle=file_handle)
     else:
         unpickler = NumpyUnpickler(filename,

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -60,7 +60,7 @@ def read_zfile(file_handle):
     length = length[len(_ZFILE_PREFIX):]
     length = int(length, 16)
     decompresser= zlib.decompressobj()
-    data = b''
+    data = bytearray()
     while True:
         chunk = file_handle.read(_CHUNK_SIZE)
         if not chunk:
@@ -82,7 +82,7 @@ def write_zfile(file_handle, data, compress=1):
     """
     compresser = zlib.compressobj(compress)
     file_handle.write(_ZFILE_PREFIX)
-    length = bytes(hex(len(data)))
+    length = hex(len(data)).encode('latin-1')
     # If python 2.x, we need to remove the trailing 'L' in the hex representation
     length = length.rstrip(b'L')
     # Store the length of the data

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -224,7 +224,11 @@ def test_masked_array_persistence():
 def test_z_file():
     # Test saving and loading data with Zfiles
     filename = env['filename'] + str(random.randint(0, 1000))
-    data = numpy_pickle.asbytes('Foo, \n Bar, baz, \n\nfoobar')
+    # asbytes() was removed as unnecessary since all internal code paths
+    # to write_zfile() pass in a bytes object already.
+    # Ian Beaver - 2/3/2014
+    #data = numpy_pickle.asbytes('Foo, \n Bar, baz, \n\nfoobar')
+    data = b'Foo, \n Bar, baz, \n\nfoobar'
     numpy_pickle.write_zfile(open(filename, 'wb'), data)
     data_read = numpy_pickle.read_zfile(open(filename, 'rb'))
     nose.tools.assert_equal(data, data_read)


### PR DESCRIPTION
If you try to save large arrays using the current version of numpy_pickle you will get integer overflow errors because the object length will not fit in an integer.  This change converts the zlib calls to use a buffer instead of calling compress with the full object.  Tested to read/write 20GB arrays with near identical performance in Python 2.7 and Python 3.2.