### PR TITLE
[numpy_pick_utils] BinaryZlibFile couldn't handle unicode filenames.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ Loïc Estève
     extension. See https://github.com/joblib/joblib/pull/382 for more
     details.
 
+Vincent Latrouite
+
+    FIX a bug in the constructor of BinaryZlibFile that would throw an
+    exception when passing unicode filename.
+    See https://github.com/joblib/joblib/pull/384 for more details.
+
 Release 0.10.0
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Loïc Estève
 Vincent Latrouite
 
     FIX a bug in the constructor of BinaryZlibFile that would throw an
-    exception when passing unicode filename.
+    exception when passing unicode filename (Python 2 only).
     See https://github.com/joblib/joblib/pull/384 for more details.
 
 Release 0.10.0

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -14,7 +14,7 @@ import warnings
 import contextlib
 from contextlib import closing
 
-from ._compat import PY3_OR_LATER, PY26, PY27
+from ._compat import PY3_OR_LATER, PY26, PY27, _bytes_or_unicode
 
 try:
     from threading import RLock
@@ -299,7 +299,7 @@ class BinaryZlibFile(io.BufferedIOBase):
         else:
             raise ValueError("Invalid mode: %r" % (mode,))
 
-        if isinstance(filename, (str, bytes, (sys.version_info < (3,) and unicode) or str)):
+        if isinstance(filename, _bytes_or_unicode):
             self._fp = open(filename, mode)
             self._closefp = True
             self._mode = mode_code

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -299,7 +299,7 @@ class BinaryZlibFile(io.BufferedIOBase):
         else:
             raise ValueError("Invalid mode: %r" % (mode,))
 
-        if isinstance(filename, (str, bytes)):
+        if isinstance(filename, (str, bytes, unicode)):
             self._fp = open(filename, mode)
             self._closefp = True
             self._mode = mode_code

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -14,7 +14,7 @@ import warnings
 import contextlib
 from contextlib import closing
 
-from ._compat import PY3_OR_LATER, PY26, PY27, _bytes_or_unicode
+from ._compat import PY3_OR_LATER, PY26, PY27, _basestring
 
 try:
     from threading import RLock
@@ -299,7 +299,7 @@ class BinaryZlibFile(io.BufferedIOBase):
         else:
             raise ValueError("Invalid mode: %r" % (mode,))
 
-        if isinstance(filename, _bytes_or_unicode):
+        if isinstance(filename, (bytes, _basestring)):
             self._fp = open(filename, mode)
             self._closefp = True
             self._mode = mode_code

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -299,7 +299,7 @@ class BinaryZlibFile(io.BufferedIOBase):
         else:
             raise ValueError("Invalid mode: %r" % (mode,))
 
-        if isinstance(filename, (str, bytes, unicode)):
+        if isinstance(filename, (str, bytes, (sys.version_info < (3,) and unicode) or str)):
             self._fp = open(filename, mode)
             self._closefp = True
             self._mode = mode_code

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -299,7 +299,7 @@ class BinaryZlibFile(io.BufferedIOBase):
         else:
             raise ValueError("Invalid mode: %r" % (mode,))
 
-        if isinstance(filename, (bytes, _basestring)):
+        if isinstance(filename, _basestring):
             self._fp = open(filename, mode)
             self._closefp = True
             self._mode = mode_code

--- a/joblib/test/test_numpy_pickle_utils.py
+++ b/joblib/test/test_numpy_pickle_utils.py
@@ -1,6 +1,5 @@
 import shutil
 import os
-import random
 from tempfile import mkdtemp
 
 from joblib import numpy_pickle_utils
@@ -20,6 +19,7 @@ def setup_module():
 def teardown_module():
     """Test teardown."""
     shutil.rmtree(env['dir'])
+
 
 def test_binary_zlib_file():
     """Testing creation of files depending on the type of the filenames."""

--- a/joblib/test/test_numpy_pickle_utils.py
+++ b/joblib/test/test_numpy_pickle_utils.py
@@ -23,12 +23,6 @@ def teardown_module():
 
 def test_binary_zlib_file():
     """Testing creation of files depending on the type of the filenames."""
-    # Testing bytes filename.
-    binary_file = numpy_pickle_utils.BinaryZlibFile(
-        os.path.join(bytes(env['dir'].encode('utf-8')), b'test'),
-        mode='wb')
-    binary_file.close()
-
     # Testing str filename.
     binary_file = numpy_pickle_utils.BinaryZlibFile(
         os.path.join(env['dir'], 'test'),

--- a/joblib/test/test_numpy_pickle_utils.py
+++ b/joblib/test/test_numpy_pickle_utils.py
@@ -1,0 +1,42 @@
+import shutil
+import os
+import random
+from tempfile import mkdtemp
+
+from joblib import numpy_pickle_utils
+
+
+###############################################################################
+# Test fixtures
+
+env = dict()
+
+
+def setup_module():
+    """Test setup."""
+    env['dir'] = mkdtemp()
+
+
+def teardown_module():
+    """Test teardown."""
+    shutil.rmtree(env['dir'])
+
+def test_binary_zlib_file():
+    """Testing creation of files depending on the type of the filenames."""
+    # Testing bytes filename.
+    binary_file = numpy_pickle_utils.BinaryZlibFile(
+        os.path.join(bytes(env['dir'].encode('utf-8')), b'test'),
+        mode='wb')
+    binary_file.close()
+
+    # Testing str filename.
+    binary_file = numpy_pickle_utils.BinaryZlibFile(
+        os.path.join(env['dir'], 'test'),
+        mode='wb')
+    binary_file.close()
+
+    # Testing unicode filename.
+    binary_file = numpy_pickle_utils.BinaryZlibFile(
+        os.path.join(env['dir'], u'test'),
+        mode='wb')
+    binary_file.close()


### PR DESCRIPTION
Hi everyone,

It seems that BinaryZlibFile cannot handle unicode filenames in python2. I just added the unicode type to check, but it's not python3 compliant now I guess .. Does it need to be ? Is there a workaround otherwise to make it works for both py2 and py3 ?