### PR TITLE
[MRG] Add python3.5 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - PYTHON_VERSION="3.3" NUMPY_VERSION="1.9"
     - PYTHON_VERSION="3.4" NUMPY_VERSION="1.9"
     - PYTHON_VERSION="3.4"
+    - PYTHON_VERSION="3.5" NUMPY_VERSION="1.9"
 
 install:
     - source continuous_integration/install.sh

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -225,6 +225,7 @@ def test_memory_name_collision():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
+        warnings.simplefilter("ignore", DeprecationWarning)
         a(1)
         b(1)
 
@@ -245,6 +246,7 @@ def test_memory_warning_lambda_collisions():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
+        warnings.simplefilter("ignore", DeprecationWarning)
         nose.tools.assert_equal(0, a(0))
         nose.tools.assert_equal(2, b(1))
         nose.tools.assert_equal(1, a(1))
@@ -272,6 +274,7 @@ def test_memory_warning_collision_detection():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
+        warnings.simplefilter("ignore", DeprecationWarning)
         a1(1)
         b1(1)
         a1(0)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -225,6 +225,9 @@ def test_memory_name_collision():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
+        # This is a temporary workaround until we get rid of
+        # inspect.getargspec, see
+        # https://github.com/joblib/joblib/issues/247
         warnings.simplefilter("ignore", DeprecationWarning)
         a(1)
         b(1)
@@ -246,6 +249,9 @@ def test_memory_warning_lambda_collisions():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
+        # This is a temporary workaround until we get rid of
+        # inspect.getargspec, see
+        # https://github.com/joblib/joblib/issues/247
         warnings.simplefilter("ignore", DeprecationWarning)
         nose.tools.assert_equal(0, a(0))
         nose.tools.assert_equal(2, b(1))
@@ -274,6 +280,9 @@ def test_memory_warning_collision_detection():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
+        # This is a temporary workaround until we get rid of
+        # inspect.getargspec, see
+        # https://github.com/joblib/joblib/issues/247
         warnings.simplefilter("ignore", DeprecationWarning)
         a1(1)
         b1(1)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -201,7 +201,14 @@ def test_parallel_pickling():
     def g(x):
         return x ** 2
 
-    assert_raises(PickleError, Parallel(), (delayed(g)(x) for x in range(10)))
+    try:
+        # pickling a local function always fail
+        pickle.dumps(g)
+    except Exception as exc:
+        exception_class = exc.__class__
+
+    assert_raises(exception_class, Parallel(),
+                  (delayed(g)(x) for x in range(10)))
 
 
 def test_error_capture():

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -202,7 +202,9 @@ def test_parallel_pickling():
         return x ** 2
 
     try:
-        # pickling a local function always fail
+        # pickling a local function always fail but the exception
+        # raised is a PickleError for python <= 3.4 and AttributeError
+        # for python >= 3.5
         pickle.dumps(g)
     except Exception as exc:
         exception_class = exc.__class__


### PR DESCRIPTION
Fix #244 and add python 3.5 to Travis. 

The fixes were done in the simplest way possible.

In particular, the deprecation warnings coming from inspect.getargspec will be fixed in a separate PR.