### PR TITLE
[MRG+1] Refactored Parallel backends

### DIFF
--- a/joblib/_compat.py
+++ b/joblib/_compat.py
@@ -11,3 +11,8 @@ try:
 except NameError:
     _basestring = str
     _bytes_or_unicode = (bytes, str)
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    return meta("NewBase", bases, {})

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -1,0 +1,297 @@
+"""
+Backends for embarrassingly parallel code.
+"""
+
+import gc
+import os
+import sys
+import warnings
+import threading
+from abc import ABCMeta, abstractmethod
+
+from .format_stack import format_exc
+from .my_exceptions import WorkerInterrupt, TransportableException
+from ._multiprocessing_helpers import mp
+from ._compat import with_metaclass
+if mp is not None:
+    from .pool import MemmapingPool
+    from multiprocessing.pool import ThreadPool
+
+
+class ParallelBackendBase(with_metaclass(ABCMeta)):
+    """Helper abc which defines all methods a ParallelBackend must implement"""
+
+    def __init__(self, parallel):
+        self.parallel = parallel
+
+    @abstractmethod
+    def effective_n_jobs(self, n_jobs):
+        """Determine the number of jobs which are going to run in parallel"""
+
+    @abstractmethod
+    def apply_async(self, func, callback=None):
+        """Schedule a func to be run"""
+
+    def initialize(self, n_jobs, backend_args):
+        """Build a process or thread pool and return the number of workers"""
+        return self.effective_n_jobs(n_jobs)
+
+    def terminate(self):
+        """Shutdown the process or thread pool"""
+
+    def compute_batch_size(self):
+        """Determine the optimal batch size"""
+        return 1
+
+    def batch_completed(self, batch_size, duration):
+        """Callback indicate how long it took to run a batch"""
+
+    def get_exceptions(self):
+        """List of exception types to be captured."""
+        return []
+
+
+class SequentialBackend(ParallelBackendBase):
+    """A ParallelBackend which will execute all batches sequentially.
+
+    Does not use/create any threading objects, and hence has minimal
+    overhead. Used when n_jobs == 1.
+    """
+
+    def effective_n_jobs(self, n_jobs):
+        """Determine the number of jobs which are going to run in parallel"""
+        if n_jobs == 0:
+            raise ValueError('n_jobs == 0 in Parallel has no meaning')
+        return 1
+
+    def apply_async(self, func, callback=None):
+        """Schedule a func to be run"""
+        result = ImmediateResult(func)
+
+        if callback:
+            callback(result)
+
+        return result
+
+
+class PoolManagerMixin(object):
+    """A helper class for managing pool of workers."""
+
+    def effective_n_jobs(self, n_jobs):
+        """Determine the number of jobs which are going to run in parallel"""
+        if n_jobs == 0:
+            raise ValueError('n_jobs == 0 in Parallel has no meaning')
+        elif mp is None or n_jobs is None:
+            # multiprocessing is not available or disabled, fallback
+            # to sequential mode
+            return 1
+        elif n_jobs < 0:
+            n_jobs = max(mp.cpu_count() + 1 + n_jobs, 1)
+        return n_jobs
+
+    def terminate(self):
+        """Shutdown the process or thread pool"""
+        if self._pool is not None:
+            self._pool.close()
+            self._pool.terminate()  # terminate does a join()
+            self._pool = None
+
+    def apply_async(self, func, callback=None):
+        """Schedule a func to be run"""
+        return self._pool.apply_async(SafeFunction(func), callback=callback)
+
+
+class AutoBatchingMixin(object):
+    """A helper class for automagically batching jobs."""
+
+    # In seconds, should be big enough to hide multiprocessing dispatching
+    # overhead.
+    # This settings was found by running benchmarks/bench_auto_batching.py
+    # with various parameters on various platforms.
+    MIN_IDEAL_BATCH_DURATION = .2
+
+    # Should not be too high to avoid stragglers: long jobs running alone
+    # on a single worker while other workers have no work to process any more.
+    MAX_IDEAL_BATCH_DURATION = 2
+
+    # Batching counters
+    _effective_batch_size = 1
+    _smoothed_batch_duration = 0.0
+
+    def compute_batch_size(self):
+        """Determine the optimal batch size"""
+        old_batch_size = self._effective_batch_size
+        batch_duration = self._smoothed_batch_duration
+        if (batch_duration > 0 and
+                batch_duration < self.MIN_IDEAL_BATCH_DURATION):
+            # The current batch size is too small: the duration of the
+            # processing of a batch of task is not large enough to hide
+            # the scheduling overhead.
+            ideal_batch_size = int(old_batch_size *
+                                   self.MIN_IDEAL_BATCH_DURATION /
+                                   batch_duration)
+            # Multiply by two to limit oscilations between min and max.
+            batch_size = max(2 * ideal_batch_size, 1)
+            self._effective_batch_size = batch_size
+            if self.parallel.verbose >= 10:
+                self.parallel._print(
+                    "Batch computation too fast (%.4fs.) "
+                    "Setting batch_size=%d.", (batch_duration, batch_size))
+        elif (batch_duration > self.MAX_IDEAL_BATCH_DURATION and
+              old_batch_size >= 2):
+            # The current batch size is too big. If we schedule overly long
+            # running batches some CPUs might wait with nothing left to do
+            # while a couple of CPUs a left processing a few long running
+            # batches. Better reduce the batch size a bit to limit the
+            # likelihood of scheduling such stragglers.
+            batch_size = old_batch_size // 2
+            self._effective_batch_size = batch_size
+            if self.parallel.verbose >= 10:
+                self.parallel._print(
+                    "Batch computation too slow (%.4fs.) "
+                    "Setting batch_size=%d.", (batch_duration, batch_size))
+        else:
+            # No batch size adjustment
+            batch_size = old_batch_size
+
+        if batch_size != old_batch_size:
+            # Reset estimation of the smoothed mean batch duration: this
+            # estimate is updated in the multiprocessing apply_async
+            # CallBack as long as the batch_size is constant. Therefore
+            # we need to reset the estimate whenever we re-tune the batch
+            # size.
+            self._smoothed_batch_duration = 0
+
+        return batch_size
+
+    def batch_completed(self, batch_size, duration):
+        """Callback indicate how long it took to run a batch"""
+        if batch_size == self._effective_batch_size:
+            # Update the smoothed streaming estimate of the duration of a batch
+            # from dispatch to completion
+            old_duration = self._smoothed_batch_duration
+            if old_duration == 0:
+                # First record of duration for this batch size after the last
+                # reset.
+                new_duration = duration
+            else:
+                # Update the exponentially weighted average of the duration of
+                # batch for the current effective size.
+                new_duration = 0.8 * old_duration + 0.2 * duration
+            self._smoothed_batch_duration = new_duration
+
+
+class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):
+    """A ParallelBackend which will use a thread pool to execute batches in.
+
+    This is a low-overhead backend but it suffers from the Python Global
+    Interpreter Lock if the called function relies a lot on Python objects.
+    Mostly useful when the execution bottleneck is a compiled extension that
+    explicitly releases the GIL (for instance a Cython loop wrapped in a
+    "with nogil" block or an expensive call to a library such as NumPy).
+    """
+
+    def initialize(self, n_jobs, backend_args):
+        """Build a process or thread pool and return the number of workers"""
+        self._pool = ThreadPool(n_jobs)
+        return n_jobs
+
+
+class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin,
+                             ParallelBackendBase):
+    """A ParallelBackend which will use a multiprocessing.Pool.
+
+    Will introduce some communication and memory overhead when exchanging
+    input and output data with the with the worker Python processes.
+    However, does not suffer from the Python Global Interpreter Lock.
+    """
+
+    # Environment variables to protect against bad situations when nesting
+    JOBLIB_SPAWNED_PROCESS = "__JOBLIB_SPAWNED_PARALLEL__"
+
+    def effective_n_jobs(self, n_jobs):
+        """ Determine the number of jobs which are going to run in parallel.
+        Will also check if we're attempting to create a nested parallel
+        loop. """
+        if mp.current_process().daemon:
+            # Daemonic processes cannot have children
+            warnings.warn(
+                'Multiprocessing-backed parallel loops cannot be nested,'
+                ' setting n_jobs=1',
+                stacklevel=3)
+            return 1
+
+        elif threading.current_thread().name != 'MainThread':
+            # Prevent posix fork inside in non-main posix threads
+            warnings.warn(
+                'Multiprocessing backed parallel loops cannot be nested'
+                ' below threads, setting n_jobs=1',
+                stacklevel=3)
+            return 1
+
+        return PoolManagerMixin.effective_n_jobs(self, n_jobs)
+
+    def initialize(self, n_jobs, backend_args):
+        """Build a process or thread pool and return the number of workers"""
+        already_forked = int(os.environ.get(self.JOBLIB_SPAWNED_PROCESS, 0))
+        if already_forked:
+            raise ImportError(
+                '[joblib] Attempting to do parallel computing '
+                'without protecting your import on a system that does '
+                'not support forking. To use parallel-computing in a '
+                'script, you must protect your main loop using "if '
+                "__name__ == '__main__'"
+                '". Please see the joblib documentation on Parallel '
+                'for more information')
+        # Set an environment variable to avoid infinite loops
+        os.environ[self.JOBLIB_SPAWNED_PROCESS] = '1'
+
+        # Make sure to free as much memory as possible before forking
+        gc.collect()
+        self._pool = MemmapingPool(n_jobs, **backend_args)
+        return n_jobs
+
+    def terminate(self):
+        """Shutdown the process or thread pool"""
+        super(MultiprocessingBackend, self).terminate()
+        if self.JOBLIB_SPAWNED_PROCESS in os.environ:
+            del os.environ[self.JOBLIB_SPAWNED_PROCESS]
+
+    def get_exceptions(self):
+        # We are using multiprocessing, we also want to capture
+        # KeyboardInterrupts
+        return [KeyboardInterrupt, WorkerInterrupt]
+
+
+class ImmediateResult(object):
+    def __init__(self, batch):
+        # Don't delay the application, to avoid keeping the input
+        # arguments in memory
+        self.results = batch()
+
+    def get(self):
+        return self.results
+
+
+class SafeFunction(object):
+    """Wrapper that handles the serialization of exception tracebacks.
+
+    If an exception is triggered when calling the inner function, a copy of
+    the full traceback is captured to make it possible to serialize
+    it so that it can be rendered in a different Python process.
+    """
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        try:
+            return self.func(*args, **kwargs)
+        except KeyboardInterrupt:
+            # We capture the KeyboardInterrupt and reraise it as
+            # something different, as multiprocessing does not
+            # interrupt processing for a KeyboardInterrupt
+            raise WorkerInterrupt()
+        except:
+            e_type, e_value, e_tb = sys.exc_info()
+            text = format_exc(e_type, e_value, e_tb, context=10, tb_offset=1)
+            raise TransportableException(text, e_type)

--- a/joblib/my_exceptions.py
+++ b/joblib/my_exceptions.py
@@ -50,6 +50,13 @@ class TransportableException(JoblibException):
         self.etype = etype
 
 
+class WorkerInterrupt(Exception):
+    """ An exception that is not KeyboardInterrupt to allow subprocesses
+        to be interrupted.
+    """
+    pass
+
+
 _exception_mapping = dict()
 
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -14,7 +14,6 @@ import functools
 import time
 import threading
 import itertools
-import warnings
 from numbers import Integral
 from contextlib import contextmanager
 try:

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -9,13 +9,12 @@ from __future__ import division
 
 import os
 import sys
-import gc
-import warnings
 from math import sqrt
 import functools
 import time
 import threading
 import itertools
+import warnings
 from numbers import Integral
 try:
     import cPickle as pickle
@@ -23,31 +22,20 @@ except:
     import pickle
 
 from ._multiprocessing_helpers import mp
-if mp is not None:
-    from .pool import MemmapingPool
-    from multiprocessing.pool import ThreadPool
 
-from .format_stack import format_exc, format_outer_frames
+from .format_stack import format_outer_frames
 from .logger import Logger, short_format_time
 from .my_exceptions import TransportableException, _mk_exception
 from .disk import memstr_to_kbytes
+from ._parallel_backends import (ParallelBackendBase, MultiprocessingBackend,
+                                 ThreadingBackend, SequentialBackend)
 from ._compat import _basestring
 
 
-VALID_BACKENDS = ['multiprocessing', 'threading']
-
-# Environment variables to protect against bad situations when nesting
-JOBLIB_SPAWNED_PROCESS = "__JOBLIB_SPAWNED_PARALLEL__"
-
-# In seconds, should be big enough to hide multiprocessing dispatching
-# overhead.
-# This settings was found by running benchmarks/bench_auto_batching.py
-# with various parameters on various platforms.
-MIN_IDEAL_BATCH_DURATION = .2
-
-# Should not be too high to avoid stragglers: long jobs running alone
-# on a single worker while other workers have no work to process any more.
-MAX_IDEAL_BATCH_DURATION = 2
+VALID_BACKENDS = {'multiprocessing': MultiprocessingBackend,
+                  'threading': ThreadingBackend,
+                  'sequential': SequentialBackend}
+VALID_BACKENDS['default'] = VALID_BACKENDS['multiprocessing']
 
 # Under Linux or OS X the default start method of multiprocessing
 # can cause third party libraries to crash. Under Python 3.4+ it is possible
@@ -108,39 +96,6 @@ def _verbosity_filter(index, verbose):
 
 
 ###############################################################################
-class WorkerInterrupt(Exception):
-    """ An exception that is not KeyboardInterrupt to allow subprocesses
-        to be interrupted.
-    """
-    pass
-
-
-###############################################################################
-class SafeFunction(object):
-    """ Wraps a function to make it exception with full traceback in
-        their representation.
-        Useful for parallel computing with multiprocessing, for which
-        exceptions cannot be captured.
-    """
-    def __init__(self, func):
-        self.func = func
-
-    def __call__(self, *args, **kwargs):
-        try:
-            return self.func(*args, **kwargs)
-        except KeyboardInterrupt:
-            # We capture the KeyboardInterrupt and reraise it as
-            # something different, as multiprocessing does not
-            # interrupt processing for a KeyboardInterrupt
-            raise WorkerInterrupt()
-        except:
-            e_type, e_value, e_tb = sys.exc_info()
-            text = format_exc(e_type, e_value, e_tb, context=10,
-                              tb_offset=1)
-            raise TransportableException(text, e_type)
-
-
-###############################################################################
 def delayed(function, check_pickle=True):
     """Decorator used to capture the arguments of a function.
 
@@ -167,23 +122,6 @@ def delayed(function, check_pickle=True):
 
 
 ###############################################################################
-class ImmediateComputeBatch(object):
-    """Sequential computation of a batch of tasks.
-
-    This replicates the async computation API but actually does not delay
-    the computations when joblib.Parallel runs in sequential mode.
-
-    """
-    def __init__(self, batch):
-        # Don't delay the application, to avoid keeping the input
-        # arguments in memory
-        self.results = batch()
-
-    def get(self):
-        return self.results
-
-
-###############################################################################
 class BatchCompletionCallBack(object):
     """Callback used by joblib.Parallel's multiprocessing backend.
 
@@ -204,24 +142,46 @@ class BatchCompletionCallBack(object):
         self.parallel.n_completed_tasks += self.batch_size
         this_batch_duration = time.time() - self.dispatch_timestamp
 
-        if (self.parallel.batch_size == 'auto'
-                and self.batch_size == self.parallel._effective_batch_size):
-            # Update the smoothed streaming estimate of the duration of a batch
-            # from dispatch to completion
-            old_duration = self.parallel._smoothed_batch_duration
-            if old_duration == 0:
-                # First record of duration for this batch size after the last
-                # reset.
-                new_duration = this_batch_duration
-            else:
-                # Update the exponentially weighted average of the duration of
-                # batch for the current effective size.
-                new_duration = 0.8 * old_duration + 0.2 * this_batch_duration
-            self.parallel._smoothed_batch_duration = new_duration
-
+        self.parallel._backend.batch_completed(self.batch_size,
+                                               this_batch_duration)
         self.parallel.print_progress()
         if self.parallel._original_iterator is not None:
             self.parallel.dispatch_next()
+
+
+###############################################################################
+def register_parallel_backend(name, cls):
+    """ Register a new Parallel backend.
+
+    The new backend can then be selected by passing its name as the backend
+    argument to the Parallel class. Moreover, the default backend can be
+    overwritten by setting the name to 'default'.
+
+    Notes
+    -----
+
+    Only the default backend can be overwritten. A ValueError will be raised
+    if an attempt is made to overwrite an already registered parallel backend.
+    """
+    if name != "default" and name in VALID_BACKENDS:
+        raise ValueError(
+            "Can only overwrite the default backend: %s was already registered"
+            % name)
+
+    if not issubclass(cls, ParallelBackendBase):
+        raise ValueError(
+            "Can only register a backend which extends SequentialBackend")
+
+    VALID_BACKENDS[name] = cls
+
+
+###############################################################################
+def effective_n_jobs():
+    """ Determine the number of jobs which are going to run in parallel, using
+    the current default parallel backend.
+    """
+    default_backend = VALID_BACKENDS['default'](None)
+    return default_backend.effective_n_jobs(n_jobs=-1)
 
 
 ###############################################################################
@@ -251,6 +211,9 @@ class Parallel(Logger):
                 explicitly releases the GIL (for instance a Cython loop wrapped
                 in a "with nogil" block or an expensive call to a library such
                 as NumPy).
+              - finally, you can register backends by calling
+                register_parallel_backend. This will allow you to implement
+                a backend of your liking.
         verbose: int, optional
             The verbosity level: if non zero, progress messages are
             printed. Above 50, the output is sent to stdout.
@@ -403,153 +366,112 @@ class Parallel(Logger):
          Produced 0
          Produced 1
          Produced 2
-         [Parallel(n_jobs=2)]: Done   1 jobs       | elapsed:    0.0s
+         [Parallel(n_jobs=2)]: Done 1 jobs     | elapsed:  0.0s
          Produced 3
-         [Parallel(n_jobs=2)]: Done   2 jobs       | elapsed:    0.0s
+         [Parallel(n_jobs=2)]: Done 2 jobs     | elapsed:  0.0s
          Produced 4
-         [Parallel(n_jobs=2)]: Done   3 jobs       | elapsed:    0.0s
+         [Parallel(n_jobs=2)]: Done 3 jobs     | elapsed:  0.0s
          Produced 5
-         [Parallel(n_jobs=2)]: Done   4 jobs       | elapsed:    0.0s
-         [Parallel(n_jobs=2)]: Done   5 out of   6 | elapsed:    0.0s remaining:    0.0s
-         [Parallel(n_jobs=2)]: Done   6 out of   6 | elapsed:    0.0s finished
+         [Parallel(n_jobs=2)]: Done 4 jobs     | elapsed:  0.0s
+         [Parallel(n_jobs=2)]: Done 5 out of 6 | elapsed:  0.0s remaining: 0.0s
+         [Parallel(n_jobs=2)]: Done 6 out of 6 | elapsed:  0.0s finished
     '''
-    def __init__(self, n_jobs=1, backend='multiprocessing', verbose=0,
+    def __init__(self, n_jobs=1, backend='default', verbose=0,
                  pre_dispatch='2 * n_jobs', batch_size='auto',
                  temp_folder=None, max_nbytes='1M', mmap_mode='r'):
+        self.n_jobs = n_jobs
         self.verbose = verbose
-        self._mp_context = DEFAULT_MP_CONTEXT
+        self.pre_dispatch = pre_dispatch
+
+        if isinstance(max_nbytes, _basestring):
+            max_nbytes = 1024 * memstr_to_kbytes(max_nbytes)
+
+        self._backend_args = dict(
+            max_nbytes=max_nbytes,
+            mmap_mode=mmap_mode,
+            temp_folder=temp_folder,
+            verbose=max(0, self.verbose - 50),
+        )
+        if DEFAULT_MP_CONTEXT is not None:
+            self._backend_args['context'] = DEFAULT_MP_CONTEXT
+
         if backend is None:
             # `backend=None` was supported in 0.8.2 with this effect
-            backend = "multiprocessing"
+            backend = "default"
         elif hasattr(backend, 'Pool') and hasattr(backend, 'Lock'):
             # Make it possible to pass a custom multiprocessing context as
             # backend to change the start method to forkserver or spawn or
             # preload modules on the forkserver helper process.
-            self._mp_context = backend
+            self._backend_args['context'] = backend
             backend = "multiprocessing"
         if backend not in VALID_BACKENDS:
             raise ValueError("Invalid backend: %s, expected one of %r"
-                             % (backend, VALID_BACKENDS))
-        self.backend = backend
-        self.n_jobs = n_jobs
-        if (batch_size == 'auto'
-                or isinstance(batch_size, Integral) and batch_size > 0):
+                             % (backend, VALID_BACKENDS.keys()))
+
+        # Silently switch to sequential backend to reduce overhead
+        if backend == "default" and n_jobs == 1:
+            backend = "sequential"
+        self.backend_factory = VALID_BACKENDS[backend]
+
+        if (batch_size == 'auto' or isinstance(batch_size, Integral) and
+                batch_size > 0):
             self.batch_size = batch_size
         else:
             raise ValueError(
                 "batch_size must be 'auto' or a positive integer, got: %r"
                 % batch_size)
 
-        self.pre_dispatch = pre_dispatch
-        self._temp_folder = temp_folder
-        if isinstance(max_nbytes, _basestring):
-            self._max_nbytes = 1024 * memstr_to_kbytes(max_nbytes)
-        else:
-            self._max_nbytes = max_nbytes
-        self._mmap_mode = mmap_mode
         # Not starting the pool in the __init__ is a design decision, to be
         # able to close it ASAP, and not burden the user with closing it
         # unless they choose to use the context manager API with a with block.
-        self._pool = None
+        self._backend = None
         self._output = None
         self._jobs = list()
-        self._managed_pool = False
+        self._managed_backend = False
+        self._mp_context = self._backend_args.get('context', None)
 
         # This lock is used coordinate the main thread of this process with
         # the async callback thread of our the pool.
         self._lock = threading.Lock()
 
     def __enter__(self):
-        self._managed_pool = True
-        self._initialize_pool()
+        self._managed_backend = True
+        self._initialize_backend()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self._terminate_pool()
-        self._managed_pool = False
+        self._terminate_backend()
+        self._managed_backend = False
 
-    def _effective_n_jobs(self):
-        n_jobs = self.n_jobs
-        if n_jobs == 0:
-            raise ValueError('n_jobs == 0 in Parallel has no meaning')
-        elif mp is None or n_jobs is None:
-            # multiprocessing is not available or disabled, fallback
-            # to sequential mode
-            return 1
-        elif n_jobs < 0:
-            n_jobs = max(mp.cpu_count() + 1 + n_jobs, 1)
-        return n_jobs
-
-    def _initialize_pool(self):
+    def _initialize_backend(self):
         """Build a process or thread pool and return the number of workers"""
-        n_jobs = self._effective_n_jobs()
+        self._backend = self.backend_factory(self)
+
         # The list of exceptions that we will capture
         self.exceptions = [TransportableException]
 
-        if n_jobs == 1:
+        n_jobs = self._backend.effective_n_jobs(self.n_jobs)
+        if (n_jobs == 1 and
+                self.backend_factory != VALID_BACKENDS['sequential']):
             # Sequential mode: do not use a pool instance to avoid any
             # useless dispatching overhead
-            self._pool = None
-        elif self.backend == 'threading':
-            self._pool = ThreadPool(n_jobs)
-        elif self.backend == 'multiprocessing':
-            if mp.current_process().daemon:
-                # Daemonic processes cannot have children
-                self._pool = None
-                warnings.warn(
-                    'Multiprocessing-backed parallel loops cannot be nested,'
-                    ' setting n_jobs=1',
-                    stacklevel=3)
-                return 1
-            elif threading.current_thread().name != 'MainThread':
-                # Prevent posix fork inside in non-main posix threads
-                self._pool = None
-                warnings.warn(
-                    'Multiprocessing backed parallel loops cannot be nested'
-                    ' below threads, setting n_jobs=1',
-                    stacklevel=3)
-                return 1
-            else:
-                already_forked = int(os.environ.get(JOBLIB_SPAWNED_PROCESS, 0))
-                if already_forked:
-                    raise ImportError('[joblib] Attempting to do parallel computing '
-                            'without protecting your import on a system that does '
-                            'not support forking. To use parallel-computing in a '
-                            'script, you must protect your main loop using "if '
-                            "__name__ == '__main__'"
-                            '". Please see the joblib documentation on Parallel '
-                            'for more information'
-                        )
-                # Set an environment variable to avoid infinite loops
-                os.environ[JOBLIB_SPAWNED_PROCESS] = '1'
+            warnings.warn('Switching multiprocessing-backed to sequential',
+                          stacklevel=3)
+            self._backend = VALID_BACKENDS['sequential'](self)
 
-                # Make sure to free as much memory as possible before forking
-                gc.collect()
-                poolargs = dict(
-                    max_nbytes=self._max_nbytes,
-                    mmap_mode=self._mmap_mode,
-                    temp_folder=self._temp_folder,
-                    verbose=max(0, self.verbose - 50),
-                )
-                if self._mp_context is not None:
-                    # Use Python 3.4+ multiprocessing context isolation
-                    poolargs['context'] = self._mp_context
-                self._pool = MemmapingPool(n_jobs, **poolargs)
+        self.exceptions.extend(self._backend.get_exceptions())
 
-                # We are using multiprocessing, we also want to capture
-                # KeyboardInterrupts
-                self.exceptions.extend([KeyboardInterrupt, WorkerInterrupt])
-        else:
-            raise ValueError("Unsupported backend: %s" % self.backend)
-        return n_jobs
+        return self._backend.initialize(n_jobs, self._backend_args)
 
-    def _terminate_pool(self):
-        if self._pool is not None:
-            self._pool.close()
-            self._pool.terminate()  # terminate does a join()
-            self._pool = None
-            if self.backend == 'multiprocessing':
-                os.environ.pop(JOBLIB_SPAWNED_PROCESS, 0)
+    def _effective_n_jobs(self):
+        if self._backend:
+            return self._backend.effective_n_jobs(self.n_jobs)
+        return 1
+
+    def _terminate_backend(self):
+        if self._backend is not None:
+            self._backend.terminate()
+            self._backend = None
 
     def _dispatch(self, batch):
         """Queue the batch for computing, with or without multiprocessing
@@ -562,24 +484,13 @@ class Parallel(Logger):
         if self._aborting:
             return
 
-        if self._pool is None:
-            job = ImmediateComputeBatch(batch)
-            self._jobs.append(job)
-            self.n_dispatched_batches += 1
-            self.n_dispatched_tasks += len(batch)
-            self.n_completed_tasks += len(batch)
-            if not _verbosity_filter(self.n_dispatched_batches, self.verbose):
-                self._print('Done %3i tasks       | elapsed: %s',
-                        (self.n_completed_tasks,
-                            short_format_time(time.time() - self._start_time)
-                        ))
-        else:
-            dispatch_timestamp = time.time()
-            cb = BatchCompletionCallBack(dispatch_timestamp, len(batch), self)
-            job = self._pool.apply_async(SafeFunction(batch), callback=cb)
-            self._jobs.append(job)
-            self.n_dispatched_tasks += len(batch)
-            self.n_dispatched_batches += 1
+        self.n_dispatched_tasks += len(batch)
+        self.n_dispatched_batches += 1
+
+        dispatch_timestamp = time.time()
+        cb = BatchCompletionCallBack(dispatch_timestamp, len(batch), self)
+        job = self._backend.apply_async(batch, callback=cb)
+        self._jobs.append(job)
 
     def dispatch_next(self):
         """Dispatch more data for parallel processing
@@ -603,52 +514,12 @@ class Parallel(Logger):
         lock so calling this function should be thread safe.
 
         """
-        if self.batch_size == 'auto' and self.backend == 'threading':
-            # Batching is never beneficial with the threading backend
-            batch_size = 1
-        elif self.batch_size == 'auto':
-            old_batch_size = self._effective_batch_size
-            batch_duration = self._smoothed_batch_duration
-            if (batch_duration > 0 and
-                    batch_duration < MIN_IDEAL_BATCH_DURATION):
-                # The current batch size is too small: the duration of the
-                # processing of a batch of task is not large enough to hide
-                # the scheduling overhead.
-                ideal_batch_size = int(
-                    old_batch_size * MIN_IDEAL_BATCH_DURATION / batch_duration)
-                # Multiply by two to limit oscilations between min and max.
-                batch_size = max(2 * ideal_batch_size, 1)
-                self._effective_batch_size = batch_size
-                if self.verbose >= 10:
-                    self._print("Batch computation too fast (%.4fs.) "
-                                "Setting batch_size=%d.", (
-                                    batch_duration, batch_size))
-            elif (batch_duration > MAX_IDEAL_BATCH_DURATION and
-                  old_batch_size >= 2):
-                # The current batch size is too big. If we schedule overly long
-                # running batches some CPUs might wait with nothing left to do
-                # while a couple of CPUs a left processing a few long running
-                # batches. Better reduce the batch size a bit to limit the
-                # likelihood of scheduling such stragglers.
-                self._effective_batch_size = batch_size = old_batch_size // 2
-                if self.verbose >= 10:
-                    self._print("Batch computation too slow (%.2fs.) "
-                                "Setting batch_size=%d.", (
-                                    batch_duration, batch_size))
-            else:
-                # No batch size adjustment
-                batch_size = old_batch_size
-
-            if batch_size != old_batch_size:
-                # Reset estimation of the smoothed mean batch duration: this
-                # estimate is updated in the multiprocessing apply_async
-                # CallBack as long as the batch_size is constant. Therefore
-                # we need to reset the estimate whenever we re-tune the batch
-                # size.
-                self._smoothed_batch_duration = 0
+        if self.batch_size == 'auto':
+            batch_size = self._backend.compute_batch_size()
         else:
             # Fixed batch size strategy
             batch_size = self.batch_size
+
         with self._lock:
             tasks = BatchedCalls(itertools.islice(iterator, batch_size))
             if not tasks:
@@ -747,13 +618,13 @@ Sub-process traceback:
                 # Kill remaining running processes without waiting for
                 # the results as we will raise the exception we got back
                 # to the caller instead of returning any result.
-                self._terminate_pool()
-                if self._managed_pool:
+                self._terminate_backend()
+                if self._managed_backend:
                     # In case we had to terminate a managed pool, let
                     # us start a new one to ensure that subsequent calls
                     # to __call__ on the same Parallel instance will get
                     # a working pool as they expect.
-                    self._initialize_pool()
+                    self._initialize_backend()
                 raise exception
 
     def __call__(self, iterable):
@@ -762,13 +633,10 @@ Sub-process traceback:
         # A flag used to abort the dispatching of jobs in case an
         # exception is found
         self._aborting = False
-        if not self._managed_pool:
-            n_jobs = self._initialize_pool()
+        if not self._managed_backend:
+            n_jobs = self._initialize_backend()
         else:
             n_jobs = self._effective_n_jobs()
-
-        if self.batch_size == 'auto':
-            self._effective_batch_size = 1
 
         iterator = iter(iterable)
         pre_dispatch = self.pre_dispatch
@@ -792,7 +660,6 @@ Sub-process traceback:
         self.n_dispatched_batches = 0
         self.n_dispatched_tasks = 0
         self.n_completed_tasks = 0
-        self._smoothed_batch_duration = 0.0
         try:
             # Only set self._iterating to True if at least a batch
             # was dispatched. In particular this covers the edge
@@ -814,8 +681,8 @@ Sub-process traceback:
                         (len(self._output), len(self._output),
                          short_format_time(elapsed_time)))
         finally:
-            if not self._managed_pool:
-                self._terminate_pool()
+            if not self._managed_backend:
+                self._terminate_backend()
             self._jobs = list()
         output = self._output
         self._output = None

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -318,11 +318,12 @@ class CustomizablePicklingQueue(object):
     pickling reducers, for instance to avoid memory copy when passing
     memory mapped datastructures.
 
-    `reducers` is expected to be a dictionary with key/values
-    being `(type, callable)` pairs where `callable` is a function that, given an
+    `reducers` is expected to be a dict with key / values being
+    `(type, callable)` pairs where `callable` is a function that, given an
     instance of `type`, will return a tuple `(constructor, tuple_of_objects)`
     to rebuild an instance out of the pickled `tuple_of_objects` as would
     return a `__reduce__` method.
+
     See the standard library documentation on pickling for more details.
     """
 


### PR DESCRIPTION
* The sequential, threadpool, and multiprocessing backends are now
refactored into separate classes. 
* Fixed tests accordingly

Some context, I am planning to create a YARN backend to allow you to run a python proces in containers spawned by YARN. It's going to be a separate plugin, to not have all hdfs/yarn dependencies in this project. My endgoal is to be able to run scikit-learn on YARN.

https://github.com/scikit-learn/scikit-learn/pull/6223