### PR TITLE
Fix TypeError when TransportableException is raised.

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -747,7 +747,7 @@ Sub-process traceback:
 %s""" % (this_report, exception.message)
                     # Convert this to a JoblibException
                     exception_type = _mk_exception(exception.etype)[0]
-                    exception = exception_type(report)
+                    exception = exception_type(report, exception.etype)
 
                 # Kill remaining running processes without waiting for
                 # the results as we will raise the exception we got back


### PR DESCRIPTION
If the exception is a TransportableException, it needs two arguments
to its constructor (message and type). Otherwise, you get an error like:

    Traceback (most recent call last):
      <...snip...>
      File "/usr/local/lib/python2.7/dist-packages/joblib/parallel.py", line 813, in __call__
        self.retrieve()
      File "/usr/local/lib/python2.7/dist-packages/joblib/parallel.py", line 750, in retrieve
        exception = exception_type(report)
    TypeError: __init__() takes at least 3 arguments (2 given)