### PR TITLE
Switch to conda environments for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: python
 
-matrix:
-  include:
-    - python: "2.6"
-    - python: "2.7"
-    - python: "3.3"
-    - python: "3.4"
-    - python: "3.4"
-      env: WITHOUT_NUMPY="true"
-
-before_install:
-    - pip --quiet install --use-mirrors numpy
+env:
+  matrix:
+    - PYTHON_VERSION="2.6" NUMPY_VERSION="1.9"
+    - PYTHON_VERSION="2.7" NUMPY_VERSION="1.9"
+    - PYTHON_VERSION="3.3" NUMPY_VERSION="1.9"
+    - PYTHON_VERSION="3.4" NUMPY_VERSION="1.9"
+    - PYTHON_VERSION="3.4"
 
 install:
     - source continuous_integration/install.sh

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -10,19 +10,64 @@
 
 set -e
 
-create_new_venv() {
-    # At the time of writing numpy 1.9.1 is included in the travis
-    # virtualenv but we want to make sure that joblib has only a soft
-    # dependence on numpy. For this we create a new virtualenv from
-    # scratch
-    deactivate
-    virtualenv --system-site-packages testvenv
-    source testvenv/bin/activate
-    pip install nose
+print_conda_requirements() {
+    # Echo a conda requirement string for example
+    # "pip nose python='.7.3 scikit-learn=*". It has a hardcoded
+    # list of possible packages to install and looks at _VERSION
+    # environment variables to know whether to install a given package and
+    # if yes which version to install. For example:
+    #   - for numpy, NUMPY_VERSION is used
+    #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
+    TO_INSTALL_ALWAYS="pip nose"
+    REQUIREMENTS="$TO_INSTALL_ALWAYS"
+    TO_INSTALL_MAYBE="python numpy"
+    for PACKAGE in $TO_INSTALL_MAYBE; do
+        # Capitalize package name and add _VERSION
+        PACKAGE_VERSION_VARNAME="${PACKAGE^^}_VERSION"
+        # replace - by _, needed for scikit-learn for example
+        PACKAGE_VERSION_VARNAME="${PACKAGE_VERSION_VARNAME//-/_}"
+        # dereference $PACKAGE_VERSION_VARNAME to figure out the
+        # version to install
+        PACKAGE_VERSION="${!PACKAGE_VERSION_VARNAME}"
+        if [ -n "$PACKAGE_VERSION" ]; then
+            REQUIREMENTS="$REQUIREMENTS $PACKAGE=$PACKAGE_VERSION"
+        fi
+    done
+    echo $REQUIREMENTS
 }
 
-if [[ "$WITHOUT_NUMPY" == "true" ]]; then
-    create_new_venv
+create_new_conda_env() {
+    # Deactivate the travis-provided virtual environment and setup a
+    # conda-based environment instead
+    deactivate
+
+    # Use the miniconda installer for faster download / install of conda
+    # itself
+    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
+         -O miniconda.sh
+    chmod +x miniconda.sh && ./miniconda.sh -b
+    export PATH=/home/travis/miniconda/bin:$PATH
+    conda update --yes conda
+
+    # Configure the conda environment and put it in the path using the
+    # provided versions
+    REQUIREMENTS=$(print_conda_requirements)
+    echo "conda requirements string: $REQUIREMENTS"
+    conda create -n testenv --yes $REQUIREMENTS
+    source activate testenv
+
+    if [[ "$INSTALL_MKL" == "true" ]]; then
+        # Make sure that MKL is used
+        conda install --yes mkl
+    else
+        # Make sure that MKL is not used
+        conda remove --yes --features mkl || echo "MKL not installed"
+    fi
+}
+
+create_new_conda_env
+
+if [ -z "$NUMPY_VERSION" ]; then
     # We want to disable doctests because they need numpy to run. I
     # could not find a way to override the with-doctest value in
     # setup.cfg so doing it the hacky way ...


### PR DESCRIPTION
In the future this will enable us to test all supported numpy versions
rather than only 1.9 which is the one that the default Travis
environment contains.

Note: this is taken mostly from the nilearn Travis continuous_integration/install.sh.