### PR TITLE
[MRG] Make joblib.Parallel more robust to custom exceptions

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -137,10 +137,7 @@ class SafeFunction(object):
             e_type, e_value, e_tb = sys.exc_info()
             text = format_exc(e_type, e_value, e_tb, context=10,
                               tb_offset=1)
-            if issubclass(e_type, TransportableException):
-                raise
-            else:
-                raise TransportableException(text, e_type)
+            raise TransportableException(text, e_type)
 
 
 ###############################################################################

--- a/joblib/test/test_my_exceptions.py
+++ b/joblib/test/test_my_exceptions.py
@@ -6,17 +6,54 @@ from nose.tools import assert_true
 from joblib import my_exceptions
 
 
+class CustomException(Exception):
+    def __init__(self, a, b, c, d):
+        self.a, self.b, self.c, self.d = a, b, c, d
+
+
+class CustomException2(Exception):
+    """A custom exception with a .args attribute
+
+    Just to check that the JoblibException created from it
+    has it args set correctly
+    """
+    def __init__(self, a, *args):
+        self.a = a
+        self.args = args
+
+
 def test_inheritance():
     assert_true(isinstance(my_exceptions.JoblibNameError(), NameError))
     assert_true(isinstance(my_exceptions.JoblibNameError(),
-                            my_exceptions.JoblibException))
+                           my_exceptions.JoblibException))
     assert_true(my_exceptions.JoblibNameError is
                 my_exceptions._mk_exception(NameError)[0])
+
+
+def test_inheritance_special_cases():
+    # _mk_exception should transform Exception to JoblibException
+    assert_true(my_exceptions._mk_exception(Exception)[0] is
+                my_exceptions.JoblibException)
+
+    # Subclasses of JoblibException should be mapped to
+    # JoblibException by _mk_exception
+    for exception in [my_exceptions.JoblibException,
+                      my_exceptions.TransportableException]:
+        assert_true(my_exceptions._mk_exception(exception)[0] is
+                    my_exceptions.JoblibException)
 
 
 def test__mk_exception():
     # Check that _mk_exception works on a bunch of different exceptions
     for klass in (Exception, TypeError, SyntaxError, ValueError,
-                  AssertionError):
-        e = my_exceptions._mk_exception(klass)[0]('Some argument')
-        assert_true('Some argument' in repr(e))
+                  AssertionError, CustomException, CustomException2):
+        message = 'This message should be in the exception repr'
+        exc = my_exceptions._mk_exception(klass)[0](
+            message,
+            'some', 'other', 'args', 'that are not', 'in the repr')
+        exc_repr = repr(exc)
+
+        assert_true(isinstance(exc, klass))
+        assert_true(isinstance(exc, my_exceptions.JoblibException))
+        assert_true(exc.__class__.__name__ in exc_repr)
+        assert_true(message in exc_repr)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -59,9 +59,17 @@ def square(x):
     return x ** 2
 
 
-def exception_raiser(x):
+class MyExceptionWithFinickyInit(Exception):
+    """An exception class with non trivial __init__
+    """
+    def __init__(self, a, b, c, d):
+        pass
+
+
+def exception_raiser(x, custom_exception=False):
     if x == 7:
-        raise ValueError
+        raise (MyExceptionWithFinickyInit('a', 'b', 'c', 'd')
+               if custom_exception else ValueError)
     return x
 
 
@@ -258,6 +266,13 @@ def test_error_capture():
     # exception to make it easy to catch them
     assert_raises(ZeroDivisionError, Parallel(n_jobs=2),
                   [delayed(division)(x, y) for x, y in zip((0, 1), (1, 0))])
+
+    assert_raises(
+        MyExceptionWithFinickyInit,
+        Parallel(n_jobs=2, verbose=0),
+        (delayed(exception_raiser)(i, custom_exception=True)
+         for i in range(30)))
+
     try:
         # JoblibException wrapping is disabled in sequential mode:
         ex = JoblibException()


### PR DESCRIPTION
Supersedes #261.


Raising custom exceptions in worker processes with a non trivial `__init__` (it need to take positional arguments)

```python
from joblib.parallel import Parallel, delayed


class MyExceptionWithFinickyInit(Exception):
    """An exception class with non trivial __init__
    """
    def __init__(self, a, b, c, d):
        self.a, self.b, self.c, self.d = a, b, c, d


def exception_raiser(x):
    if x == 7:
        raise MyExceptionWithFinickyInit('a', 'b', 'c', 'd')
        # raise JoblibException('No way', 'in hell')
    return x


def test_capture_exception():
    print('result: ', Parallel(n_jobs=2)(
        delayed(exception_raiser)(i) for i in range(10)))


if __name__ == '__main__':
    test_capture_exception()
```

Output:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/home/le243287/dev/joblib/tmp/test_parallel.py in <module>()
     22 
     23 if __name__ == '__main__':
---> 24     test_capture_exception()

/home/le243287/dev/joblib/tmp/test_parallel.py in test_capture_exception()
     18 def test_capture_exception():
     19     print('result: ', Parallel(n_jobs=2)(
---> 20         delayed(exception_raiser)(i) for i in range(10)))
     21 
     22 

/home/le243287/dev/joblib/joblib/parallel.pyc in __call__(self, iterable)
    810                 # consumption.
    811                 self._iterating = False
--> 812             self.retrieve()
    813             # Make sure that we get a last message telling us we are done
    814             elapsed_time = time.time() - self._start_time

/home/le243287/dev/joblib/joblib/parallel.pyc in retrieve(self)
    747                     # Convert this to a JoblibException
    748                     exception_type = _mk_exception(exception.etype)[0]
--> 749                     exception = exception_type(report)
    750 
    751                 # Kill remaining running processes without waiting for

TypeError: __init__() takes exactly 5 arguments (2 given)
```