### PR TITLE
Add Travis build config without numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: python
 
-python:
-    - "2.6"
-    - "2.7"
-    - "3.3"
-    - "3.4"
+matrix:
+  include:
+    - python: "2.6"
+    - python: "2.7"
+    - python: "3.3"
+    - python: "3.4"
+    - python: "3.4"
+      env: WITHOUT_NUMPY="true"
 
 before_install:
     - pip --quiet install --use-mirrors numpy
 
 install:
-    - python setup.py install
+    - source continuous_integration/install.sh
 
 script:
     - make

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# This script is meant to be called by the "install" step defined in
+# .travis.yml. See http://docs.travis-ci.com/ for more details.
+# The behavior of the script is controlled by environment variabled defined
+# in the .travis.yml in the top level folder of the project.
+#
+# This script is adapted from a similar script from the scikit-learn repository.
+#
+# License: 3-clause BSD
+
+set -e
+
+create_new_venv() {
+    # At the time of writing numpy 1.9.1 is included in the travis
+    # virtualenv but we want to make sure that joblib has only a soft
+    # dependence on numpy. For this we create a new virtualenv from
+    # scratch
+    deactivate
+    virtualenv --system-site-packages testvenv
+    source testvenv/bin/activate
+    pip install nose
+}
+
+if [[ "$WITHOUT_NUMPY" == "true" ]]; then
+    create_new_venv
+    # We want to disable doctests because they need numpy to run. I
+    # could not find a way to override the with-doctest value in
+    # setup.cfg so doing it the hacky way ...
+    cat setup.cfg | grep -v 'with-doctest=' > setup.cfg.new
+    mv setup.cfg{.new,}
+fi
+
+python setup.py install

--- a/joblib/test/data/create_numpy_pickle.py
+++ b/joblib/test/data/create_numpy_pickle.py
@@ -4,7 +4,12 @@ This script is used to generate test data for joblib/test/test_numpy_pickle.py
 
 import sys
 
-import numpy as np
+# nosetests needs to be able to import this module even when numpy is
+# not installed
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 import joblib
 
@@ -31,16 +36,15 @@ def write_test_pickle(to_pickle):
     joblib.dump(to_pickle, pickle_filename, compress=True)
 
 
-to_pickle = [np.arange(5, dtype=np.int64),
-             np.arange(5, dtype=np.float64),
-             # all possible bytes as a byte string
-             # .tostring actually returns bytes and is a
-             # compatibility alias for .tobytes which was
-             # added in 1.9.0
-             np.arange(256, dtype=np.uint8).tostring(),
-             # unicode string with non-ascii chars
-             u"C'est l'\xe9t\xe9 !"]
-
-
 if __name__ == '__main__':
+    to_pickle = [np.arange(5, dtype=np.int64),
+                 np.arange(5, dtype=np.float64),
+                 # all possible bytes as a byte string
+                 # .tostring actually returns bytes and is a
+                 # compatibility alias for .tobytes which was
+                 # added in 1.9.0
+                 np.arange(256, dtype=np.uint8).tostring(),
+                 # unicode string with non-ascii chars
+                 u"C'est l'\xe9t\xe9 !"]
+
     write_test_pickle(to_pickle)


### PR DESCRIPTION
to test that joblib has only a soft dependence on numpy. Note many doctests assume numpy is installed so doctests are disabled when WITHOUT_NUMPY="true".

I could not find a way to override the with-doctest value in setup.cfg (there doesn't seem to be a config flag saying --with-doctest=0 or a value of NOSE_WITH_DOCTEST which disables doctests) so I did it the hacky way:

```bash
cat setup.cfg | grep -v 'with-doctest=' > setup.cfg
```