### PR TITLE
FIX: persistence with pickle HIGHEST_PROTOCOL

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -267,7 +267,9 @@ class NumpyPickler(Pickler):
 
             # A framer was introduced with pickle protocol 4 and we want to
             # ensure the wrapper object is written before the numpy array
-            # buffer in the pickle byte stream.
+            # buffer in the pickle file.
+            # See https://www.python.org/dev/peps/pep-3154/#framing to get
+            # more information on the framer behavior.
             if self.proto >= 4:
                 self.framer.commit_frame(force=True)
 

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -224,7 +224,6 @@ class NumpyPickler(Pickler):
         if protocol is None:
             protocol = (pickle.DEFAULT_PROTOCOL if PY3_OR_LATER
                         else pickle.HIGHEST_PROTOCOL)
-        self.protocol = protocol
 
         Pickler.__init__(self, self.file_handle, protocol=protocol)
         # delayed import of numpy, to avoid tight coupling
@@ -264,13 +263,12 @@ class NumpyPickler(Pickler):
 
             # The array wrapper is pickled instead of the real array.
             wrapper = self._create_array_wrapper(obj)
-
             Pickler.save(self, wrapper)
 
             # A framer was introduced with pickle protocol 4 and we want to
             # ensure the wrapper object is written before the numpy array
             # buffer in the pickle byte stream.
-            if self.protocol >= 4:
+            if self.proto >= 4:
                 self.framer.commit_frame(force=True)
 
             # And then array bytes are written right after the wrapper.

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -13,6 +13,7 @@ import warnings
 import nose
 import gzip
 import zlib
+import pickle
 from contextlib import closing
 
 from joblib.test.common import np, with_numpy
@@ -821,3 +822,17 @@ def test_non_contiguous_array_pickling():
         array_reloaded = numpy_pickle.load(filename)
         np.testing.assert_array_equal(array_reloaded, array)
         os.remove(filename)
+
+
+@with_numpy
+def test_pickle_highest_protocol():
+    # ensure persistence is valid when using the pickle HIGHEST_PROTOCOL.
+    # see https://github.com/joblib/joblib/issues/362
+
+    filename = env['filename'] + str(random.randint(0, 1000))
+    test_array = np.zeros((1, 235), np.uint32)
+
+    numpy_pickle.dump(test_array, filename, protocol=pickle.HIGHEST_PROTOCOL)
+    array_reloaded = numpy_pickle.load(filename)
+
+    np.testing.assert_array_equal(array_reloaded, test_array)

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -826,11 +826,12 @@ def test_non_contiguous_array_pickling():
 
 @with_numpy
 def test_pickle_highest_protocol():
-    # ensure persistence is valid when using the pickle HIGHEST_PROTOCOL.
+    # ensure persistence of a numpy array is valid even when using
+    # the pickle HIGHEST_PROTOCOL.
     # see https://github.com/joblib/joblib/issues/362
 
     filename = env['filename'] + str(random.randint(0, 1000))
-    test_array = np.zeros((1, 235), np.uint32)
+    test_array = np.zeros(10)
 
     numpy_pickle.dump(test_array, filename, protocol=pickle.HIGHEST_PROTOCOL)
     array_reloaded = numpy_pickle.load(filename)


### PR DESCRIPTION
Should fix #362.

With pickle protocol 4, the Pickler uses a framer member object to avoid committing bytes too often. With the joblib hack, which consists in writing a numpy wrapper object __before__ the array buffer (see [here](https://github.com/joblib/joblib/blob/master/joblib/numpy_pickle.py#L266)), the new framer was delaying the actual write of the wrapper after the array buffer is written in the file.

The fix consists in forcing the commit of bytes using the framer member of the pickler. A non regression test is there as well.