### PR TITLE
ENH: Process filter arguments when getting key

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -155,7 +155,7 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
     return module, name
 
 
-def filter_args(func, ignore_lst, args=(), kwargs=dict()):
+def filter_args(func, ignore_lst, args=(), kwargs=dict(), process={}):
     """ Filters the given args and kwargs using a list of arguments to
         ignore, and a function specification.
 
@@ -170,6 +170,13 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
             Positional arguments passed to the function.
         **kwargs: dict
             Keyword arguments passed to the function
+        process: dict
+            Dictionary with processing functions.  The keys of this
+            dictionary should correspond to arguments.  The values are
+            callables.  For each dictionary entry process[arg] = f, the
+            argument will be replaced by f(arg).  This may be necessary,
+            for example, if some arguments cause a failure in hashing, for
+            whatever reason.
 
         Returns
         -------
@@ -260,6 +267,11 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
                                                    arg_keywords,
                                                    arg_defaults,
                                                    )))
+
+    # Now apply processors for remaining arguments
+    for (arg, pr) in process.items():
+        arg_dict[arg] = pr(arg_dict[arg])
+
     # XXX: Return a sorted list of pairs?
     return arg_dict
 

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -319,6 +319,13 @@ class MemorizedFunc(Logger):
             List of variable names to ignore when choosing whether to
             recompute.
 
+        process: dict or None
+            Dictionary of variable names with associated functions to
+            filter prior to computing a key.  This means that for each
+            (arg, func) pair in process, rather than using the value of
+            arg directly, func(arg) will be used.  This may be needed
+            in case some arguments cause a failure in calculating the key.
+
         mmap_mode: {None, 'r+', 'r', 'w+', 'c'}
             The memmapping mode used when loading from cache
             numpy arrays. See numpy.load for the meaning of the different
@@ -339,7 +346,7 @@ class MemorizedFunc(Logger):
     #-------------------------------------------------------------------------
 
     def __init__(self, func, cachedir, ignore=None, mmap_mode=None,
-                 compress=False, verbose=1, timestamp=None):
+                 compress=False, verbose=1, timestamp=None, process=None):
         """
             Parameters
             ----------
@@ -349,6 +356,13 @@ class MemorizedFunc(Logger):
                 The path of the base directory to use as a data store
             ignore: list or None
                 List of variable names to ignore.
+            process: dict or None
+                Dictionary of variable names with associated functions
+                to filter prior to computing a key.  This means that for
+                each (arg, func) pair in process, rather than using the
+                value of arg directly, func(arg) will be used.  This may
+                be needed in case some arguments cause a failure in
+                calculating the key.
             mmap_mode: {None, 'r+', 'r', 'w+', 'c'}, optional
                 The memmapping mode used when loading from cache
                 numpy arrays. See numpy.load for the meaning of the
@@ -371,6 +385,9 @@ class MemorizedFunc(Logger):
         if ignore is None:
             ignore = []
         self.ignore = ignore
+        if process is None:
+            process = {}
+        self.process = process
 
         self._verbose = verbose
         self.cachedir = cachedir
@@ -504,7 +521,8 @@ class MemorizedFunc(Logger):
 
     def _get_argument_hash(self, *args, **kwargs):
         return hashing.hash(filter_args(self.func, self.ignore,
-                                         args, kwargs),
+                                         args, kwargs,
+                                         process=self.process),
                              coerce_mmap=(self.mmap_mode is not None))
 
     def _get_output_dir(self, *args, **kwargs):
@@ -714,7 +732,8 @@ class MemorizedFunc(Logger):
         """
         start_time = time.time()
         argument_dict = filter_args(self.func, self.ignore,
-                                    args, kwargs)
+                                    args, kwargs,
+                                    process=self.process)
 
         input_repr = dict((k, repr(v)) for k, v in argument_dict.items())
         # This can fail due to race-conditions with multiple
@@ -828,7 +847,7 @@ class Memory(Logger):
             mkdirp(self.cachedir)
 
     def cache(self, func=None, ignore=None, verbose=None,
-                        mmap_mode=False):
+                        mmap_mode=False, process=None):
         """ Decorates the given function func to only compute its return
             value for input arguments not cached on disk.
 
@@ -845,6 +864,13 @@ class Memory(Logger):
                 The memmapping mode used when loading from cache
                 numpy arrays. See numpy.load for the meaning of the
                 arguments. By default that of the memory object is used.
+            process: dict or None
+                Dictionary of variable names with associated functions
+                to filter prior to computing a key.  This means that for
+                each (arg, func) pair in process, rather than using the
+                value of arg directly, func(arg) will be used.  This may
+                be needed in case some arguments cause a failure in
+                calculating the key.
 
             Returns
             -------
@@ -872,7 +898,8 @@ class Memory(Logger):
                                    ignore=ignore,
                                    compress=self.compress,
                                    verbose=verbose,
-                                   timestamp=self.timestamp)
+                                   timestamp=self.timestamp,
+                                   process=process)
 
     def clear(self, warn=True):
         """ Erase the complete cache directory.

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -100,6 +100,9 @@ def test_filter_args():
     yield nose.tools.assert_equal, filter_args(f2, [], (),
                                                dict(x=1)), {'x': 1}
 
+    yield nose.tools.assert_equal, filter_args(f, [], (1, ),
+                process={"x": lambda a: 2*a}), {'x': 2, 'y': 0}
+
 
 def test_filter_args_method():
     obj = Klass()


### PR DESCRIPTION
This pull request adds functionality to joblib.func_inspect.filter_args to have
not only a list of arguments that are ignored, but also a dictionary of
arguments processed in a particular way.  This can be useful when we want
to avoid values that cause a failure to calculate a key.  One example
would be an ndarray containing datetime64 (see issue #188).  This commit
adds the appropriate functionality to the MemorizedFunc and Memory
classes, by adding an attribute `process` analogous to the existing
attribute `ignore`.

Also add a test to see if this works, to
joblib.test.test_func_inspect.test_filter_args.