### PR TITLE
[MRG] mmap_mode for mixed dtype objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ Loïc Estève
     Python 3. Compressed pickles can be written with one and read with
     the other.
 
+Olivier Grisel
+
+    FIX make it possible to call joblib.load(filename, mmap_mode='r')
+    on pickled objects that include arrays with a mix arrays of both
+    memmory memmapable dtypes and object dtype.
+
+
 Release 0.8.4
 -------------
 

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -213,6 +213,25 @@ def test_memmap_persistence():
 
 
 @with_numpy
+def test_memmap_persistence_mixed_dtypes():
+    # loading datastructures that have sub-arrays with dtype=object
+    # should not prevent memmaping on fixed size dtype sub-arrays.
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample(10)
+    b = np.array([1, 'b'], dtype=object)
+    construct = (a, b)
+    filename = env['filename'] + str(random.randint(0, 1000))
+    numpy_pickle.dump(construct, filename)
+    a_clone, b_clone = numpy_pickle.load(filename, mmap_mode='r')
+    if [int(x) for x in np.__version__.split('.', 2)[:2]] >= [1, 3]:
+        # the floating point array has been memory mapped
+        nose.tools.assert_true(isinstance(a_clone, np.memmap))
+
+        # the object-dtype array has been loaded in memory
+        nose.tools.assert_false(isinstance(b_clone, np.memmap))
+
+
+@with_numpy
 def test_masked_array_persistence():
     # The special-case picker fails, because saving masked_array
     # not implemented, but it just delegates to the standard pickler.


### PR DESCRIPTION
Here is the kind of error message that users get when trying to load an object that has both memmap-able arrays and object-dtyped arrays in ther internal data-structures:

```
======================================================================
ERROR: joblib.test.test_numpy_pickle.test_memmap_persistence_mixed_dtypes
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ogrisel/venvs/py34/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/ogrisel/code/joblib/joblib/test/test_numpy_pickle.py", line 225, in test_memmap_persistence_mixed_dtypes
    a_clone, b_clone = numpy_pickle.load(filename, mmap_mode='r')
  File "/Users/ogrisel/code/joblib/joblib/numpy_pickle.py", line 520, in load
    obj = unpickler.load()
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/pickle.py", line 1038, in load
    dispatch[key[0]](self)
  File "/Users/ogrisel/code/joblib/joblib/numpy_pickle.py", line 386, in load_build
    array = nd_array_wrapper.read(self)
  File "/Users/ogrisel/code/joblib/joblib/numpy_pickle.py", line 136, in read
    mmap_mode=unpickler.mmap_mode)
  File "/Users/ogrisel/venvs/py34/lib/python3.4/site-packages/numpy/lib/npyio.py", line 391, in load
    return format.open_memmap(file, mode=mmap_mode)
  File "/Users/ogrisel/venvs/py34/lib/python3.4/site-packages/numpy/lib/format.py", line 725, in open_memmap
    raise ValueError(msg)
ValueError: Array can't be memory-mapped: Python objects in dtype.
```

This fix in `NDArrayWrapper` makes `joblib.load` avoid tying memmory-mapping inner arrays with `dtype=object`.