### PR TITLE
[MRG+1] Replace memstr_to_kbytes by memstr_to_bytes that return size in bytes

### DIFF
--- a/joblib/disk.py
+++ b/joblib/disk.py
@@ -31,18 +31,17 @@ def disk_used(path):
     return int(size / 1024.)
 
 
-def memstr_to_kbytes(text):
-    """ Convert a memory text to it's value in kilobytes.
+def memstr_to_bytes(text):
+    """ Convert a memory text to its value in bytes.
     """
     kilo = 1024
-    units = dict(K=1, M=kilo, G=kilo ** 2)
+    units = dict(K=kilo, M=kilo ** 2, G=kilo ** 3)
     try:
         size = int(units[text[-1]] * float(text[:-1]))
     except (KeyError, ValueError):
         raise ValueError(
-                "Invalid literal for size give: %s (type %s) should be "
-                "alike '10G', '500M', '50K'." % (text, type(text))
-                )
+            "Invalid literal for size give: %s (type %s) should be "
+            "alike '10G', '500M', '50K'." % (text, type(text)))
     return size
 
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -26,7 +26,7 @@ from ._multiprocessing_helpers import mp
 from .format_stack import format_outer_frames
 from .logger import Logger, short_format_time
 from .my_exceptions import TransportableException, _mk_exception
-from .disk import memstr_to_kbytes
+from .disk import memstr_to_bytes
 from ._parallel_backends import (FallbackToBackend, MultiprocessingBackend,
                                  ThreadingBackend, SequentialBackend)
 from ._compat import _basestring
@@ -472,7 +472,7 @@ class Parallel(Logger):
         self.pre_dispatch = pre_dispatch
 
         if isinstance(max_nbytes, _basestring):
-            max_nbytes = 1024 * memstr_to_kbytes(max_nbytes)
+            max_nbytes = memstr_to_bytes(max_nbytes)
 
         self._backend_args = dict(
             max_nbytes=max_nbytes,

--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -16,7 +16,7 @@ from tempfile import mkdtemp
 
 import nose
 
-from joblib.disk import disk_used, memstr_to_kbytes, mkdirp
+from joblib.disk import disk_used, memstr_to_bytes, mkdirp
 
 
 ###############################################################################
@@ -43,12 +43,13 @@ def test_disk_used():
         shutil.rmtree(cachedir)
 
 
-def test_memstr_to_kbytes():
+def test_memstr_to_bytes():
     for text, value in zip(('80G', '1.4M', '120M', '53K'),
-                           (80 * 1024 ** 2, int(1.4 * 1024), 120 * 1024, 53)):
-        yield nose.tools.assert_equal, memstr_to_kbytes(text), value
+                           (80 * 1024 ** 3, int(1.4 * 1024 ** 2),
+                            120 * 1024 ** 2, 53 * 1024)):
+        yield nose.tools.assert_equal, memstr_to_bytes(text), value
 
-    nose.tools.assert_raises(ValueError, memstr_to_kbytes, 'foobar')
+    nose.tools.assert_raises(ValueError, memstr_to_bytes, 'foobar')
 
 
 def test_mkdirp():


### PR DESCRIPTION
The only usage I could find was actually converting in bytes by doing `1024 * memstr_to_kbytes`.

Any objections?

Full disclosure I am using memstr_to_(k)bytes in the lru-cache PR which is why I bumped into this.