### PR TITLE
Use absolute imports in tests

### DIFF
--- a/joblib/test/__init__.py
+++ b/joblib/test/__init__.py
@@ -1,2 +1,2 @@
-from . import test_memory
-from . import test_hashing
+from joblib.test import test_memory
+from joblib.test import test_hashing

--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -16,7 +16,7 @@ from tempfile import mkdtemp
 
 import nose
 
-from ..disk import disk_used, memstr_to_kbytes, mkdirp
+from joblib.disk import disk_used, memstr_to_kbytes, mkdirp
 
 
 ###############################################################################

--- a/joblib/test/test_format_stack.py
+++ b/joblib/test/test_format_stack.py
@@ -8,7 +8,7 @@ Unit tests for the stack formatting utilities
 
 import nose
 
-from ..format_stack import safe_repr
+from joblib.format_stack import safe_repr
 
 
 ###############################################################################

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -12,10 +12,10 @@ import nose
 import tempfile
 import functools
 
-from ..func_inspect import filter_args, get_func_name, get_func_code
-from ..func_inspect import _clean_win_chars, format_signature
-from ..memory import Memory
-from .common import with_numpy
+from joblib.func_inspect import filter_args, get_func_name, get_func_code
+from joblib.func_inspect import _clean_win_chars, format_signature
+from joblib.memory import Memory
+from joblib.test.common import with_numpy
 
 
 ###############################################################################
@@ -204,7 +204,7 @@ def test_format_signature_numpy():
 
 
 def test_special_source_encoding():
-    from .test_func_inspect_special_encoding import big5_f
+    from joblib.test.test_func_inspect_special_encoding import big5_f
     func_code, source_file, first_line = get_func_code(big5_f)
     nose.tools.assert_equal(first_line, 5)
     nose.tools.assert_true("def big5_f():" in func_code)
@@ -212,12 +212,12 @@ def test_special_source_encoding():
 
 
 def _get_code():
-    from .test_func_inspect_special_encoding import big5_f
+    from joblib.test.test_func_inspect_special_encoding import big5_f
     return get_func_code(big5_f)[0]
 
 
 def test_func_code_consistency():
-    from ..parallel import Parallel, delayed
+    from joblib.parallel import Parallel, delayed
     codes = Parallel(n_jobs=2)(delayed(_get_code)() for _ in range(5))
     nose.tools.assert_equal(len(set(codes)), 1)
 

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -16,14 +16,14 @@ import gc
 import io
 import collections
 
-from ..hashing import hash
-from ..func_inspect import filter_args
-from ..memory import Memory
-from .common import np, with_numpy
+from joblib.hashing import hash
+from joblib.func_inspect import filter_args
+from joblib.memory import Memory
+from joblib.test.common import np, with_numpy
 
-from .test_memory import env as test_memory_env
-from .test_memory import setup_module as test_memory_setup_func
-from .test_memory import teardown_module as test_memory_teardown_func
+from joblib.test.test_memory import env as test_memory_env
+from joblib.test.test_memory import setup_module as test_memory_setup_func
+from joblib.test.test_memory import teardown_module as test_memory_teardown_func
 
 try:
     # Python 2/Python 3 compat

--- a/joblib/test/test_logger.py
+++ b/joblib/test/test_logger.py
@@ -13,7 +13,7 @@ import io
 from tempfile import mkdtemp
 import re
 
-from ..logger import PrintTime
+from joblib.logger import PrintTime
 
 try:
     # Python 2/Python 3 compat

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -18,9 +18,9 @@ import time
 
 import nose
 
-from ..memory import Memory, MemorizedFunc, NotMemorizedFunc, MemorizedResult
-from ..memory import NotMemorizedResult, _FUNCTION_HASHES
-from .common import with_numpy, np
+from joblib.memory import Memory, MemorizedFunc, NotMemorizedFunc, MemorizedResult
+from joblib.memory import NotMemorizedResult, _FUNCTION_HASHES
+from joblib.test.common import with_numpy, np
 
 
 ###############################################################################

--- a/joblib/test/test_my_exceptions.py
+++ b/joblib/test/test_my_exceptions.py
@@ -3,7 +3,7 @@ Test my automatically generate exceptions
 """
 from nose.tools import assert_true
 
-from .. import my_exceptions
+from joblib import my_exceptions
 
 
 def test_inheritance():

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -14,12 +14,12 @@ import tempfile
 
 import nose
 
-from .common import np, with_numpy
+from joblib.test.common import np, with_numpy
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.
-from .. import numpy_pickle
-from . import data
+from joblib import numpy_pickle
+from joblib.test import data
 
 ###############################################################################
 # Define a list of standard types.

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -34,9 +34,9 @@ except ImportError:
     from Queue import Queue
 
 
-from ..parallel import Parallel, delayed, SafeFunction, WorkerInterrupt, \
+from joblib.parallel import Parallel, delayed, SafeFunction, WorkerInterrupt, \
         mp, cpu_count, VALID_BACKENDS
-from ..my_exceptions import JoblibException
+from joblib.my_exceptions import JoblibException
 
 import nose
 

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -8,16 +8,16 @@ from nose.tools import assert_equal
 from nose.tools import assert_raises
 from nose.tools import assert_false
 from nose.tools import assert_true
-from .common import with_numpy, np
-from .common import setup_autokill
-from .common import teardown_autokill
+from joblib.test.common import with_numpy, np
+from joblib.test.common import setup_autokill
+from joblib.test.common import teardown_autokill
 
-from .._multiprocessing_helpers import mp
+from joblib._multiprocessing_helpers import mp
 if mp is not None:
-    from ..pool import MemmapingPool
-    from ..pool import has_shareable_memory
-    from ..pool import ArrayMemmapReducer
-    from ..pool import reduce_memmap
+    from joblib.pool import MemmapingPool
+    from joblib.pool import has_shareable_memory
+    from joblib.pool import ArrayMemmapReducer
+    from joblib.pool import reduce_memmap
 
 
 TEMP_FOLDER = None


### PR DESCRIPTION
as advised in the scikit-learn developers guide [here](http://scikit-learn.org/stable/developers/#coding-guidelines). For one this make it a lot easier to check that a test is failing on a released version of joblib but fixed in master.