### PR TITLE
Improve tests for python 2 and 3 compressed pickles compatibility

### DIFF
--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -256,9 +256,17 @@ def test_compressed_pickle_python_2_3_compatibility():
             [int(each) for each in version_match.groups()])
         python_version_used_for_reading = sys.version_info[:2]
 
-        if ('0.8.4' in fname and
-                python_version_used_for_reading >=
-                python_version_used_for_writing):
+        python_version_to_default_pickle_protocol = {
+            (2, 6): 2, (2, 7): 2,
+            (3, 0): 3, (3, 1): 3, (3, 2): 3, (3, 3): 3, (3, 4): 4}
+
+        pickle_reading_protocol = python_version_to_default_pickle_protocol[
+            python_version_used_for_reading]
+        pickle_writing_protocol = python_version_to_default_pickle_protocol[
+            python_version_used_for_writing]
+        if ('0.8.4' not in fname or
+                pickle_reading_protocol >=
+                pickle_writing_protocol):
             result1, result2 = numpy_pickle.load(fname)
             nose.tools.assert_equal(result1.dtype, expected1.dtype)
             nose.tools.assert_equal(result2.dtype, expected2.dtype)
@@ -272,6 +280,8 @@ def test_compressed_pickle_python_2_3_compatibility():
             # for python 3.4)
             try:
                 numpy_pickle.load(fname)
+                raise AssertionError('Numpy pickle loading should '
+                                     'have raised a ValueError exception')
             except ValueError as e:
                 nose.tools.assert_true(
                     'unsupported pickle protocol' in str(e.args))


### PR DESCRIPTION
AssertionError should be raised if the numpy pickle fail to raise a ValueError. Also the proper thing to check is the default pickle protocol rather than the python version.