### PR TITLE
Format stack is broken in python2 if you pass parameter to delayed such that repr(param) contains non-ascii symbol

### DIFF
--- a/joblib/format_stack.py
+++ b/joblib/format_stack.py
@@ -17,7 +17,7 @@ Adapted from IPython's VerboseTB.
 #            2001-2004, Fernando Perez
 #            2001 Nathaniel Gray
 # License: BSD 3 clause
-
+from __future__ import unicode_literals
 
 import inspect
 import keyword


### PR DESCRIPTION
fix format_stack in python2 if parameter value repr of delayed function contains non-ascii symbol
