### PR TITLE
[MRG] LRU cache replacement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,13 @@ Alexandre Abadie
     Remove deprecated `format_signature`, `format_call` and `load_output`
     functions from Memory API.
 
+Loïc Estève
+
+    Add initial implementation of LRU cache cleaning. You can specify
+    the size limit of a ``Memory`` object via the ``bytes_limit``
+    parameter and then need to clean explicitly the cache via the
+    ``Memory.reduce_size`` method.
+
 
 Release 0.10.2
 --------------

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -146,7 +146,7 @@ def _get_cache_items(root_path):
     cache_items = []
 
     for dirpath, dirnames, filenames in os.walk(root_path):
-        is_cache_hash_dir = re.match('[a-z0-9]{32}', os.path.basename(dirpath))
+        is_cache_hash_dir = re.match('[a-f0-9]{32}', os.path.basename(dirpath))
 
         if is_cache_hash_dir:
             output_filename = os.path.join(dirpath, 'output.pkl')

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -142,7 +142,7 @@ def _load_output(output_dir, func_name, timestamp=None, metadata=None,
 
 
 def _get_cache_items(root_path):
-    """Get cache information for reducing the size of the cache"""
+    """Get cache information for reducing the size of the cache."""
     cache_items = []
 
     for dirpath, dirnames, filenames in os.walk(root_path):

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -938,7 +938,7 @@ class Memory(Logger):
             rm_subdirs(self.cachedir)
 
     def reduce_size(self):
-        """Removes cache foldes until cache size is less than ``bytes_limit``."""
+        """Remove cache folders to make cache size fit in ``bytes_limit``."""
         if self.cachedir is not None and self.bytes_limit is not None:
             cache_items_to_delete = _get_cache_items_to_delete(
                 self.cachedir, self.bytes_limit)

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -27,6 +27,9 @@ import inspect
 import json
 import weakref
 import io
+import operator
+import collections
+import datetime
 
 # Local imports
 from . import hashing
@@ -35,10 +38,13 @@ from .func_inspect import format_signature, format_call
 from ._memory_helpers import open_py_source
 from .logger import Logger, format_time, pformat
 from . import numpy_pickle
-from .disk import mkdirp, rm_subdirs
+from .disk import mkdirp, rm_subdirs, memstr_to_bytes
 from ._compat import _basestring, PY3_OR_LATER
 
 FIRST_LINE_TEXT = "# first line:"
+
+CacheItemInfo = collections.namedtuple('CacheItemInfo',
+                                       'path size last_access')
 
 # TODO: The following object should have a data store object as a sub
 # object, and the interface to persist and query should be separated in
@@ -130,8 +136,71 @@ def _load_output(output_dir, func_name, timestamp=None, metadata=None,
         raise KeyError(
             "Non-existing cache value (may have been cleared).\n"
             "File %s does not exist" % filename)
-    return numpy_pickle.load(filename, mmap_mode=mmap_mode)
+    result = numpy_pickle.load(filename, mmap_mode=mmap_mode)
 
+    return result
+
+
+def _get_cache_items(root_path):
+    """Get cache information for reducing the size of the cache"""
+    cache_items = []
+
+    for dirpath, dirnames, filenames in os.walk(root_path):
+        is_cache_hash_dir = re.match('[a-z0-9]{32}', os.path.basename(dirpath))
+
+        if is_cache_hash_dir:
+            output_filename = os.path.join(dirpath, 'output.pkl')
+            try:
+                last_access = os.path.getatime(output_filename)
+            except OSError:
+                try:
+                    last_access = os.path.getatime(dirpath)
+                except OSError:
+                    # The directory has already been deleted
+                    continue
+
+            last_access = datetime.datetime.fromtimestamp(last_access)
+            try:
+                full_filenames = [os.path.join(dirpath, fn)
+                                  for fn in filenames]
+                dirsize = sum(os.path.getsize(fn)
+                              for fn in full_filenames)
+            except OSError:
+                # Either output_filename or one of the files in
+                # dirpath does not exist any more. We assume this
+                # directory is being cleaned by another process already
+                continue
+
+            cache_items.append(CacheItemInfo(dirpath, dirsize, last_access))
+
+    return cache_items
+
+
+def _get_cache_items_to_delete(root_path, bytes_limit):
+    """Get cache items to delete to keep the cache under a size limit"""
+    if isinstance(bytes_limit, _basestring):
+        bytes_limit = memstr_to_bytes(bytes_limit)
+
+    cache_items = _get_cache_items(root_path)
+    cache_size = sum(item.size for item in cache_items)
+
+    to_delete_size = cache_size - bytes_limit
+    if to_delete_size < 0:
+        return []
+
+    cache_items.sort(key=operator.attrgetter('last_access'))
+
+    cache_items_to_delete = []
+    size_so_far = 0
+
+    for item in cache_items:
+        if size_so_far > to_delete_size:
+            break
+
+        cache_items_to_delete.append(item)
+        size_so_far += item.size
+
+    return cache_items_to_delete
 
 # An in-memory store to avoid looking at the disk-based function
 # source code to check if a function definition has changed
@@ -742,6 +811,7 @@ class MemorizedFunc(Logger):
 
     # XXX: Need a method to check if results are available.
 
+
     #-------------------------------------------------------------------------
     # Private `object` interface
     #-------------------------------------------------------------------------
@@ -770,7 +840,8 @@ class Memory(Logger):
     # Public interface
     #-------------------------------------------------------------------------
 
-    def __init__(self, cachedir, mmap_mode=None, compress=False, verbose=1):
+    def __init__(self, cachedir, mmap_mode=None, compress=False, verbose=1,
+                 bytes_limit=None):
         """
             Parameters
             ----------
@@ -790,6 +861,8 @@ class Memory(Logger):
             verbose: int, optional
                 Verbosity flag, controls the debug messages that are issued
                 as functions are evaluated.
+            bytes_limit: int, optional
+                Limit in bytes of the size of the cache
         """
         # XXX: Bad explanation of the None value of cachedir
         Logger.__init__(self)
@@ -797,6 +870,7 @@ class Memory(Logger):
         self.mmap_mode = mmap_mode
         self.timestamp = time.time()
         self.compress = compress
+        self.bytes_limit = bytes_limit
         if compress and mmap_mode is not None:
             warnings.warn('Compressed results cannot be memmapped',
                           stacklevel=2)
@@ -860,6 +934,23 @@ class Memory(Logger):
             self.warn('Flushing completely the cache')
         if self.cachedir is not None:
             rm_subdirs(self.cachedir)
+
+    def reduce_size(self):
+        if self.cachedir is not None and self.bytes_limit is not None:
+            cache_items_to_delete = _get_cache_items_to_delete(
+                self.cachedir, self.bytes_limit)
+
+            for cache_item in cache_items_to_delete:
+                if self._verbose > 10:
+                    print('Deleting cache item {0}'.format(cache_item))
+                try:
+                    shutil.rmtree(cache_item.path, ignore_errors=True)
+                except OSError:
+                    # Even with ignore_errors=True can shutil.rmtree
+                    # can raise OSErrror with [Errno 116] Stale file
+                    # handle if another process has deleted the folder
+                    # already.
+                    pass
 
     def eval(self, func, *args, **kwargs):
         """ Eval function func with arguments `*args` and `**kwargs`,

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -177,7 +177,7 @@ def _get_cache_items(root_path):
 
 
 def _get_cache_items_to_delete(root_path, bytes_limit):
-    """Get cache items to delete to keep the cache under a size limit"""
+    """Get cache items to delete to keep the cache under a size limit."""
     if isinstance(bytes_limit, _basestring):
         bytes_limit = memstr_to_bytes(bytes_limit)
 
@@ -188,6 +188,8 @@ def _get_cache_items_to_delete(root_path, bytes_limit):
     if to_delete_size < 0:
         return []
 
+    # We want to delete first the cache items that were accessed a
+    # long time ago
     cache_items.sort(key=operator.attrgetter('last_access'))
 
     cache_items_to_delete = []
@@ -936,6 +938,7 @@ class Memory(Logger):
             rm_subdirs(self.cachedir)
 
     def reduce_size(self):
+        """Removes cache foldes until cache size is less than ``bytes_limit``."""
         if self.cachedir is not None and self.bytes_limit is not None:
             cache_items_to_delete = _get_cache_items_to_delete(
                 self.cachedir, self.bytes_limit)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -16,7 +16,6 @@ import io
 import sys
 import time
 import datetime
-import random
 
 import nose
 
@@ -849,30 +848,3 @@ def test_memory_reduce_size():
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
     nose.tools.assert_equal(cache_items, [])
-
-
-def test_memory_reduce_size_lru():
-    # Test that reduce_size is keeping its promise of LRU. Loading
-    # results from half of the cache items and making sure that they
-    # survive a reduce_size
-    n_inputs = 10
-    mem, full_cache_dirs, get_1000_bytes = \
-        _setup_temporary_cache_folder(n_inputs)
-    cachedir = mem.cachedir
-
-    # bytes_limit is set so that only half of the cache items are kept
-    mem.bytes_limit = (n_inputs + 1) * 1000 // 2
-
-    # Loading the results from the cache for half of the cache items
-    # (chosen at random)
-    inputs = random.sample(range(n_inputs), n_inputs // 2)
-    for arg in inputs:
-        get_1000_bytes(arg)
-
-    mem.reduce_size()
-
-    surviving_cache_items = _get_cache_items(cachedir)
-
-    nose.tools.assert_equal(
-        set(ci.path for ci in surviving_cache_items),
-        set(full_cache_dirs[inp] for inp in inputs))

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -22,7 +22,7 @@ import nose
 from joblib.memory import Memory, MemorizedFunc, NotMemorizedFunc
 from joblib.memory import MemorizedResult, NotMemorizedResult, _FUNCTION_HASHES
 from joblib.memory import _get_cache_items, _get_cache_items_to_delete
-from joblib.memory import _FUNCTION_HASHES, _load_output, _get_func_fullname
+from joblib.memory import _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
 from joblib.testing import assert_raises_regex
 from joblib._compat import PY3_OR_LATER


### PR DESCRIPTION
This is the first step in having a cache replacement policy in joblib whose main goal is to avoid cache folders to grow and eventually fill the disk. See the [initial issue](https://github.com/joblib/joblib/issues/85) with additional details.

Still need to be done:
- [ ] documentation. I will do that once the rest of this PR has matured.

Caveats or more controversial things on the todo list:
- [ ] how to test multiprocessing things in the tests. Some race conditions I bumped into needed something like 2 minutes to be triggered on average (essentially multiple processes trying to reduce the size of the same cache folder)
- [ ]  Only hash-level folders are cleaned. That could mean that the function-level folder remain forever. This is not really important in terms of cache size but a bit untidy. It is probably doable to fix this though although that may introduce additional race conditions, not sure.
- [ ] `shutil.rmtree(ignore_errors=True)` is the main way we achieve "robustness" (i.e. what happens if we are trying to remove a cache folder while another process is writing into it). I am not sure how likely it is that part of unused cache lies around for some period of time. Probably worth investigating on real-life caches after a while.