### PR TITLE
[MRG+1] Made hashing module robust to dtype and string shared in memory

### DIFF
--- a/joblib/_compat.py
+++ b/joblib/_compat.py
@@ -4,6 +4,7 @@ Compatibility layer for Python 3/Python 2 single codebase
 
 try:
     _basestring = basestring
+    _bytes_or_unicode = (str, unicode)
 except NameError:
     _basestring = str
-
+    _bytes_or_unicode = (bytes, str)


### PR DESCRIPTION
Shoulf fix bug #231, maybe #213 and nilearn/nilearn#771