### PR TITLE
[MRG+1] Improve flake8_diff.sh

### DIFF
--- a/continuous_integration/flake8_diff.sh
+++ b/continuous_integration/flake8_diff.sh
@@ -1,28 +1,57 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-# Travis does the git clone with a limited depth (50 at the time of
-# writing). This may not be enough to find the common ancestor with
-# $REMOTE/master so we unshallow the git checkout
-git fetch --unshallow || echo "Unshallowing the git checkout failed"
+PROJECT=joblib/joblib
+PROJECT_URL=https://github.com/$PROJECT.git
 
-# Tackle both common cases of origin and upstream as remote
-# Note: upstream has priority if it exists
-git remote -v
-git remote | grep upstream && REMOTE=upstream || REMOTE=origin
-# Make sure that $REMOTE/master is set
-git remote set-branches --add $REMOTE master
-git fetch $REMOTE master
-REMOTE_MASTER_REF="$REMOTE/master"
+echo "Remotes:"
+git remote --verbose
+
+# Find the remote with the project name (upstream in most cases)
+REMOTE=$(git remote -v | grep $PROJECT | cut -f1 | head -1)
+
+# Add a temporary remote if needed. For example this is necessary when
+# Travis is configured to run in a fork. In this case 'origin' is the
+# fork and not the reference repo we want to diff against.
+if [[ -z "$REMOTE" ]]; then
+    TMP_REMOTE=tmp_reference_upstream
+    REMOTE=$TMP_REMOTE
+    git remote add $REMOTE $PROJECT_URL
+fi
+
+if [[ "$TRAVIS" == "true" ]]; then
+    if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
+    then
+        # Travis does the git clone with a limited depth (50 at the time of
+        # writing). This may not be enough to find the common ancestor with
+        # $REMOTE/master so we unshallow the git checkout
+        git fetch --unshallow || echo "Unshallowing the git checkout failed"
+    else
+        # We want to fetch the code as it is in the PR branch and not
+        # the result of the merge into master. This way line numbers
+        # reported by Travis will match with the local code.
+        BRANCH_NAME=travis_pr_$TRAVIS_PULL_REQUEST
+        git fetch $REMOTE pull/$TRAVIS_PULL_REQUEST/head:$BRANCH_NAME
+        git checkout $BRANCH_NAME
+    fi
+fi
+
 
 echo -e '\nLast 2 commits:'
 echo '--------------------------------------------------------------------------------'
 git log -2 --pretty=short
 
+git fetch $REMOTE master
+REMOTE_MASTER_REF="$REMOTE/master"
+
 # Find common ancestor between HEAD and remotes/$REMOTE/master
 COMMIT=$(git merge-base @ $REMOTE_MASTER_REF) || \
     echo "No common ancestor found for $(git show @ -q) and $(git show $REMOTE_MASTER_REF -q)"
+
+if [[ -n "$TMP_REMOTE" ]]; then
+    git remote remove $TMP_REMOTE
+fi
 
 if [ -z "$COMMIT" ]; then
     exit 1
@@ -39,4 +68,5 @@ echo '--------------------------------------------------------------------------
 
 # Conservative approach: diff without context so that code that was
 # not changed does not create failures
-git diff --unified=0 $COMMIT | flake8 --diff && echo -e "No problem detected by flake8\n"
+git diff --unified=0 $COMMIT | flake8 --diff --show-source
+echo -e "No problem detected by flake8\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,3 @@ universal=1
 # http://pep8.readthedocs.org/en/latest/intro.html#error-codes
 # E402: module level import not at top of file
 ignore=E402
-# __init__.py is full of "imported but unused" F401 errors which we don't care
-# we exclude this file on purpose.
-exclude = joblib/__init__.py


### PR DESCRIPTION
Improvements:
* on a PR it runs on the PR branch rather than on the result of
  the merge.
* runs fine in a branch configured to be trigger a Travis build
* better mechanism for finding the REMOTE to diff against
* it shows the source together with the PEP8 violation

Also ignoring `joblib/__init__.py` in setup.cfg is not necessary anymore since we are not showing any context.
