### PR TITLE
[MRG]  persistence in/from file objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Latest changes
 Release 0.10.0
 --------------
 
+Alexandre Abadie
+
+    ENH: joblib.dump/load now accept file-like objects besides filenames.
+    https://github.com/joblib/joblib/pull/351 for more details.
+
 Niels Zeilemaker and Olivier Grisel
 
     Refactored joblib.Parallel to enable the registration of custom

--- a/doc/persistence.rst
+++ b/doc/persistence.rst
@@ -92,8 +92,7 @@ are 'gzip', 'bz2', 'lzma' and 'xz':
     Lzma and Xz compression methods are only available for python versions >= 3.3.
 
 Compressor files provided by the python standard library can also be used to
-compress pickle in a context manager, e.g `gzip.GzipFile`, `bz2.BZ2File`,
-`lzma.LZMAFile`:
+compress pickle, e.g ``gzip.GzipFile``, ``bz2.BZ2File``, ``lzma.LZMAFile``:
     >>> # Dumping in a gzip.GzipFile object using a compression level of 3.
     >>> import gzip
     >>> with gzip.GzipFile(filename + '.gz', 'wb', compresslevel=3) as fo:  # doctest: +ELLIPSIS

--- a/doc/persistence.rst
+++ b/doc/persistence.rst
@@ -46,6 +46,20 @@ We can then load the object from the file::
   [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
 
 
+Persist in file objects
+=======================
+
+Instead of filenames, `dump` and `load` functions also accept opened file
+objects:
+
+  >> with open(filename, 'wb') as fo:  # doctest: +ELLIPSIS
+          joblib.dump(to_persist, fo)
+  ['...test.pkl']
+  >> with open(filename, 'rb') as fo:  # doctest: +ELLIPSIS
+          joblib.load(to_persist)
+  [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
+
+
 Compressed joblib pickles
 =========================
 
@@ -79,6 +93,16 @@ are 'gzip', 'bz2', 'lzma' and 'xz':
 
     Lzma and Xz compression methods are only available for python versions >= 3.3.
 
+Compressor files provided by the python standard library can also be used to
+compress pickle in a context manager, e.g `gzip.GzipFile`, `bz2.BZ2File`,
+`lzma.LZMAFile`:
+    >>> # Dumping in a gzip.GzipFile file object using a compress level of 3.
+    >>> with gzip.GzipFile(filename + '.gz', 'wb') as fo:  # doctest: +ELLIPSIS
+            joblib.dump(to_persist, f)  # doctest: +ELLIPSIS
+    ['...test.pkl.gz']
+    >>> with gzip.GzipFile(filename + '.gz', 'rb') as fo:  # doctest: +ELLIPSIS
+            joblib.load(filename + '.gz')
+    [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
 
 More details can be found in the :func:`joblib.dump` and
 :func:`joblib.load` documentation.

--- a/doc/persistence.rst
+++ b/doc/persistence.rst
@@ -53,7 +53,6 @@ Instead of filenames, `dump` and `load` functions also accept file objects:
 
   >>> with open(filename, 'wb') as fo:  # doctest: +ELLIPSIS
   ...    joblib.dump(to_persist, fo)
-  [<...>]
   >>> with open(filename, 'rb') as fo:  # doctest: +ELLIPSIS
   ...    joblib.load(fo)
   [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
@@ -97,10 +96,9 @@ compress pickle in a context manager, e.g `gzip.GzipFile`, `bz2.BZ2File`,
 `lzma.LZMAFile`:
     >>> # Dumping in a gzip.GzipFile object using a compression level of 3.
     >>> import gzip
-    >>> with gzip.GzipFile(filename + '.gz', 'wb', compresslevel=3) as fo:  # doctest: +ELLIPSIS +SKIP
+    >>> with gzip.GzipFile(filename + '.gz', 'wb', compresslevel=3) as fo:  # doctest: +ELLIPSIS
     ...    joblib.dump(to_persist, fo)
-    [<...>]
-    >>> with gzip.GzipFile(filename + '.gz', 'rb') as fo:  # doctest: +ELLIPSIS +SKIP
+    >>> with gzip.GzipFile(filename + '.gz', 'rb') as fo:  # doctest: +ELLIPSIS
     ...    joblib.load(fo)
     [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
 

--- a/doc/persistence.rst
+++ b/doc/persistence.rst
@@ -51,11 +51,10 @@ Persistence in file objects
 
 Instead of filenames, `dump` and `load` functions also accept file objects:
 
-  >> with open(filename, 'wb') as fo:  # doctest: +ELLIPSIS
-          joblib.dump(to_persist, fo)
-  ['...test.pkl']
-  >> with open(filename, 'rb') as fo:  # doctest: +ELLIPSIS
-          joblib.load(to_persist)
+  >>> with open(filename, 'wb') as fo:  # doctest: +ELLIPSIS +SKIP
+  ...    joblib.dump(to_persist, fo)
+  >>> with open(filename, 'rb') as fo:  # doctest: +ELLIPSIS
+  ...    joblib.load(fo)
   [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
 
 
@@ -96,11 +95,12 @@ Compressor files provided by the python standard library can also be used to
 compress pickle in a context manager, e.g `gzip.GzipFile`, `bz2.BZ2File`,
 `lzma.LZMAFile`:
     >>> # Dumping in a gzip.GzipFile object using a compression level of 3.
-    >>> with gzip.GzipFile(filename + '.gz', 'wb', compresslevel=3) as fo:  # doctest: +ELLIPSIS
-            joblib.dump(to_persist, f)  # doctest: +ELLIPSIS
-    ['...test.pkl.gz']
-    >>> with gzip.GzipFile(filename + '.gz', 'rb') as fo:  # doctest: +ELLIPSIS
-            joblib.load(filename + '.gz')
+    >>> import gzip
+    >>> with gzip.GzipFile(filename + '.gz', 'wb', compresslevel=3) as fo:  # doctest: +ELLIPSIS +SKIP
+    ...    joblib.dump(to_persist, fo)
+
+    >>> with gzip.GzipFile(filename + '.gz', 'rb') as fo:  # doctest: +ELLIPSIS +SKIP
+    ...    joblib.load(fo)
     [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
 
 More details can be found in the :func:`joblib.dump` and

--- a/doc/persistence.rst
+++ b/doc/persistence.rst
@@ -95,8 +95,8 @@ are 'gzip', 'bz2', 'lzma' and 'xz':
 Compressor files provided by the python standard library can also be used to
 compress pickle in a context manager, e.g `gzip.GzipFile`, `bz2.BZ2File`,
 `lzma.LZMAFile`:
-    >>> # Dumping in a gzip.GzipFile file object using a compress level of 3.
-    >>> with gzip.GzipFile(filename + '.gz', 'wb') as fo:  # doctest: +ELLIPSIS
+    >>> # Dumping in a gzip.GzipFile object using a compression level of 3.
+    >>> with gzip.GzipFile(filename + '.gz', 'wb', compresslevel=3) as fo:  # doctest: +ELLIPSIS
             joblib.dump(to_persist, f)  # doctest: +ELLIPSIS
     ['...test.pkl.gz']
     >>> with gzip.GzipFile(filename + '.gz', 'rb') as fo:  # doctest: +ELLIPSIS

--- a/doc/persistence.rst
+++ b/doc/persistence.rst
@@ -46,11 +46,10 @@ We can then load the object from the file::
   [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
 
 
-Persist in file objects
-=======================
+Persistence in file objects
+===========================
 
-Instead of filenames, `dump` and `load` functions also accept opened file
-objects:
+Instead of filenames, `dump` and `load` functions also accept file objects:
 
   >> with open(filename, 'wb') as fo:  # doctest: +ELLIPSIS
           joblib.dump(to_persist, fo)

--- a/doc/persistence.rst
+++ b/doc/persistence.rst
@@ -51,8 +51,9 @@ Persistence in file objects
 
 Instead of filenames, `dump` and `load` functions also accept file objects:
 
-  >>> with open(filename, 'wb') as fo:  # doctest: +ELLIPSIS +SKIP
+  >>> with open(filename, 'wb') as fo:  # doctest: +ELLIPSIS
   ...    joblib.dump(to_persist, fo)
+  [<...>]
   >>> with open(filename, 'rb') as fo:  # doctest: +ELLIPSIS
   ...    joblib.load(fo)
   [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
@@ -98,7 +99,7 @@ compress pickle in a context manager, e.g `gzip.GzipFile`, `bz2.BZ2File`,
     >>> import gzip
     >>> with gzip.GzipFile(filename + '.gz', 'wb', compresslevel=3) as fo:  # doctest: +ELLIPSIS +SKIP
     ...    joblib.dump(to_persist, fo)
-
+    [<...>]
     >>> with gzip.GzipFile(filename + '.gz', 'rb') as fo:  # doctest: +ELLIPSIS +SKIP
     ...    joblib.load(fo)
     [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]

--- a/doc/persistence_fixture.py
+++ b/doc/persistence_fixture.py
@@ -7,4 +7,7 @@ from joblib import _compat
 def setup_module(module):
     """Setup module."""
     if _compat.PY26:
+        # gzip.GZipFile and bz2.BZ2File compressor classes cannot be used
+        # within a context manager (e.g in a `with` block) in python 2.6 so
+        # we skip doctesting of persistence documentation in this case.
         raise SkipTest("Skipping persistence doctest in Python 2.6")

--- a/doc/persistence_fixture.py
+++ b/doc/persistence_fixture.py
@@ -7,4 +7,4 @@ from joblib import _compat
 def setup_module(module):
     """Setup module."""
     if _compat.PY26:
-        raise SkipTest("Skipping persitence doctest in Python 2.6")
+        raise SkipTest("Skipping persistence doctest in Python 2.6")

--- a/doc/persistence_fixture.py
+++ b/doc/persistence_fixture.py
@@ -1,0 +1,10 @@
+"""Fixture module to skip the persistence doctest with python 2.6."""
+
+from nose import SkipTest
+from joblib import _compat
+
+
+def setup_module(module):
+    """Setup module."""
+    if _compat.PY26:
+        raise SkipTest("Skipping persitence doctest in Python 2.6")

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -397,6 +397,9 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
     if Path is not None and isinstance(filename, Path):
         filename = str(filename)
 
+    isFilename = isinstance(filename, _basestring)
+    isFileobj = hasattr(filename, "read") and hasattr(filename, "write")
+
     compress_method = 'zlib'  # zlib is the default compression method.
     if compress is True:
         # By default, if compress is enabled, we want to be using 3 by default
@@ -424,14 +427,16 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
             'Non valid compression method given: "{0}". Possible values are '
             '{1}.'.format(compress_method, _COMPRESSORS))
 
-    if not isinstance(filename, _basestring):
+    if not isFilename and not isFileobj:
         # People keep inverting arguments, and the resulting error is
         # incomprehensible
         raise ValueError(
-            'Second argument should be a filename, %s (type %s) was given'
+            'Second argument should be a filename or a file-like object, '
+            '%s (type %s) was given.'
             % (filename, type(filename))
         )
-    elif not isinstance(compress, tuple):
+
+    if isFilename and not isinstance(compress, tuple):
         # In case no explicit compression was requested using both compression
         # method and level in a tuple and the filename has an explicit
         # extension, we select the corresponding compressor.
@@ -475,10 +480,45 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
             NumpyPickler(f, protocol=protocol).dump(value)
 
     else:
-        with open(filename, 'wb') as f:
-            NumpyPickler(f, protocol=protocol).dump(value)
+        if isFilename:
+            with open(filename, 'wb') as f:
+                NumpyPickler(f, protocol=protocol).dump(value)
+        else:
+            NumpyPickler(filename, protocol=protocol).dump(value)
 
     return [filename]
+
+
+def _unpickle(fobj, filename="", mmap_mode=None):
+    # We are careful to open the file handle early and keep it open to
+    # avoid race-conditions on renames.
+    # That said, if data is stored in companion files, which can be
+    # the case with the old persistence format, moving the directory
+    # will create a race when joblib tries to access the companion
+    # files.
+    unpickler = NumpyUnpickler(filename, fobj, mmap_mode=mmap_mode)
+    obj = None
+    try:
+        obj = unpickler.load()
+        if unpickler.compat_mode:
+            warnings.warn("The file '%s' has been generated with a "
+                          "joblib version less than 0.10. "
+                          "Please regenerate this pickle file."
+                          % filename,
+                          DeprecationWarning, stacklevel=3)
+    except UnicodeDecodeError as exc:
+        # More user-friendly error message
+        if PY3_OR_LATER:
+            new_exc = ValueError(
+                'You may be trying to read with '
+                'python 3 a joblib pickle generated with python 2. '
+                'This feature is not supported by joblib.')
+            new_exc.__cause__ = exc
+            raise new_exc
+        # Raise exception "as-is" with python 2
+        raise
+
+    return obj
 
 
 def load(filename, mmap_mode=None):
@@ -514,37 +554,19 @@ def load(filename, mmap_mode=None):
     """
     if Path is not None and isinstance(filename, Path):
         filename = str(filename)
-    with open(filename, 'rb') as f:
-        with _read_fileobject(f, filename, mmap_mode) as f:
-            if isinstance(f, _basestring):
-                # if the returned file object is a string, this means we try
-                # to load a pickle file generated with an version of Joblib
-                # so we load it with joblib compatibility function.
-                return load_compatibility(f)
 
-            # We are careful to open the file handle early and keep it open to
-            # avoid race-conditions on renames.
-            # That said, if data is stored in companion files, which can be
-            # the case with the old persistence format, moving the directory
-            # will create a race when joblib tries to access the companion
-            # files.
-            unpickler = NumpyUnpickler(filename, f, mmap_mode=mmap_mode)
-            try:
-                obj = unpickler.load()
-                if unpickler.compat_mode:
-                    warnings.warn("The file '%s' has been generated with a "
-                                  "joblib version less than 0.10. "
-                                  "Please regenerate this pickle file."
-                                  % filename,
-                                  DeprecationWarning, stacklevel=2)
-            except UnicodeDecodeError as exc:
-                # More user-friendly error message
-                if PY3_OR_LATER:
-                    new_exc = ValueError(
-                        'You may be trying to read with '
-                        'python 3 a joblib pickle generated with python 2. '
-                        'This feature is not supported by joblib.')
-                    new_exc.__cause__ = exc
-                    raise new_exc
+    if hasattr(filename, "read") and hasattr(filename, "write"):
+        with _read_fileobject(filename, "", mmap_mode) as fobj:
+            obj = _unpickle(fobj)
+    else:
+        with open(filename, 'rb') as f:
+            with _read_fileobject(f, filename, mmap_mode) as fobj:
+                if isinstance(fobj, _basestring):
+                    # if the returned file object is a string, this means we
+                    # try to load a pickle file generated with an version of
+                    # Joblib so we load it with joblib compatibility function.
+                    return load_compatibility(fobj)
+
+                obj = _unpickle(fobj, filename, mmap_mode)
 
     return obj

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -478,13 +478,11 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
         with _write_fileobject(filename, compress=(compress_method,
                                                    compress_level)) as f:
             NumpyPickler(f, protocol=protocol).dump(value)
-
+    elif is_filename:
+        with open(filename, 'wb') as f:
+            NumpyPickler(f, protocol=protocol).dump(value)
     else:
-        if is_filename:
-            with open(filename, 'wb') as f:
-                NumpyPickler(f, protocol=protocol).dump(value)
-        else:
-            NumpyPickler(filename, protocol=protocol).dump(value)
+        NumpyPickler(filename, protocol=protocol).dump(value)
 
     return [filename]
 

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -397,8 +397,8 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
     if Path is not None and isinstance(filename, Path):
         filename = str(filename)
 
-    isFilename = isinstance(filename, _basestring)
-    isFileobj = hasattr(filename, "read") and hasattr(filename, "write")
+    is_filename = isinstance(filename, _basestring)
+    is_fileobj = hasattr(filename, "write")
 
     compress_method = 'zlib'  # zlib is the default compression method.
     if compress is True:
@@ -427,7 +427,7 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
             'Non valid compression method given: "{0}". Possible values are '
             '{1}.'.format(compress_method, _COMPRESSORS))
 
-    if not isFilename and not isFileobj:
+    if not is_filename and not is_fileobj:
         # People keep inverting arguments, and the resulting error is
         # incomprehensible
         raise ValueError(
@@ -436,7 +436,7 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
             % (filename, type(filename))
         )
 
-    if isFilename and not isinstance(compress, tuple):
+    if is_filename and not isinstance(compress, tuple):
         # In case no explicit compression was requested using both compression
         # method and level in a tuple and the filename has an explicit
         # extension, we select the corresponding compressor.
@@ -480,7 +480,7 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
             NumpyPickler(f, protocol=protocol).dump(value)
 
     else:
-        if isFilename:
+        if is_filename:
             with open(filename, 'wb') as f:
                 NumpyPickler(f, protocol=protocol).dump(value)
         else:
@@ -556,7 +556,7 @@ def load(filename, mmap_mode=None):
     if Path is not None and isinstance(filename, Path):
         filename = str(filename)
 
-    if hasattr(filename, "read") and hasattr(filename, "write"):
+    if hasattr(filename, "read") and hasattr(filename, "seek"):
         with _read_fileobject(filename, "", mmap_mode) as fobj:
             obj = _unpickle(fobj)
     else:

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -490,6 +490,7 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
 
 
 def _unpickle(fobj, filename="", mmap_mode=None):
+    """Internal unpickling function."""
     # We are careful to open the file handle early and keep it open to
     # avoid race-conditions on renames.
     # That said, if data is stored in companion files, which can be

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -514,7 +514,7 @@ def _unpickle(fobj, filename="", mmap_mode=None):
                 'This feature is not supported by joblib.')
             new_exc.__cause__ = exc
             raise new_exc
-        # Raise exception "as-is" with python 2
+        # Reraise exception with Python 2
         raise
 
     return obj

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -484,6 +484,12 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
     else:
         NumpyPickler(filename, protocol=protocol).dump(value)
 
+    # If the target container is a file object, nothing is returned.
+    if is_fileobj:
+        return
+
+    # For compatibility, the list of created filenames (e.g with one element
+    # after 0.10.0) is returned by default.
     return [filename]
 
 

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -50,9 +50,9 @@ _LZMA_PREFIX = b'\x5d\x00'
 
 # Supported compressors
 _COMPRESSORS = ('zlib', 'bz2', 'lzma', 'xz', 'gzip')
-_COMPRESSOR_OBJS = [gzip.GzipFile, bz2.BZ2File]
+_COMPRESSOR_CLASSES = [gzip.GzipFile, bz2.BZ2File]
 if lzma is not None:
-    _COMPRESSOR_OBJS.append(lzma.LZMAFile)
+    _COMPRESSOR_CLASSES.append(lzma.LZMAFile)
 
 # The max magic number length of supported compression file types.
 _MAX_PREFIX_LEN = max(len(prefix)
@@ -151,7 +151,7 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
     """
     # Detect if the fileobj contains compressed data.
     compressor = _detect_compressor(fileobj)
-    if isinstance(fileobj, tuple(_COMPRESSOR_OBJS)):
+    if isinstance(fileobj, tuple(_COMPRESSOR_CLASSES)):
         compressor = fileobj.__class__.__name__
     if compressor == 'compat':
         # Compatibility with old pickle mode: simply return the input
@@ -167,22 +167,22 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
         # mmap_mode cannot be used with compressed file or in memory buffers
         # such as io.BytesIO.
         if ((compressor in _COMPRESSORS or
-                isinstance(fileobj, tuple(_COMPRESSOR_OBJS))) and
+                isinstance(fileobj, tuple(_COMPRESSOR_CLASSES))) and
                 mmap_mode is not None):
             warnings.warn('File "%(filename)s" is compressed using '
                           '"%(compressor)s" which is not compatible with '
                           'mmap_mode "%(mmap_mode)s" flag passed. mmap_mode '
                           'option will be ignored.'
-                          % locals(), Warning, stacklevel=2)
+                          % locals(), stacklevel=2)
         if isinstance(fileobj, io.BytesIO) and mmap_mode is not None:
             warnings.warn('In memory persistence is not compatible with '
                           'mmap_mode "%(mmap_mode)s" flag passed. mmap_mode '
                           'option will be ignored.'
-                          % locals(), Warning, stacklevel=2)
+                          % locals(), stacklevel=2)
 
         # if the passed fileobj is in the supported list of decompressor
         # objects (GzipFile, BZ2File, LzmaFile), we simply return it.
-        if isinstance(fileobj, tuple(_COMPRESSOR_OBJS)):
+        if isinstance(fileobj, tuple(_COMPRESSOR_CLASSES)):
             yield fileobj
         # otherwise, based on the compressor detected in the file, we open the
         # correct decompressor file object, wrapped in a buffer.

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -8,6 +8,7 @@ import pickle
 import sys
 import io
 import zlib
+import gzip
 import bz2
 import warnings
 import contextlib
@@ -49,6 +50,9 @@ _LZMA_PREFIX = b'\x5d\x00'
 
 # Supported compressors
 _COMPRESSORS = ('zlib', 'bz2', 'lzma', 'xz', 'gzip')
+_COMPRESSOR_OBJS = [gzip.GzipFile, bz2.BZ2File]
+if lzma is not None:
+    _COMPRESSOR_OBJS.append(lzma.LZMAFile)
 
 # The max magic number length of supported compression file types.
 _MAX_PREFIX_LEN = max(len(prefix)
@@ -147,20 +151,42 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
     """
     # Detect if the fileobj contains compressed data.
     compressor = _detect_compressor(fileobj)
+    if isinstance(fileobj, tuple(_COMPRESSOR_OBJS)):
+        compressor = fileobj.__class__.__name__
     if compressor == 'compat':
+        # Compatibility with old pickle mode: simply return the input
+        # filename "as-is" and let the compatibility function be called by the
+        # caller.
         warnings.warn("The file '%s' has been generated with a joblib "
                       "version less than 0.10. "
                       "Please regenerate this pickle file." % filename,
                       DeprecationWarning, stacklevel=2)
         yield filename
     else:
-        if compressor in _COMPRESSORS and mmap_mode is not None:
+        # Checking if incompatible load parameters with the type of file:
+        # mmap_mode cannot be used with compressed file or in memory buffers
+        # such as io.BytesIO.
+        if ((compressor in _COMPRESSORS or
+                isinstance(fileobj, tuple(_COMPRESSOR_OBJS))) and
+                mmap_mode is not None):
             warnings.warn('File "%(filename)s" is compressed using '
                           '"%(compressor)s" which is not compatible with '
-                          'mmap_mode "%(mmap_mode)s" flag passed.'
-                          % locals(), DeprecationWarning, stacklevel=2)
+                          'mmap_mode "%(mmap_mode)s" flag passed. mmap_mode '
+                          'option will be ignored.'
+                          % locals(), Warning, stacklevel=2)
+        if isinstance(fileobj, io.BytesIO) and mmap_mode is not None:
+            warnings.warn('In memory persistence is not compatible with '
+                          'mmap_mode "%(mmap_mode)s" flag passed. mmap_mode '
+                          'option will be ignored.'
+                          % locals(), Warning, stacklevel=2)
 
-        if compressor == 'zlib':
+        # if the passed fileobj is in the supported list of decompressor
+        # objects (GzipFile, BZ2File, LzmaFile), we simply return it.
+        if isinstance(fileobj, tuple(_COMPRESSOR_OBJS)):
+            yield fileobj
+        # otherwise, based on the compressor detected in the file, we open the
+        # correct decompressor file object, wrapped in a buffer.
+        elif compressor == 'zlib':
             yield _buffered_read_file(BinaryZlibFile(fileobj, 'rb'))
         elif compressor == 'gzip':
             yield _buffered_read_file(BinaryGzipFile(fileobj, 'rb'))
@@ -180,6 +206,7 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
                                           "python ({0}.{1})"
                                           .format(sys.version_info[0],
                                                   sys.version_info[1]))
+        # No compression detected => returning the input file object (open)
         else:
             yield fileobj
 

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -335,7 +335,7 @@ def test_compress_mmap_mode_warning():
         numpy_pickle.load(this_filename, mmap_mode='r+')
         nose.tools.assert_equal(len(caught_warnings), 1)
         for warn in caught_warnings:
-            nose.tools.assert_equal(warn.category, Warning)
+            nose.tools.assert_equal(warn.category, UserWarning)
             nose.tools.assert_equal(warn.message.args[0],
                                     'File "%(filename)s" is compressed using '
                                     '"%(compressor)s" which is not compatible '
@@ -764,7 +764,7 @@ def test_file_handle_persistence_compressed_mmap():
             numpy_pickle.load(f, mmap_mode='r+')
             nose.tools.assert_equal(len(caught_warnings), 1)
             for warn in caught_warnings:
-                nose.tools.assert_equal(warn.category, Warning)
+                nose.tools.assert_equal(warn.category, UserWarning)
                 nose.tools.assert_equal(warn.message.args[0],
                                         'File "%(filename)s" is compressed '
                                         'using "%(compressor)s" which is not '
@@ -789,7 +789,7 @@ def test_file_handle_persistence_in_memory_mmap():
         numpy_pickle.load(buf, mmap_mode='r+')
         nose.tools.assert_equal(len(caught_warnings), 1)
         for warn in caught_warnings:
-            nose.tools.assert_equal(warn.category, Warning)
+            nose.tools.assert_equal(warn.category, UserWarning)
             nose.tools.assert_equal(warn.message.args[0],
                                     'In memory persistence is not compatible '
                                     'with mmap_mode "%(mmap_mode)s" '


### PR DESCRIPTION
This PR should fix #341 and fix #312.

Examples of new usage:
```python
import joblib
data = "some data to persist"
# persist to/from a raw file
with open('/tmp/test.pkl', 'wb') as f:
    joblib.dump(data, f)

with open('/tmp/test.pkl', 'rb') as f:
    print(joblib.load(f))

# compressors are also supported:
import gzip
with gzip.GzipFile('/tmp/test.pkl.gz', 'wb') as f:
    joblib.dump(data, f)

with gzip.GzipFile('/tmp/test.pkl.gz', 'rb') as f:
    print(joblib.load(f))

# auto detection of compression also works:
with open('/tmp/test.pkl.gz', 'rb') as f:
    print(joblib.load(f))

# it's also possible to pickle in a buffer in memory using io.BytesIO:
import io
buf = io.BytesIO()
joblib.dump(data, buf)
joblib.load(buf)
```

Test functions are still missing.