### PR TITLE
Correct number of arguments when raising TransportableException

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -99,7 +99,7 @@ class SafeFunction(object):
             e_type, e_value, e_tb = sys.exc_info()
             text = format_exc(e_type, e_value, e_tb, context=10,
                              tb_offset=1)
-            if e_type == TransportableException:
+            if issubclass(e_type, TransportableException):
                 raise
             else:
                 raise TransportableException(text, e_type)

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -99,7 +99,10 @@ class SafeFunction(object):
             e_type, e_value, e_tb = sys.exc_info()
             text = format_exc(e_type, e_value, e_tb, context=10,
                              tb_offset=1)
-            raise TransportableException(text, e_type)
+            if e_type == TransportableException:
+                raise
+            else:
+                raise TransportableException(text, e_type)
 
 
 ###############################################################################
@@ -540,7 +543,7 @@ class Parallel(Logger):
                             )
                         # Convert this to a JoblibException
                         exception_type = _mk_exception(exception.etype)[0]
-                        raise exception_type(report, exception.etype)
+                        raise exception_type(report)
                     raise exception
                 finally:
                     self._lock.release()

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -540,7 +540,7 @@ class Parallel(Logger):
                             )
                         # Convert this to a JoblibException
                         exception_type = _mk_exception(exception.etype)[0]
-                        raise exception_type(report)
+                        raise exception_type(report, exception.etype)
                     raise exception
                 finally:
                     self._lock.release()

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -62,7 +62,6 @@ def exception_raiser(x):
         raise ValueError
     return x
 
-
 def interrupt_raiser(x):
     time.sleep(.05)
     raise KeyboardInterrupt
@@ -289,6 +288,13 @@ def test_exception_dispatch():
                     (delayed(exception_raiser)(i) for i in range(30)),
             )
 
+def test_nested_exception_dispatch():
+    """Ensure TransportableException objects for nested joblib cases gets propagated.
+    """
+    nose.tools.assert_raises(
+        JoblibException,
+        Parallel(n_jobs=2, pre_dispatch=16, verbose=0),
+                (delayed(SafeFunction(exception_raiser))(i) for i in range(30)))
 
 def _reload_joblib():
     # Retrieve the path of the parallel module in a robust way

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -289,8 +289,7 @@ def test_exception_dispatch():
             )
 
 def test_nested_exception_dispatch():
-    """Ensure TransportableException objects for nested joblib cases gets propagated.
-    """
+    # Ensure TransportableException objects for nested joblib cases gets propagated.
     nose.tools.assert_raises(
         JoblibException,
         Parallel(n_jobs=2, pre_dispatch=16, verbose=0),


### PR DESCRIPTION
Thanks for all the great work on joblib. When using it for parallel processing, some errors can cause a confusing stack that obscures the underlying issue:
```
File "python2.7/site-packages/joblib/parallel.py", line 651, in __call__
    self.retrieve()
  File "lib/python2.7/site-packages/joblib/parallel.py", line 534, in retrieve
    raise exception_type(report)
TypeError: __init__() takes at least 3 arguments (2 given)
```
TransportableExceptions take both the message and message type:

https://github.com/joblib/joblib/blob/001fab4ab42e604a5471a6bef9722ea3d77e4309/joblib/my_exceptions.py#L41

and this small change fixes the problem. Thanks again.