### PR TITLE
MAINT bumb the upper supported version for Python in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
     - "2.6"
     - "2.7"
     - "3.2"
-    - "3.3"
+    - "3.4"
 
 before_install:
     - pip --quiet install --use-mirrors numpy


### PR DESCRIPTION
Check Python 3.4. I removed 3.3 as testing both for 3.2 and 3.4 should be enough to catch all bugs in that range.
