### PR TITLE
[MRG] make it possible to pass n_jobs to parallel_backend context

### DIFF
--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -177,8 +177,8 @@ argument to the constructor of the :class:`joblib.Parallel` class::
 
 or equivalently by using the :func:`joblib.parallel_backend` context manager::
 
-    with parallel_backend('custom'):
-        Parallel(n_jobs=2)(delayed(some_function)(i) for i in range(10))
+    with parallel_backend('custom', n_jobs=2):
+        Parallel()(delayed(some_function)(i) for i in range(10))
 
 Using the context manager can be helpful when using a third-party library that
 uses :class:`joblib.Parallel` internally while not exposing the ``backend``


### PR DESCRIPTION
This is a refinement for the new `parallel_backend` context manager introduced in #306.

This makes it possible to override the default value of `n_jobs` used internally by library code using the context manager.

Note in particular that `parallel_backend` uses `n_jobs=-1` by default meaning to use all the available workers of my registered backend. For instance the following will use all the `ipyparallel` backend and by default will use all the available worker without having the change all my code to pass `n_jobs=-1` everywhere. This is particularly useful when doing nested cross-validation of scikit-learn models, for instance by calling `cross_val_score` and `GridSearchCV` within one another:

```python
with parallel_backend('ipyparallel'):
    call_my_nested_cross_vall_parameter_search()
```

similarly, I am running the same code on a shared compute servers with 48 cores and I want to leave some compute power for other users working on the same machine I can globally set the number of process workers I want to use in my main script without having to :

```python
with parallel_backend('multiprocessing', n_jobs=12):
    call_my_nested_cross_vall_parameter_search()
```