### PR TITLE
TST: add test that checks compression files generated by joblib.dump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # make it explicit that we favor the new container-based travis workers
-sudo: false
+sudo: true
 
 language: python
 
@@ -14,6 +14,12 @@ env:
     - PYTHON_VERSION="3.5" NUMPY_VERSION="1.10" COVERAGE="true"
     # flake8 linting on diff wrt common ancestor with upstream/master
     - PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
+
+before_install:
+  - sudo apt-get -qq update
+  # qpdf contains the zlib-flate command used to decompress zlib pickle
+  - sudo apt-get install -y gzip qpdf
+
 
 install:
     - source continuous_integration/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # make it explicit that we favor the new container-based travis workers
-sudo: true
+sudo: false
 
 language: python
 
@@ -14,12 +14,6 @@ env:
     - PYTHON_VERSION="3.5" NUMPY_VERSION="1.10" COVERAGE="true"
     # flake8 linting on diff wrt common ancestor with upstream/master
     - PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
-
-before_install:
-  - sudo apt-get -qq update
-  # qpdf contains the zlib-flate command used to decompress zlib pickle
-  - sudo apt-get install -y gzip qpdf
-
 
 install:
     - source continuous_integration/install.sh

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -8,13 +8,12 @@ import random
 import sys
 import re
 import tempfile
-import glob
 import io
 import warnings
 import nose
 import gzip
 import zlib
-from distutils.spawn import find_executable
+from contextlib import closing
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_memory_profiler, memory_used
@@ -603,7 +602,7 @@ def test_joblib_compression_formats():
 
 def _decompress_gzip(filename):
     """Decompress a gzip file."""
-    with gzip.GzipFile(filename + ".gz", "rb") as fo:
+    with closing(gzip.GzipFile(filename + ".gz", "rb")) as fo:
         buf = fo.read()
 
     with open(filename, "wb") as fo:

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -600,21 +600,21 @@ def test_joblib_compression_formats():
                     os.remove(dump_filename)
 
 
-def _decompress_gzip(filename):
+def _gzip_file_decompress(source_filename, target_filename):
     """Decompress a gzip file."""
-    with closing(gzip.GzipFile(filename + ".gz", "rb")) as fo:
+    with closing(gzip.GzipFile(source_filename, "rb")) as fo:
         buf = fo.read()
 
-    with open(filename, "wb") as fo:
+    with open(target_filename, "wb") as fo:
         fo.write(buf)
 
 
-def _decompress_zlib(filename):
+def _zlib_file_decompress(source_filename, target_filename):
     """Decompress a zlib file."""
-    with open(filename + ".z", 'rb') as fo:
+    with open(source_filename, 'rb') as fo:
         buf = zlib.decompress(fo.read())
 
-    with open(filename, 'wb') as fo:
+    with open(target_filename, 'wb') as fo:
         fo.write(buf)
 
 
@@ -622,17 +622,16 @@ def test_load_externally_decompressed_files():
     # Test that BinaryZlibFile generates valid gzip and zlib compressed files.
     obj = "a string to persist"
     filename_raw = env['filename'] + str(random.randint(0, 1000))
-    compress_list = (('.z', _decompress_zlib),
-                     ('.gz', _decompress_gzip))
+    compress_list = (('.z', _zlib_file_decompress),
+                     ('.gz', _gzip_file_decompress))
 
-    for extension, decompress_function in compress_list:
+    for extension, decompress in compress_list:
         filename_compressed = filename_raw + extension
         # Use automatic extension detection to compress with the right method.
         numpy_pickle.dump(obj, filename_compressed)
 
         # Decompress with the corresponding method
-        decompress_function(filename_raw)
-        nose.tools.assert_true(os.path.exists(filename_raw))
+        decompress(filename_compressed, filename_raw)
 
         # Test that the uncompressed pickle can be loaded and
         # that the result is correct.


### PR DESCRIPTION
The idea behind this test is to verify that pickle compressed with BinaryZlibFile object uses a valid `gzip` and `zlib` format. So the compressed pickle files can be uncompressed using regular command line tools and reloaded using `joblib.load`