### PR TITLE
Remove lingering python 3.2 specific code

### DIFF
--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -161,12 +161,13 @@ class NumpyHasher(Hasher):
                 # taking the memoryview
                 obj_bytes_view = obj.view(self.np.uint8)
                 self._hash.update(self._getbuffer(obj_bytes_view))
-            except (TypeError, BufferError, ValueError):
+            # ValueError is raised by .view when the array is not contiguous
+            # BufferError is raised by Python 3 in the hash update if
+            # the array is Fortran rather than C contiguous
+            except (ValueError, BufferError):
                 # Cater for non-single-segment arrays: this creates a
                 # copy, and thus aleviates this issue.
                 # XXX: There might be a more efficient way of doing this
-                # Python 3.2's memoryview raise a ValueError instead of a
-                # TypeError or a BufferError
                 obj_bytes_view = obj.flatten().view(self.np.uint8)
                 self._hash.update(self._getbuffer(obj_bytes_view))
 

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -35,9 +35,6 @@ except ImportError:
 # Customizable pure Python pickler in Python 2
 # customizable C-optimized pickler under Python 3.3+
 from pickle import Pickler
-if sys.version_info[0] > 2 and not hasattr(Pickler, 'dispatch_table'):
-    # Special case for Python 3.2: use the pure Python pickler as fallback
-    from pickle import _Pickler as Pickler
 
 from pickle import HIGHEST_PROTOCOL
 from io import BytesIO

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ Lightweight pipelining: using Python functions as pipeline jobs.
               'Programming Language :: Python :: 2.6',
               'Programming Language :: Python :: 2.7',
               'Programming Language :: Python :: 3',
-              'Programming Language :: Python :: 3.2',
               'Programming Language :: Python :: 3.3',
               'Programming Language :: Python :: 3.4',
               'Topic :: Scientific/Engineering',


### PR DESCRIPTION
since it is not supported anymore.

The only non completely trivial change is a tweak of the exception caught in hashing.py. With the recent addition of the bytes view in #204, I don't think that TypeError can be raised anymore.