### PR TITLE
[MRG] FIX #146: Heisen test failure caused by thread-unsafe Python lists

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -103,10 +103,10 @@ class SafeFunction(object):
 
 
 ###############################################################################
-def delayed(function, check_picklability=True):
+def delayed(function, check_pickle=True):
     """Decorator used to capture the arguments of a function.
 
-    Pass `check_picklability=False` when:
+    Pass `check_pickle=False` when:
 
     - performing a possibly repeated check is too costly and has been done
       already once outside of the call to delayed.
@@ -116,7 +116,7 @@ def delayed(function, check_picklability=True):
     """
     # Try to pickle the input function, to catch the problems early when
     # using with multiprocessing:
-    if check_picklability:
+    if check_pickle:
         pickle.dumps(function)
 
     def delayed_function(*args, **kwargs):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -146,7 +146,7 @@ def test_mutate_input_with_threads():
     """Input is mutable when using the threading backend"""
     q = Queue(maxsize=5)
     Parallel(n_jobs=2, backend="threading")(
-        delayed(q.put, check_picklability=False)(1) for _ in range(5))
+        delayed(q.put, check_pickle=False)(1) for _ in range(5))
     nose.tools.assert_true(q.full())
 
 


### PR DESCRIPTION
This fix uses a `queue.Queue` datastructure in the failing test. This
datastructure is thread-safe thanks to an internal Lock. This Lock instance is
not picklable hence cause the picklability check of delayed to check fail.

When using the threading backend, picklability is no longer required, hence
this PRs give the user the ability to disable it on a case by case basis.
