### PR TITLE
[MRG] use /dev/shm as advertised in the documentation when possible

### DIFF
--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -502,33 +502,35 @@ class MemmapingPool(PicklingPool):
         # pool instance (do not create in advance to spare FS write access if
         # no array is to be dumped):
         use_shared_mem = False
+        pool_folder_name = "joblib_memmaping_pool_%d_%d" % (
+            os.getpid(), id(self))
         if temp_folder is None:
             temp_folder = os.environ.get('JOBLIB_TEMP_FOLDER', None)
         if temp_folder is None:
             if os.path.exists(SYSTEM_SHARED_MEM_FS):
                 try:
-                    joblib_folder = os.path.join(
-                        SYSTEM_SHARED_MEM_FS, 'joblib')
-                    if not os.path.exists(joblib_folder):
-                        os.makedirs(joblib_folder)
+                    temp_folder = SYSTEM_SHARED_MEM_FS
+                    pool_folder = os.path.join(temp_folder, pool_folder_name)
+                    if not os.path.exists(pool_folder):
+                        os.makedirs(pool_folder)
                     use_shared_mem = True
                 except IOError:
-                    # Missing rights in the the /dev/shm partition, ignore
-                    pass
+                    # Missing rights in the the /dev/shm partition,
+                    # fallback to regular temp folder.
+                    temp_folder = None
         if temp_folder is None:
             # Fallback to the default tmp folder, typically /tmp
             temp_folder = tempfile.gettempdir()
         temp_folder = os.path.abspath(os.path.expanduser(temp_folder))
-        self._temp_folder = temp_folder = os.path.join(
-            temp_folder, "joblib_memmaping_pool_%d_%d" % (
-                os.getpid(), id(self)))
+        pool_folder = os.path.join(temp_folder, pool_folder_name)
+        self._temp_folder = pool_folder
 
         # Register the garbage collector at program exit in case caller forgets
         # to call terminate explicitly: note we do not pass any reference to
         # self to ensure that this callback won't prevent garbage collection of
         # the pool instance and related file handler resources such as POSIX
         # semaphores and pipes
-        atexit.register(lambda: delete_folder(temp_folder))
+        atexit.register(lambda: delete_folder(pool_folder))
 
         if np is not None:
             # Register smart numpy.ndarray reducers that detects memmap backed
@@ -537,7 +539,7 @@ class MemmapingPool(PicklingPool):
             if prewarm == "auto":
                 prewarm = not use_shared_mem
             forward_reduce_ndarray = ArrayMemmapReducer(
-                max_nbytes, temp_folder, mmap_mode, verbose,
+                max_nbytes, pool_folder, mmap_mode, verbose,
                 context_id=context_id, prewarm=prewarm)
             forward_reducers[np.ndarray] = forward_reduce_ndarray
             forward_reducers[np.memmap] = reduce_memmap
@@ -547,7 +549,7 @@ class MemmapingPool(PicklingPool):
             # to avoid confusing the caller and make it tricky to collect the
             # temporary folder
             backward_reduce_ndarray = ArrayMemmapReducer(
-                None, temp_folder, mmap_mode, verbose)
+                None, pool_folder, mmap_mode, verbose)
             backward_reducers[np.ndarray] = backward_reduce_ndarray
             backward_reducers[np.memmap] = reduce_memmap
 


### PR DESCRIPTION
Fix for #148: /dev/shm was never used even when available. Added a non-regression test that should only execute on platform that support it (typically linux).

Let's see if travis likes that.
