### PR TITLE
[MRG+1] Add test for Parallel with interactively defined function

### DIFF
--- a/joblib/test/test_testing.py
+++ b/joblib/test/test_testing.py
@@ -16,7 +16,8 @@ def test_check_subprocess_call():
 
     # Now checking stdout with a regex
     check_subprocess_call([sys.executable, '-c', code],
-                          stdout_regex=r'7\n\[1, 2, 3\]')
+                          # Regex needed for platform-specific line endings
+                          stdout_regex=r'7\s{1,2}\[1, 2, 3\]')
 
 
 def test_check_subprocess_call_non_matching_regex():

--- a/joblib/test/test_testing.py
+++ b/joblib/test/test_testing.py
@@ -1,0 +1,49 @@
+import sys
+import re
+
+from joblib.testing import assert_raises_regex, check_subprocess_call
+
+
+def test_check_subprocess_call():
+    code = '\n'.join(['result = 1 + 2 * 3',
+                      'print(result)',
+                      'my_list = [1, 2, 3]',
+                      'print(my_list)'])
+
+    check_subprocess_call([sys.executable, '-c', code])
+
+    # Now checking stdout with a regex
+    check_subprocess_call([sys.executable, '-c', code],
+                          stdout_regex=r'7\n\[1, 2, 3\]')
+
+
+def test_check_subprocess_call_non_matching_regex():
+    code = '42'
+    non_matching_pattern = '_no_way_this_matches_anything_'
+    assert_raises_regex(ValueError,
+                        'Unexpected output.+{0}'.format(non_matching_pattern),
+                        check_subprocess_call,
+                        [sys.executable, '-c', code],
+                        stdout_regex=non_matching_pattern)
+
+
+def test_check_subprocess_call_wrong_command():
+    wrong_command = '_a_command_that_does_not_exist_'
+    assert_raises_regex(OSError,
+                        '',
+                        check_subprocess_call,
+                        [wrong_command])
+
+    code_with_non_zero_exit = '\n'.join([
+        'import sys',
+        'print("writing on stdout")',
+        'sys.stderr.write("writing on stderr")',
+        'sys.exit(123)'])
+
+    pattern = re.compile('Non-zero return code: 123.+'
+                         'Stdout:\nwriting on stdout.+'
+                         'Stderr:\nwriting on stderr', re.DOTALL)
+    assert_raises_regex(ValueError,
+                        pattern,
+                        check_subprocess_call,
+                        [sys.executable, '-c', code_with_non_zero_exit])

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -6,6 +6,11 @@ import sys
 import warnings
 import os.path
 import re
+import subprocess
+import threading
+
+PY3 = sys.version_info[0] >= 3
+
 
 def warnings_to_stdout():
     """ Redirect all warnings to stdout.
@@ -44,3 +49,37 @@ except ImportError:
             if not_raised:
                 raise AssertionError("Should have raised %r" %
                                      expected_exception(expected_regexp))
+
+
+def check_subprocess_call(cmd, timeout=1, stdout_regex=None):
+    """Runs a command in a subprocess with timeout in seconds.
+
+    Also checks returncode is zero and stdout if stdout_regex is set.
+    """
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+
+    def kill_process():
+        proc.kill()
+
+    timer = threading.Timer(timeout, kill_process)
+    try:
+        timer.start()
+        stdout, stderr = proc.communicate()
+
+        if PY3:
+            stdout, stderr = stdout.decode(), stderr.decode()
+        if proc.returncode != 0:
+            message = (
+                'Non-zero return code: {0}.\nStdout:\n{1}\n'
+                'Stderr:\n{2}').format(
+                    proc.returncode, stdout, stderr)
+            raise ValueError(message)
+
+        if (stdout_regex is not None and
+                not re.search(stdout_regex, stdout)):
+            raise ValueError(
+                "Unexpected output: '{0}' does not match:\n{1}".format(
+                    stdout_regex, stdout))
+    finally:
+        timer.cancel()

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -79,7 +79,7 @@ def check_subprocess_call(cmd, timeout=1, stdout_regex=None):
         if (stdout_regex is not None and
                 not re.search(stdout_regex, stdout)):
             raise ValueError(
-                "Unexpected output: '{0}' does not match:\n{1}".format(
+                "Unexpected output: '{0!r}' does not match:\n{1!r}".format(
                     stdout_regex, stdout))
     finally:
         timer.cancel()


### PR DESCRIPTION
This functionality was broken when we changed the default process start method for 3.4+ to be forksever as mentioned in https://github.com/joblib/joblib/issues/263.

Now at least there is a test for it.