### PR TITLE
[WIP] Fix inconsistent hashes between Parallel and direct computation

### DIFF
--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -156,7 +156,7 @@ def reduce_memmap(a):
         # This memmap instance is actually backed by a regular in-memory
         # buffer: this can happen when using binary operators on numpy.memmap
         # instances
-        return (loads, (dumps(np.asarray(a), protocol=HIGHEST_PROTOCOL),))
+        return np.asarray(a).__reduce__()
 
 
 class ArrayMemmapReducer(object):
@@ -256,7 +256,7 @@ class ArrayMemmapReducer(object):
             if self.verbose > 1:
                 print("Pickling array (shape=%r, dtype=%s)." % (
                     a.shape, a.dtype))
-            return (loads, (dumps(a, protocol=HIGHEST_PROTOCOL),))
+            return a.__reduce__()
 
 
 ###############################################################################

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -261,6 +261,19 @@ def test_hash_object_dtype():
 
 
 @with_numpy
+def test_hash_consistency_between_parrallel_and_direct_computation():
+    # See https://github.com/joblib/joblib/issues/176 for more details
+    args = [np.arange(10), np.arange(20)]
+
+    from joblib import Parallel, delayed, hash
+    parallel_results = Parallel(n_jobs=3)(
+        delayed(hash)(args) for _ in range(10))
+
+    nose.tools.assert_equal(len(set(parallel_results)), 1)
+    nose.tools.assert_equal(parallel_results[0], hash(args))
+
+
+@with_numpy
 def test_numpy_scalar():
     # Numpy scalars are built from compiled functions, and lead to
     # strange pickling paths explored, that can give hash collisions


### PR DESCRIPTION
This fixes #176 and supersedes #208. 

It fixes the problem reported in #176 but is still work in progress at the moment, for example it still doesn't work properly for memapped arrays.

Also there is a more general problem with hashing which is sensible to pickle memoization, which arguably we should try to fix...

```python
from joblib import hash
hash(['aa', 'aa'])
# 'b0851fea41e328d9423b5b5907542fb0'
hash(['aa', 'aaZ'[:-1]])
# '0a6d2c17d2abceb9d1062c88e6bc2622'
```