### PR TITLE
Use pythonhosted.org rather than packages.python.org

### DIFF
--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -14,7 +14,7 @@ data and has specific optimizations for `numpy` arrays. It is
 
 
     ============================== ============================================
-    **User documentation**:        http://packages.python.org/joblib
+    **User documentation**:        http://pythonhosted.org/joblib
 
     **Download packages**:         http://pypi.python.org/pypi/joblib#downloads
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
           summary='Tools to use Python functions as pipeline jobs.',
           author='Gael Varoquaux',
           author_email='gael.varoquaux@normalesup.org',
-          url='http://packages.python.org/joblib/',
+          url='http://pythonhosted.org/joblib/',
           description="""
 Lightweight pipelining: using Python functions as pipeline jobs.
 """,

--- a/sphinx_pypi_upload.py
+++ b/sphinx_pypi_upload.py
@@ -133,7 +133,7 @@ class UploadDoc(upload):
         elif response.status == 301:
             location = response.getheader('Location')
             if location is None:
-                location = 'http://packages.python.org/%s/' % meta.get_name()
+                location = 'http://pythonhosted.org/%s/' % meta.get_name()
             self.announce('Upload successful. Visit %s' % location,
                           log.INFO)
         else:


### PR DESCRIPTION
The only reference I could find that states that pythonhosted is the new official name is [here](http://www.mechanicalcat.net/richard/log/Python/Introducing_pythonhosted_org___the_new_packages_python_org)

