### PR TITLE
Switched to "dill" to support wider range of function arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
 
 before_install:
     - pip --quiet install --use-mirrors numpy
-    - pip --quiet install dill
 
 install:
     - source continuous_integration/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
 
 before_install:
     - pip --quiet install --use-mirrors numpy
+    - pip --quiet install dill
 
 install:
     - source continuous_integration/install.sh

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -18,6 +18,7 @@ create_new_venv() {
     deactivate
     virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
+    pip install dill
     pip install nose
 }
 

--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -8,7 +8,7 @@ hashing of numpy arrays.
 # License: BSD Style, 3 clauses.
 
 import warnings
-import pickle
+import dill
 import hashlib
 import sys
 import types
@@ -16,11 +16,11 @@ import struct
 
 import io
 
-if sys.version_info[0] < 3:
-    Pickler = pickle.Pickler
-else:
-    Pickler = pickle._Pickler
-
+# if sys.version_info[0] < 3:
+#     Pickler = dill.Pickler
+# else:
+#     Pickler = dill._Pickler
+Pickler = dill.Pickler
 
 class _ConsistentSet(object):
     """ Class used to ensure the hash of Sets is preserved
@@ -51,7 +51,7 @@ class Hasher(Pickler):
     def hash(self, obj, return_digest=True):
         try:
             self.dump(obj)
-        except pickle.PicklingError as e:
+        except dill.PicklingError as e:
             warnings.warn('PicklingError while hashing %r: %r' % (obj, e))
         dumps = self.stream.getvalue()
         self._hash.update(dumps)
@@ -67,7 +67,7 @@ class Hasher(Pickler):
             else:
                 func_name = obj.__name__
             inst = obj.__self__
-            if type(inst) == type(pickle):
+            if type(inst) == type(dill):
                 obj = _MyHash(func_name, inst.__name__)
             elif inst is None:
                 # type(None) or type(module) do not pickle
@@ -88,7 +88,7 @@ class Hasher(Pickler):
             del kwargs['pack']
         try:
             Pickler.save_global(self, obj, **kwargs)
-        except pickle.PicklingError:
+        except dill.PicklingError:
             Pickler.save_global(self, obj, **kwargs)
             module = getattr(obj, "__module__", None)
             if module == '__main__':
@@ -109,7 +109,7 @@ class Hasher(Pickler):
     # classobj
     dispatch[type(Pickler)] = save_global
     # function
-    dispatch[type(pickle.dump)] = save_global
+    dispatch[type(dill.dump)] = save_global
 
     def _batch_setitems(self, items):
         # forces order of keys in dict to ensure consistent hash


### PR DESCRIPTION
I changed hashing.py to use the 'dill' package (https://github.com/uqfoundation/dill) instead of pickle. This allows the use of joblib.memory with a wider range of functions. I made this for a use case I had where the function arguments consisted objects with function handles inside them (among other things). 

'nosetests' succeeded without any problem. 