### PR TITLE
Use python 3.3 in Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
     - "2.6"
     - "2.7"
-    - "3.2"
+    - "3.3"
     - "3.4"
 
 before_install:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 The homepage of joblib with user documentation is located on:
 
-http://packages.python.org/joblib/
+https://pythonhosted.org/joblib/
 
 Getting the latest code
 =========================
@@ -21,9 +21,9 @@ As any Python packages, to install joblib, simply do::
 
 in the source code directory.
 
-Joblib has no other mandatory dependency than Python (at least version
-2.6). Numpy (at least version 1.3) is an optional dependency for array
-manipulation.
+Joblib has no other mandatory dependency than Python (supported
+versions are 2.6+ and 3.3+). Numpy (at least version 1.3) is an
+optional dependency for array manipulation.
 
 Workflow to contribute
 =========================

--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -100,7 +100,23 @@ Main features
 
 """
 
-__version__ = '0.8.4'
+# PEP0440 compatible formatted version, see:
+# https://www.python.org/dev/peps/pep-0440/
+#
+# Generic release markers:
+# X.Y
+# X.Y.Z # For bugfix releases
+#
+# Admissible pre-release markers:
+# X.YaN # Alpha release
+# X.YbN # Beta release
+# X.YrcN # Release Candidate
+# X.Y # Final release
+#
+# Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
+# 'X.Y.dev0' is the canonical version of 'X.Y.dev'
+#
+__version__ = '0.9.0.dev0'
 
 
 from .memory import Memory, MemorizedResult


### PR DESCRIPTION
rather than python 3.2.

Any objections? One of the reason is that Python 3.2 has some idiosyncrasies (I recently realised than `u''` gives a SyntaxError and also python 3.2 is not available through conda which is very annoying to test fixes locally) and is probably not used that much in the wild.