### PR TITLE
DOC: update joblib installation procedure in the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,11 +15,15 @@ of the latest code: http://github.com/joblib/joblib/archives/master
 Installing
 =========================
 
-As any Python packages, to install joblib, simply do::
+As most of pure Python packages, to install joblib, simply do::
 
-    python setup.py install
+    pip install joblib
 
-in the source code directory.
+from any directory or
+
+    pip install -e .
+
+from the source directory.
 
 Joblib has no other mandatory dependency than Python (supported
 versions are 2.6+ and 3.3+). Numpy (at least version 1.6.1) is an

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ As most of pure Python packages, to install joblib, simply do::
 
 from any directory or
 
-    pip install -e .
+    pip install .
 
 from the source directory.
 

--- a/README.rst
+++ b/README.rst
@@ -15,13 +15,13 @@ of the latest code: http://github.com/joblib/joblib/archives/master
 Installing
 =========================
 
-As most of pure Python packages, to install joblib, simply do::
+You can use `pip` to install joblib::
 
     pip install joblib
 
 from any directory or
 
-    pip install .
+    python setup.py install
 
 from the source directory.
 

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -2,7 +2,7 @@ Installing joblib
 ===================
 
 Using `pip`
------------
+------------
 
 You can use `pip` to install joblib::
 
@@ -22,6 +22,14 @@ You can use `pip` to install joblib::
 
     pip install --user joblib
 
+Using distributions
+--------------------
+
+Joblib is packaged for several linux distribution: archlinux, debian,
+ubuntu, altlinux, and fedora. For minimum administration overhead, using the
+package manager is the recommended installation strategy on these
+systems.
+
 The manual way
 ---------------
 
@@ -38,7 +46,7 @@ the changes are local to your account and easy to clean up.
 Simply move to the directory created by expanding the `joblib` tarball
 and run the following command::
 
-    pip install . --user
+    python setup.py install --user
 
 Installing for all users
 ........................
@@ -47,9 +55,9 @@ If you have administrator rights and want to install for all users, all
 you need to do is to go in directory created by expanding the `joblib`
 tarball and run the following line::
 
-    pip install .
+    python setup.py install
 
 If you are under Unix, we suggest that you install in '/usr/local' in
 order not to interfere with your system::
 
-    pip install --prefix /usr/local
+    python setup.py install --prefix /usr/local

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -4,7 +4,7 @@ Installing joblib
 Using `pip`
 -----------
 
-The easiest way to install joblib is to use `pip`:
+The easiest way to install joblib is to use `pip`::
 
 * For installing for all users, you need to run::
 
@@ -25,22 +25,11 @@ The easiest way to install joblib is to use `pip`:
 Using `conda`
 -------------
 
-Simply run the following command:
+The latest version is already available with conda on the `conda-forge`
+channel.
+To install Joblib using `conda`, simply run the following command::
 
-    conda install joblib
-
-.. warning::
-
-    The joblib version provided by `conda` might be older than the one shipped by
-    `pip`. Thus `pip` is the recommended way for installing joblib.
-
-Using distributions
---------------------
-
-Joblib is packaged for several linux distribution: archlinux, debian,
-ubuntu, altlinux, and fedora. For minimum administration overhead, using the
-package manager is the recommended installation strategy on these
-systems.
+    conda install --channel conda-forge joblib
 
 The manual way
 ---------------

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -1,34 +1,38 @@
 Installing joblib
 ===================
 
-The `easy_install` way
------------------------
+Using `pip`
+-----------
 
-For the easiest way to install joblib you need to have `setuptools`
-installed.
+The easiest way to install joblib is to use `pip`:
 
 * For installing for all users, you need to run::
 
-    easy_install joblib
+    pip install joblib
 
   You may need to run the above command as administrator
 
   On a unix environment, it is better to install outside of the hierarchy
   managed by the system::
 
-    easy_install --prefix /usr/local joblib
+    pip install --prefix /usr/local joblib
 
 * Installing only for a specific user is easy if you use Python 2.6 or
   above::
 
-    easy_install --user joblib
+    pip install --user joblib
+
+Using `conda`
+-------------
+
+Simply run the following command:
+
+    conda install joblib
 
 .. warning::
 
-    Packages installed via `easy_install` override the Python module look
-    up mechanism and thus can confused people not familiar with
-    setuptools. Although it may seem harder, we suggest that you use the
-    manual way, as described in the following paragraph.
+    The joblib version provided by `conda` might be older than the one shipped by
+    `pip`. Thus `pip` is the recommended way for installing joblib.
 
 Using distributions
 --------------------
@@ -54,7 +58,7 @@ the changes are local to your account and easy to clean up.
 Simply move to the directory created by expanding the `joblib` tarball
 and run the following command::
 
-    python setup.py install --user
+    pip install -e . --user
 
 Installing for all users
 ........................
@@ -63,9 +67,9 @@ If you have administrator rights and want to install for all users, all
 you need to do is to go in directory created by expanding the `joblib`
 tarball and run the following line::
 
-    python setup.py install
+    pip install -e .
 
 If you are under Unix, we suggest that you install in '/usr/local' in
 order not to interfere with your system::
 
-    python setup.py install --prefix /usr/local
+    pip install -e --prefix /usr/local

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -4,7 +4,7 @@ Installing joblib
 Using `pip`
 -----------
 
-The easiest way to install joblib is to use `pip`::
+You can use `pip` to install joblib::
 
 * For installing for all users, you need to run::
 
@@ -22,15 +22,6 @@ The easiest way to install joblib is to use `pip`::
 
     pip install --user joblib
 
-Using `conda`
--------------
-
-The latest version is already available with conda on the `conda-forge`
-channel.
-To install Joblib using `conda`, simply run the following command::
-
-    conda install --channel conda-forge joblib
-
 The manual way
 ---------------
 
@@ -47,7 +38,7 @@ the changes are local to your account and easy to clean up.
 Simply move to the directory created by expanding the `joblib` tarball
 and run the following command::
 
-    pip install -e . --user
+    pip install . --user
 
 Installing for all users
 ........................
@@ -56,9 +47,9 @@ If you have administrator rights and want to install for all users, all
 you need to do is to go in directory created by expanding the `joblib`
 tarball and run the following line::
 
-    pip install -e .
+    pip install .
 
 If you are under Unix, we suggest that you install in '/usr/local' in
 order not to interfere with your system::
 
-    pip install -e --prefix /usr/local
+    pip install --prefix /usr/local


### PR DESCRIPTION
Update installation procedure in the documentation. I think everyone now uses `pip` or `conda`. Fix #339.