### PR TITLE
[MRG+1] Avoid deprecation from inspect.getargspec()

### DIFF
--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -433,7 +433,7 @@ class FunctionDoc(NumpyDocString):
                    argspec = inspect.getargspec(func)
                 else:
                    # getargspec deprecated in python3
-                argspec = inspect.getargspec(func)
+                   argspec = inspect.getargspec(func)
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')
                 signature = '%s%s' % (func_name, argspec)

--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -6,6 +6,7 @@ import inspect
 import textwrap
 import re
 import pydoc
+import sys
 from warnings import warn
 
 
@@ -428,6 +429,10 @@ class FunctionDoc(NumpyDocString):
             func, func_name = self.get_func()
             try:
                 # try to read signature
+                if 3 > sys.version_info[0]:
+                   argspec = inspect.getargspec(func)
+                else:
+                   # getargspec deprecated in python3
                 argspec = inspect.getargspec(func)
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')

--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -430,10 +430,10 @@ class FunctionDoc(NumpyDocString):
             try:
                 # try to read signature
                 if 3 > sys.version_info[0]:
-                   argspec = inspect.getargspec(func)
+                    argspec = inspect.getargspec(func)
                 else:
-                   # getargspec deprecated in python3
-                   argspec = inspect.getargspec(func)
+                    # getargspec deprecated in python3
+                    argspec = inspect.getargspec(func)
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')
                 signature = '%s%s' % (func_name, argspec)

--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -433,7 +433,7 @@ class FunctionDoc(NumpyDocString):
                     argspec = inspect.getargspec(func)
                 else:
                     # getargspec deprecated in python3
-                    argspec = inspect.getargspec(func)
+                    argspec = inspect.signature(func)
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')
                 signature = '%s%s' % (func_name, argspec)

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -171,10 +171,10 @@ def getfullargspec(func):
         return inspect.getfullargspec(func)
     except AttributeError:
         if 3 > sys.version_info[0]:
-           argspec = inspect.getargspec(func)
+           arg_spec = inspect.getargspec(func)
         else:
            # getargspec deprecated in python3
-           argspec = inspect.signature(func)
+           arg_spec = inspect.signature(func)
         import collections
         tuple_fields = ('args varargs varkw defaults kwonlyargs '
                         'kwonlydefaults annotations')

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -11,6 +11,7 @@ import inspect
 import warnings
 import re
 import os
+import sys
 
 from ._compat import _basestring
 from .logger import pformat
@@ -169,7 +170,11 @@ def getfullargspec(func):
     try:
         return inspect.getfullargspec(func)
     except AttributeError:
-        arg_spec = inspect.getargspec(func)
+        if 3 > sys.version_info[0]:
+           argspec = inspect.getargspec(func)
+        else:
+           # getargspec deprecated in python3
+           argspec = inspect.signature(func)
         import collections
         tuple_fields = ('args varargs varkw defaults kwonlyargs '
                         'kwonlydefaults annotations')

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -171,10 +171,10 @@ def getfullargspec(func):
         return inspect.getfullargspec(func)
     except AttributeError:
         if 3 > sys.version_info[0]:
-           arg_spec = inspect.getargspec(func)
+            arg_spec = inspect.getargspec(func)
         else:
-           # getargspec deprecated in python3
-           arg_spec = inspect.signature(func)
+            # getargspec deprecated in python3
+            arg_spec = inspect.signature(func)
         import collections
         tuple_fields = ('args varargs varkw defaults kwonlyargs '
                         'kwonlydefaults annotations')

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -227,10 +227,6 @@ def test_memory_name_collision():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
-        # This is a temporary workaround until we get rid of
-        # inspect.getargspec, see
-        # https://github.com/joblib/joblib/issues/247
-        warnings.simplefilter("ignore", DeprecationWarning)
         a(1)
         b(1)
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -247,10 +247,6 @@ def test_memory_warning_lambda_collisions():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
-        # This is a temporary workaround until we get rid of
-        # inspect.getargspec, see
-        # https://github.com/joblib/joblib/issues/247
-        warnings.simplefilter("ignore", DeprecationWarning)
         nose.tools.assert_equal(0, a(0))
         nose.tools.assert_equal(2, b(1))
         nose.tools.assert_equal(1, a(1))
@@ -278,10 +274,6 @@ def test_memory_warning_collision_detection():
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
-        # This is a temporary workaround until we get rid of
-        # inspect.getargspec, see
-        # https://github.com/joblib/joblib/issues/247
-        warnings.simplefilter("ignore", DeprecationWarning)
         a1(1)
         b1(1)
         a1(0)


### PR DESCRIPTION
This change fixes the need to filter DeprecationWarning for inspect.getargspec().

This was fixed for scikit-learn which uses a local copy of joblib. @amueller recommended pushing fix to joblib.