### PR TITLE
FIX disable memmapping for object arrays

### DIFF
--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -200,7 +200,9 @@ class ArrayMemmapReducer(object):
             # a is already backed by a memmap file, let's reuse it directly
             return _reduce_memmap_backed(a, m)
 
-        if self._max_nbytes is not None and a.nbytes > self._max_nbytes:
+        if (not a.dtype.hasobject
+                and self._max_nbytes is not None
+                and a.nbytes > self._max_nbytes):
             # check that the folder exists (lazily create the pool temp folder
             # if required)
             try:

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -347,6 +347,12 @@ def test_memmaping_pool_for_large_arrays():
         dumped_filenames = os.listdir(p._temp_folder)
         assert_equal(len(dumped_filenames), 2)
 
+        # Check that memmory mapping is not triggered for arrays with
+        # dtype='object'
+        objects = np.array(['abc'] * 100, dtype='object')
+        results = p.map(has_shareable_memory, [objects])
+        assert_false(results[0])
+
     finally:
         # check FS garbage upon pool termination
         p.terminate()


### PR DESCRIPTION
Fix for #162. Otherwise this can cause errors such as:

```
...
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/pickle.py", line 1036, in load
    dispatch[key[0]](self)
  File "/Users/ogrisel/code/joblib/joblib/numpy_pickle.py", line 291, in load_build
    array = nd_array_wrapper.read(self)
  File "/Users/ogrisel/code/joblib/joblib/numpy_pickle.py", line 113, in read
    mmap_mode=unpickler.mmap_mode)
  File "/Users/ogrisel/code/numpy/numpy/lib/npyio.py", line 389, in load
    return format.open_memmap(file, mode=mmap_mode)
  File "/Users/ogrisel/code/numpy/numpy/lib/format.py", line 684, in open_memmap
    raise ValueError(msg)
ValueError: Array can't be memory-mapped: Python objects in dtype.
```
