### PR TITLE
[MRG] Remove code specific to numpy < 1.3

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -136,11 +136,9 @@ class NDArrayWrapper(object):
         # use getattr instead of self.allow_mmap to ensure backward compat
         # with NDArrayWrapper instances pickled with joblib < 0.9.0
         allow_mmap = getattr(self, 'allow_mmap', True)
-        if np_ver >= [1, 3] and allow_mmap:
-            array = unpickler.np.load(filename, mmap_mode=unpickler.mmap_mode)
-        else:
-            # Numpy does not have mmap_mode before 1.3
-            array = unpickler.np.load(filename)
+        memmap_kwargs = ({} if not allow_mmap
+                         else {'mmap_mode': unpickler.mmap_mode})
+        array = unpickler.np.load(filename, **memmap_kwargs)
         # Reconstruct subclasses. This does not work with old
         # versions of numpy
         if (hasattr(array, '__array_prepare__')

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -208,8 +208,8 @@ def test_memmap_persistence():
     filename = env['filename'] + str(random.randint(0, 1000))
     numpy_pickle.dump(a, filename)
     b = numpy_pickle.load(filename, mmap_mode='r')
-    if [int(x) for x in np.__version__.split('.', 2)[:2]] >= [1, 3]:
-        nose.tools.assert_true(isinstance(b, np.memmap))
+
+    nose.tools.assert_true(isinstance(b, np.memmap))
 
 
 @with_numpy
@@ -223,12 +223,12 @@ def test_memmap_persistence_mixed_dtypes():
     filename = env['filename'] + str(random.randint(0, 1000))
     numpy_pickle.dump(construct, filename)
     a_clone, b_clone = numpy_pickle.load(filename, mmap_mode='r')
-    if [int(x) for x in np.__version__.split('.', 2)[:2]] >= [1, 3]:
-        # the floating point array has been memory mapped
-        nose.tools.assert_true(isinstance(a_clone, np.memmap))
 
-        # the object-dtype array has been loaded in memory
-        nose.tools.assert_false(isinstance(b_clone, np.memmap))
+    # the floating point array has been memory mapped
+    nose.tools.assert_true(isinstance(a_clone, np.memmap))
+
+    # the object-dtype array has been loaded in memory
+    nose.tools.assert_false(isinstance(b_clone, np.memmap))
 
 
 @with_numpy


### PR DESCRIPTION
If installed, numpy >= 1.3 is required according to the README.rst.

I double-checked that the `memmap_mode` argument was indeed introduced in numpy 1.3.