### PR TITLE
Add source encoding parameter in Memory module

### DIFF
--- a/joblib/_memory_helpers.py
+++ b/joblib/_memory_helpers.py
@@ -1,0 +1,105 @@
+try:
+    # Available in Python 3
+    from tokenize import open as open_py_source
+
+except ImportError:
+    # Copied from python3 tokenize
+    from codecs import lookup, BOM_UTF8
+    import re
+    from io import TextIOWrapper, open
+    cookie_re = re.compile("coding[:=]\s*([-\w.]+)")
+
+    def _get_normal_name(orig_enc):
+        """Imitates get_normal_name in tokenizer.c."""
+        # Only care about the first 12 characters.
+        enc = orig_enc[:12].lower().replace("_", "-")
+        if enc == "utf-8" or enc.startswith("utf-8-"):
+            return "utf-8"
+        if enc in ("latin-1", "iso-8859-1", "iso-latin-1") or \
+           enc.startswith(("latin-1-", "iso-8859-1-", "iso-latin-1-")):
+            return "iso-8859-1"
+        return orig_enc
+
+    def _detect_encoding(readline):
+        """
+        The detect_encoding() function is used to detect the encoding that
+        should be used to decode a Python source file.  It requires one
+        argment, readline, in the same way as the tokenize() generator.
+
+        It will call readline a maximum of twice, and return the encoding used
+        (as a string) and a list of any lines (left as bytes) it has read in.
+
+        It detects the encoding from the presence of a utf-8 bom or an encoding
+        cookie as specified in pep-0263.  If both a bom and a cookie are
+        present, but disagree, a SyntaxError will be raised.  If the encoding
+        cookie is an invalid charset, raise a SyntaxError.  Note that if a
+        utf-8 bom is found, 'utf-8-sig' is returned.
+
+        If no encoding is specified, then the default of 'utf-8' will be
+        returned.
+        """
+        bom_found = False
+        encoding = None
+        default = 'utf-8'
+
+        def read_or_stop():
+            try:
+                return readline()
+            except StopIteration:
+                return b''
+
+        def find_cookie(line):
+            try:
+                line_string = line.decode('ascii')
+            except UnicodeDecodeError:
+                return None
+
+            matches = cookie_re.findall(line_string)
+            if not matches:
+                return None
+            encoding = _get_normal_name(matches[0])
+            try:
+                codec = lookup(encoding)
+            except LookupError:
+                # This behaviour mimics the Python interpreter
+                raise SyntaxError("unknown encoding: " + encoding)
+
+            if bom_found:
+                if codec.name != 'utf-8':
+                    # This behaviour mimics the Python interpreter
+                    raise SyntaxError('encoding problem: utf-8')
+                encoding += '-sig'
+            return encoding
+
+        first = read_or_stop()
+        if first.startswith(BOM_UTF8):
+            bom_found = True
+            first = first[3:]
+            default = 'utf-8-sig'
+        if not first:
+            return default, []
+
+        encoding = find_cookie(first)
+        if encoding:
+            return encoding, [first]
+
+        second = read_or_stop()
+        if not second:
+            return default, [first]
+
+        encoding = find_cookie(second)
+        if encoding:
+            return encoding, [first, second]
+
+        return default, [first, second]
+
+    def open_py_source(filename):
+        """Open a file in read only mode using the encoding detected by
+        detect_encoding().
+        """
+        buffer = open(filename, 'rb')
+        encoding, lines = _detect_encoding(buffer.readline)
+        buffer.seek(0)
+        text = TextIOWrapper(buffer, encoding, line_buffering=True)
+        text.mode = 'r'
+        return text

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -14,7 +14,7 @@ import os
 
 from ._compat import _basestring
 from .logger import pformat
-
+from ._memory_helpers import open_py_source
 
 def get_func_code(func):
     """ Attempts to retrieve a reliable function code hash.
@@ -54,7 +54,7 @@ def get_func_code(func):
                 source_file = '<doctest %s>' % source_file
             return source_code, source_file, line_no
         # Try to retrieve the source code.
-        with open(source_file) as source_file_obj:
+        with open_py_source(source_file) as source_file_obj:
             first_line = code.co_firstlineno
             # All the lines after the function definition:
             source_lines = list(islice(source_file_obj, first_line - 1, None))
@@ -74,12 +74,13 @@ def get_func_code(func):
 
 
 def _clean_win_chars(string):
-    "Windows cannot encode some characters in filenames"
+    """Windows cannot encode some characters in filename."""
     import urllib
     if hasattr(urllib, 'quote'):
         quote = urllib.quote
     else:
         # In Python 3, quote is elsewhere
+        import urllib.parse
         quote = urllib.parse.quote
     for char in ('<', '>', '!', ':', '\\'):
         string = string.replace(char, quote(char))

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -26,11 +26,13 @@ import warnings
 import inspect
 import json
 import weakref
+import io
 
 # Local imports
 from . import hashing
 from .func_inspect import get_func_code, get_func_name, filter_args
 from .func_inspect import format_signature, format_call
+from ._memory_helpers import open_py_source
 from .logger import Logger, format_time, pformat
 from . import numpy_pickle
 from .disk import mkdirp, rm_subdirs
@@ -540,8 +542,8 @@ class MemorizedFunc(Logger):
         # sometimes have several functions named the same way in a
         # file. This is bad practice, but joblib should be robust to bad
         # practice.
-        func_code = '%s %i\n%s' % (FIRST_LINE_TEXT, first_line, func_code)
-        with open(filename, 'w') as out:
+        func_code = u'%s %i\n%s' % (FIRST_LINE_TEXT, first_line, func_code)
+        with io.open(filename, 'w', encoding="UTF-8") as out:
             out.write(func_code)
         # Also store in the in-memory store of function hashes
         is_named_callable = False
@@ -590,7 +592,7 @@ class MemorizedFunc(Logger):
         func_code_file = os.path.join(func_dir, 'func_code.py')
 
         try:
-            with open(func_code_file) as infile:
+            with io.open(func_code_file, encoding="UTF-8") as infile:
                 old_func_code, old_first_line = \
                             extract_first_line(infile.read())
         except IOError:
@@ -624,7 +626,7 @@ class MemorizedFunc(Logger):
             if os.path.exists(source_file):
                 _, func_name = get_func_name(self.func, resolv_alias=False)
                 num_lines = len(func_code.split('\n'))
-                with open(source_file) as f:
+                with open_py_source(source_file) as f:
                     on_disk_func_code = f.readlines()[
                         old_first_line - 1:old_first_line - 1 + num_lines - 1]
                 on_disk_func_code = ''.join(on_disk_func_code)

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -202,3 +202,23 @@ def test_format_signature_numpy():
     """ Test the format signature formatting with numpy.
     """
 
+
+def test_special_source_encoding():
+    from .test_func_inspect_special_encoding import big5_f
+    func_code, source_file, first_line = get_func_code(big5_f)
+    nose.tools.assert_equal(first_line, 5)
+    nose.tools.assert_true("def big5_f():" in func_code)
+    nose.tools.assert_true("test_func_inspect_special_encoding" in source_file)
+
+
+def _get_code():
+    from .test_func_inspect_special_encoding import big5_f
+    return get_func_code(big5_f)[0]
+
+
+def test_func_code_consistency():
+    from ..parallel import Parallel, delayed
+    codes = Parallel(n_jobs=2)(delayed(_get_code)() for _ in range(5))
+    nose.tools.assert_equal(len(set(codes)), 1)
+
+

--- a/joblib/test/test_func_inspect_special_encoding.py
+++ b/joblib/test/test_func_inspect_special_encoding.py
@@ -1,0 +1,10 @@
+# -*- coding: big5 -*-
+
+
+# Some Traditional Chinese characters: 一些中文字符
+def big5_f():
+    """用於測試的函數
+    """
+    # 註釋
+    return 0
+


### PR DESCRIPTION
When caching a function's return value,  current implementation assume that the source file encoding of that function is the system's default encoding. If not, something bad happens.
This pull request added a source code encoding parameter to fix this problem. I think it would be useful.