### PR TITLE
[MRG] Fix auto memmap gc failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Latest changes
 Release 0.9.4
 -------------
 
+Olivier Grisel
+
+    FIX a bug that caused joblib.Parallel to wrongly reuse previously
+    memmapped arrays instead of creating new temporary files.
+    https://github.com/joblib/joblib/pull/294 for more details.
+
 Loïc Estève
 
     FIX for raising non inheritable exceptions in a Parallel call. See

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -530,7 +530,6 @@ class Parallel(Logger):
                     mmap_mode=self._mmap_mode,
                     temp_folder=self._temp_folder,
                     verbose=max(0, self.verbose - 50),
-                    context_id=0,  # the pool is used only for one call
                 )
                 if self._mp_context is not None:
                     # Use Python 3.4+ multiprocessing context isolation

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -22,6 +22,13 @@ import threading
 import atexit
 import tempfile
 import shutil
+import warnings
+from time import sleep
+
+try:
+    WindowsError
+except NameError:
+    WindowsError = None
 
 try:
     # Python 2 compat
@@ -177,13 +184,6 @@ class ArrayMemmapReducer(object):
         If verbose > 0, memmap creations are logged.
         If verbose > 1, both memmap creations, reuse and array pickling are
         logged.
-    context_id: int, optional, None by default
-        Set to a value identifying a call context to spare costly hashing of
-        the content of the input arrays when it is safe to assume that each
-        array will not be mutated by the parent process for the duration of the
-        dispatch process. This is the case when using the high level Parallel
-        API. It might not be the case when using the MemmapingPool API
-        directly.
     prewarm: bool, optional, False by default.
         Force a read on newly memmaped array to make sure that OS pre-cache it
         memory. This can be useful to avoid concurrent disk access when the
@@ -196,8 +196,11 @@ class ArrayMemmapReducer(object):
         self._temp_folder = temp_folder
         self._mmap_mode = mmap_mode
         self.verbose = int(verbose)
-        self._context_id = context_id
         self._prewarm = prewarm
+        if context_id is not None:
+            warnings.warn('context_id is deprecated and ignored in joblib'
+                          ' 0.9.4 and will be removed in 0.11',
+                          DeprecationWarning)
 
     def __call__(self, a):
         m = _get_backing_memmap(a)
@@ -219,12 +222,8 @@ class ArrayMemmapReducer(object):
 
             # Find a unique, concurrent safe filename for writing the
             # content of this array only once.
-            if self._context_id is not None:
-                marker = self._context_id
-            else:
-                marker = hash(a)
-            basename = "%d-%d-%d-%s.pkl" % (
-                os.getpid(), id(threading.current_thread()), id(a), marker)
+            basename = "%d-%d-%s.pkl" % (
+                os.getpid(), id(threading.current_thread()), hash(a))
             filename = os.path.join(self._temp_folder, basename)
 
             # In case the same array with the same content is passed several
@@ -430,8 +429,11 @@ class PicklingPool(Pool):
 
 def delete_folder(folder_path):
     """Utility function to cleanup a temporary folder if still existing"""
-    if os.path.exists(folder_path):
-        shutil.rmtree(folder_path)
+    try:
+        if os.path.exists(folder_path):
+            shutil.rmtree(folder_path)
+    except WindowsError:
+        warnings.warn("Failed to clean temporary folder: %s" % folder_path)
 
 
 class MemmapingPool(PicklingPool):
@@ -486,12 +488,6 @@ class MemmapingPool(PicklingPool):
     verbose: int, optional
         Make it possible to monitor how the communication of numpy arrays
         with the subprocess is handled (pickling or memmaping)
-    context_id: int, optional, None by default
-        Set to a value identifying a call context to spare costly hashing of
-        the content of the input arrays when it is safe to assume that each
-        array will not be mutated by the parent process for the duration of the
-        dispatch process. This is the case when using the high level Parallel
-        API.
     prewarm: bool or str, optional, "auto" by default.
         If True, force a read on newly memmaped array to make sure that OS pre-
         cache it in memory. This can be useful to avoid concurrent disk access
@@ -516,6 +512,10 @@ class MemmapingPool(PicklingPool):
             forward_reducers = dict()
         if backward_reducers is None:
             backward_reducers = dict()
+        if context_id is not None:
+            warnings.warn('context_id is deprecated and ignored in joblib'
+                          ' 0.9.4 and will be removed in 0.11',
+                          DeprecationWarning)
 
         # Prepare a sub-folder name for the serialization of this particular
         # pool instance (do not create in advance to spare FS write access if
@@ -559,7 +559,7 @@ class MemmapingPool(PicklingPool):
                 prewarm = not use_shared_mem
             forward_reduce_ndarray = ArrayMemmapReducer(
                 max_nbytes, pool_folder, mmap_mode, verbose,
-                context_id=context_id, prewarm=prewarm)
+                prewarm=prewarm)
             forward_reducers[np.ndarray] = forward_reduce_ndarray
             forward_reducers[np.memmap] = reduce_memmap
 

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -247,8 +247,8 @@ class ArrayMemmapReducer(object):
                 print("Memmaping (shape=%s, dtype=%s) to old file %s" % (
                     a.shape, a.dtype, filename))
 
-            # Let's use the memmap reducer
-            return reduce_memmap(load(filename, mmap_mode=self._mmap_mode))
+            # The worker process will use joblib.load to memmap the data
+            return (load, (filename, self._mmap_mode))
         else:
             # do not convert a into memmap, let pickler do its usual copy with
             # the default system pickler

--- a/joblib/test/common.py
+++ b/joblib/test/common.py
@@ -8,6 +8,9 @@ import time
 import os
 import sys
 
+from joblib._multiprocessing_helpers import mp
+from nose import SkipTest
+from nose.tools import with_setup
 
 # A decorator to run tests only when numpy is available
 try:
@@ -68,3 +71,19 @@ def teardown_autokill(module_name):
     killer = _KILLER_THREADS.get(module_name)
     if killer is not None:
         killer.cancel()
+
+
+def check_multiprocessing():
+    if mp is None:
+        raise SkipTest('Need multiprocessing to run')
+
+
+with_multiprocessing = with_setup(check_multiprocessing)
+
+
+def setup_if_has_dev_shm():
+    if not os.path.exists('/dev/shm'):
+        raise SkipTest("This test requires the /dev/shm shared memory fs.")
+
+
+with_dev_shm = with_setup(setup_if_has_dev_shm)

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import tempfile
 
-from nose import SkipTest
 from nose.tools import with_setup
 from nose.tools import assert_equal
 from nose.tools import assert_raises
@@ -11,6 +10,8 @@ from nose.tools import assert_true
 from joblib.test.common import with_numpy, np
 from joblib.test.common import setup_autokill
 from joblib.test.common import teardown_autokill
+from joblib.test.common import with_multiprocessing
+from joblib.test.common import with_dev_shm
 
 from joblib._multiprocessing_helpers import mp
 if mp is not None:
@@ -31,14 +32,6 @@ def teardown_module():
     teardown_autokill(__name__)
 
 
-def check_multiprocessing():
-    if mp is None:
-        raise SkipTest('Need multiprocessing to run')
-
-
-with_multiprocessing = with_setup(check_multiprocessing)
-
-
 def setup_temp_folder():
     global TEMP_FOLDER
     TEMP_FOLDER = tempfile.mkdtemp(prefix='joblib_test_pool_')
@@ -52,14 +45,6 @@ def teardown_temp_folder():
 
 
 with_temp_folder = with_setup(setup_temp_folder, teardown_temp_folder)
-
-
-def setup_if_has_dev_shm():
-    if not os.path.exists('/dev/shm'):
-        raise SkipTest("This test requires the /dev/shm shared memory fs.")
-
-
-with_dev_shm = with_setup(setup_if_has_dev_shm)
 
 
 def check_array(args):

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -391,10 +391,13 @@ def test_memmaping_on_dev_shm():
         # pickling procedure generate a .pkl and a .npy file:
         assert_equal(len(os.listdir(pool_temp_folder)), 2)
 
-        b = np.ones(100, dtype=np.float64)
+        # create a new array with content that is different from 'a' so that
+        # it is mapped to a different file in the temporary folder of the
+        # pool.
+        b = np.ones(100, dtype=np.float64) * 2
         assert_equal(b.nbytes, 800)
         p.map(id, [b] * 10)
-        # A copy of both a and b are not stored in the shared memory folder
+        # A copy of both a and b are now stored in the shared memory folder
         assert_equal(len(os.listdir(pool_temp_folder)), 4)
 
     finally:


### PR DESCRIPTION
The automatic memmap feature of joblib can be mislead by the reuse of `id()` values for recently garbage collected numpy arrays as demonstrated in the non-regression test of this PR. This problem is actually quite frequent when generating large numpy arrays with a Python generator.

This PR fixes the issues by systematically hashing the arrays to find a robust unique identifier for the filenames of the temporary memmap'ed arrays.

I ran the benchmark script varying the parameters and could not find a configuration where hashing could cause a very large performance degradation w.r.t. the current master.

This fixes scikit-learn/scikit-learn#6063.