### PR TITLE
FIX: Make exception wrapping work under Python 3

### DIFF
--- a/joblib/my_exceptions.py
+++ b/joblib/my_exceptions.py
@@ -9,28 +9,32 @@ import sys
 
 
 class JoblibException(Exception):
-    """ A simple exception with an error message that you can get to.
-    """
+    """A simple exception with an error message that you can get to."""
 
-    def __init__(self, message):
-        self.message = message
+    def __init__(self, *args):
+        self.args = args
 
     def __reduce__(self):
         # For pickling
-        return self.__class__, (self.message,), {}
+        return self.__class__, self.args, {}
 
     def __repr__(self):
-        return '%s\n%s\n%s\n%s' % (
-                    self.__class__.__name__,
-                    75 * '_',
-                    self.message,
-                    75 * '_')
+        if hasattr(self, 'args'):
+            message = self.args[0]
+        else:
+            # Python 2 compat: instances of JoblibException can be created
+            # without calling JoblibException __init__ in case of
+            # multi-inheritance: in that case the message is stored as an
+            # explicit attribute under Python 2 (only)
+            message = self.message
+        name = self.__class__.__name__
+        return '%s\n%s\n%s\n%s' % (name, 75 * '_', message, 75 * '_')
 
     __str__ = __repr__
 
 
 class TransportableException(JoblibException):
-    """ An exception containing all the info to wrap an original
+    """An exception containing all the info to wrap an original
         exception and recreate it.
     """
 

--- a/joblib/test/test_my_exceptions.py
+++ b/joblib/test/test_my_exceptions.py
@@ -18,4 +18,5 @@ def test__mk_exception():
     # Check that _mk_exception works on a bunch of different exceptions
     for klass in (Exception, TypeError, SyntaxError, ValueError,
                   AssertionError):
-        my_exceptions._mk_exception(klass)
+        e = my_exceptions._mk_exception(klass)[0]('Some argument')
+        assert_true('Some argument' in repr(e))


### PR DESCRIPTION
Exceptions in Python 3 no longer have a the `.message` attribute but instead store all constructor arguments as `.args`.
