### PR TITLE
[MRG+1] Avoid use of sys.version for version checks

### DIFF
--- a/joblib/format_stack.py
+++ b/joblib/format_stack.py
@@ -34,7 +34,7 @@ try:                           # Python 2
 except AttributeError:         # Python 3
     generate_tokens = tokenize.tokenize
 
-PY3 = (sys.version[0] == '3')
+PY3 = (sys.version_info[0] == 3)
 INDENT = ' ' * 8
 
 from ._compat import _basestring


### PR DESCRIPTION
The string `sys.version` should not be used for version checks (as it may or may not contain the version number at the beginning) so this change updates it to be done using `sys.version_info`. See also the note in the documentation: https://docs.python.org/3/library/sys.html#sys.version.