### PR TITLE
[MRG+1] Fix my_exceptions._mk_exception when input exception is not inheritable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Latest changes
 Release 0.9.4
 -------------
 
+Loïc Estève
+
+    FIX for raising non inheritable exceptions in a Parallel call. See
+    https://github.com/joblib/joblib/issues/269 for more details.
+
 Alexandre Abadie
 
     FIX joblib.hash error with mixed types sets and dicts containing mixed

--- a/joblib/my_exceptions.py
+++ b/joblib/my_exceptions.py
@@ -64,14 +64,20 @@ def _mk_exception(exception, name=None):
         this_exception = _exception_mapping[this_name]
     else:
         if exception is Exception:
-            # We cannot create a subclass: we are already a trivial
-            # subclass
+            # JoblibException is already a subclass of Exception. No
+            # need to use multiple inheritance
             return JoblibException, this_name
-        elif issubclass(exception, JoblibException):
-            return JoblibException, JoblibException.__name__
-        this_exception = type(
-            this_name, (JoblibException, exception), {})
-        _exception_mapping[this_name] = this_exception
+        try:
+            this_exception = type(
+                this_name, (JoblibException, exception), {})
+            _exception_mapping[this_name] = this_exception
+        except TypeError:
+            # This happens if "Cannot create a consistent method
+            # resolution order", e.g. because 'exception' is a
+            # subclass of JoblibException or 'exception' is not an
+            # acceptable base class
+            this_exception = JoblibException
+
     return this_exception, this_name
 
 

--- a/joblib/test/test_my_exceptions.py
+++ b/joblib/test/test_my_exceptions.py
@@ -42,6 +42,16 @@ def test_inheritance_special_cases():
         assert_true(my_exceptions._mk_exception(exception)[0] is
                     my_exceptions.JoblibException)
 
+    # Non-inheritable exception classes should be mapped to
+    # JoblibException by _mk_exception. That can happen with classes
+    # generated with SWIG. See
+    # https://github.com/joblib/joblib/issues/269 for a concrete
+    # example.
+    non_inheritable_classes = [type(lambda: None), bool]
+    for exception in non_inheritable_classes:
+        assert_true(my_exceptions._mk_exception(exception)[0] is
+                    my_exceptions.JoblibException)
+
 
 def test__mk_exception():
     # Check that _mk_exception works on a bunch of different exceptions


### PR DESCRIPTION
Fix #269.

Note that if the exception raised in a worker process is not inheritable, the exception raised in the master process will be JobException.