### PR TITLE
Prevent tokenizing .pyc files in format_records

### DIFF
--- a/joblib/format_stack.py
+++ b/joblib/format_stack.py
@@ -195,7 +195,12 @@ def format_records(records):   # , print_globals=False):
             # the abspath call will throw an OSError.  Just ignore it and
             # keep the original file string.
             pass
+
+        if file.endswith('.pyc'):
+            file = file[:-4] + '.py'
+
         link = file
+
         try:
             args, varargs, varkw, locals = inspect.getargvalues(frame)
         except:

--- a/joblib/test/test_format_stack.py
+++ b/joblib/test/test_format_stack.py
@@ -7,8 +7,9 @@ Unit tests for the stack formatting utilities
 # License: BSD Style, 3 clauses.
 
 import nose
+import sys
 
-from joblib.format_stack import safe_repr
+from joblib.format_stack import safe_repr, _fixed_getframes, format_records
 
 
 ###############################################################################
@@ -20,3 +21,23 @@ class Vicious(object):
 
 def test_safe_repr():
     safe_repr(Vicious())
+
+def test_format_records():
+    try:
+        raise ValueError
+    except ValueError:
+        etb = sys.exc_info()[2]
+        records = _fixed_getframes(etb)
+
+        # Modify filenames in traceback records from .py to .pyc
+        pyc_records = []
+        for record in records:
+            if record[1].endswith('.py'):
+                record = list(record)
+                record[1] += 'c'
+                record = tuple(record)
+                pyc_records.append(record)
+
+        # Check that no .pyc files are listed in traceback
+        for fmt_rec in format_records(pyc_records):
+            assert '.pyc in' not in fmt_rec


### PR DESCRIPTION
This update should address issue https://github.com/joblib/joblib/issues/258.