### PR TITLE
ENH: Make MemorizedFunc __doc__ autodoc-compatible

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -380,8 +380,9 @@ class MemorizedFunc(Logger):
         except:
             " Objects like ufunc don't like that "
         if inspect.isfunction(func):
-            doc = pydoc.TextDoc().document(func
-                                           ).replace('\n', '\n\n', 1)
+            doc = pydoc.TextDoc().document(func)
+            # Remove blank line
+            doc = doc.replace('\n', '\n\n', 1)
             # Strip backspace-overprints for compatibility with autodoc
             doc = re.sub('\x08.', '', doc)
         else:


### PR DESCRIPTION
This PR just strips the `\x08` control characters that `pydoc`  uses for displaying function names in bold, so that the modified docstring of a `MemorizedFunc` plays nicely with tools like `sphinx.ext.autodoc`.

Currently, using `autodoc` on `joblib.Memory('dir').cache(func(args))` results in documentation like this:

```
Memoized version of ffuunncc(args)
```
