### PR TITLE
Explicit handling of job cancellation on first collected exception

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -675,7 +675,10 @@ class Parallel(Logger):
                     self._output.extend(job.get(timeout=self.timeout))
                 else:
                     self._output.extend(job.get())
-            except Exception as exception:
+            except BaseException as exception:
+                # Note: we catch any BaseException instead of just Exception
+                # instances to also include KeyboardInterrupt.
+
                 # Stop dispatching any new job in the async callback thread
                 self._aborting = True
 


### PR DESCRIPTION
This adds an explicit way to cancel submitted tasks when an exception is raised. This is useful to clean up the queues of some backends such as distributed.

It also simplifies the handling of exceptions in general.
