### PR TITLE
[MRG+1] Fix format_stack with compiled code (e.g. .so or .pyd) in the traceback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Latest changes
 ===============
 
+Release 0.10.1
+--------------
+
+Loïc Estève
+
+    FIX a bug in stack formatting when the error happens in a compiled
+    extension. See https://github.com/joblib/joblib/pull/382 for more
+    details.
+
 Release 0.10.0
 --------------
 

--- a/joblib/format_stack.py
+++ b/joblib/format_stack.py
@@ -273,8 +273,10 @@ def format_records(records):   # , print_globals=False):
             # enclosing scope.
             for token in generate_tokens(linereader):
                 tokeneater(*token)
-        except (IndexError, UnicodeDecodeError):
+        except (IndexError, UnicodeDecodeError, SyntaxError):
             # signals exit of tokenizer
+            # SyntaxError can happen when trying to tokenize
+            # a compiled (e.g. .so or .pyd) extension
             pass
         except tokenize.TokenError as msg:
             _m = ("An unexpected error occurred while tokenizing input file %s\n"


### PR DESCRIPTION
Fixes #101.

Took the fix from IPython.core.ultratb.py