### PR TITLE
[MRG] FIX make joblib not break BLAS / OpenMP under Python 3.4+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ Release 0.9.0
 
 Olivier Grisel
 
+    Make joblib use the 'forkserver' start method by default under Python 3.4+
+    to avoid causing crash with 3rd party libraries (such as Apple vecLib /
+    Accelerate or the GCC OpenMP runtime) that use an internal thread pool that
+    is not not reinitialized when a ``fork`` system call happens.
+
+Olivier Grisel
+
     New context manager based API (``with`` block) to re-use
     the same pool of workers across consecutive parallel calls.
 

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -107,6 +107,26 @@ the ``Parallel`` object::
 .. include:: parallel_numpy.rst
 
 
+Bad interaction of multiprocessing and third-party libraries
+============================================================
+
+Prior to Python 3.4, the ``'multiprocessing'`` backend of joblib can only use
+the ``fork`` strategy to create worker processes under non-Windows systems.
+This can cause some third-party libraries to crash or freeze. Such libraries
+include as Apple vecLib / Accelerate (used by NumPy under OSX), some old
+version of OpenBLAS (prior to 0.2.10) or the OpenMP runtime implementation from
+GCC.
+
+To avoid this problem ``joblib.Parallel`` uses the ``'forkserver'`` start
+method by default on Python 3.4 and later. If necessary this behavior can be
+changed by setting the ``JOBLIB_START_METHOD`` environment variable back to the
+unsafe ``'fork'`` method. You can read more on this topic in the
+`multiprocessing documentation
+<https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
+
+Under Windows the ``fork`` system call does not exist at all so this problem
+does not exist (but multiprocessing has more overhead).
+
 `Parallel` reference documentation
 ==================================
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -49,6 +49,18 @@ MIN_IDEAL_BATCH_DURATION = .2
 # on a single worker while other workers have no work to process any more.
 MAX_IDEAL_BATCH_DURATION = 2
 
+# Under Python 3.4+ use the 'forkserver' start method by default: this makes it
+# possible to avoid crashing 3rd party libraries that manage an internal thread
+# pool that does not tolerate forking
+if hasattr(mp, 'get_start_method'):
+    method = os.environ.get('JOBLIB_START_METHOD')
+    if (method is None and mp.get_start_method() == 'fork'
+            and 'forkserver' in mp.get_all_start_methods()):
+        method = 'forkserver'
+    DEFAULT_MP_CONTEXT = mp.get_context(method=method)
+else:
+    DEFAULT_MP_CONTEXT = None
+
 
 class BatchedCalls(object):
     """Wrap a sequence of (func, args, kwargs) tuples as a single callable"""
@@ -406,10 +418,10 @@ class Parallel(Logger):
          [Parallel(n_jobs=2)]: Done   6 out of   6 | elapsed:    0.0s finished
     '''
     def __init__(self, n_jobs=1, backend='multiprocessing', verbose=0,
-                 pre_dispatch='2 * n_jobs', batch_size='auto', temp_folder=None,
-                 max_nbytes='1M', mmap_mode='r'):
+                 pre_dispatch='2 * n_jobs', batch_size='auto',
+                 temp_folder=None, max_nbytes='1M', mmap_mode='r'):
         self.verbose = verbose
-        self._mp_context = None
+        self._mp_context = DEFAULT_MP_CONTEXT
         if backend is None:
             # `backend=None` was supported in 0.8.2 with this effect
             backend = "multiprocessing"


### PR DESCRIPTION
Let's enable the forkserver start method by default under Python 3.4+