### PR TITLE
MAINT: give version information in memory deprecation warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Olivier Grisel
     :class:`joblib.parallel.AutoBatchingMixin` in the public API to
     make them officially re-usable by backend implementers.
 
+Alexandre Abadie
+
+    Remove deprecated `format_signature`, `format_call` and `load_output`
+    functions from Memory API.
+
 
 Release 0.10.0
 --------------

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -491,13 +491,15 @@ class MemorizedFunc(Logger):
                 self.mmap_mode, self.compress, self._verbose))
 
     def format_signature(self, *args, **kwargs):
-        warnings.warn("MemorizedFunc.format_signature will be removed in a "
-                      "future version of joblib.", DeprecationWarning)
+        warnings.warn("MemorizedFunc.format_signature is deprecated since "
+                      "version 0.8 and will be removed after version 0.10",
+                      DeprecationWarning)
         return format_signature(self.func, *args, **kwargs)
 
     def format_call(self, *args, **kwargs):
-        warnings.warn("MemorizedFunc.format_call will be removed in a "
-                      "future version of joblib.", DeprecationWarning)
+        warnings.warn("MemorizedFunc.format_call is deprecated since "
+                      "version 0.8 and will be removed after version 0.10",
+                      DeprecationWarning)
         return format_call(self.func, args, kwargs)
 
     #-------------------------------------------------------------------------
@@ -754,9 +756,9 @@ class MemorizedFunc(Logger):
         """ Read the results of a previous calculation from the directory
             it was cached in.
         """
-        warnings.warn("MemorizedFunc.load_output is deprecated and will be "
-                      "removed in a future version\n"
-                      "of joblib. A MemorizedResult provides similar features",
+        warnings.warn("MemorizedFunc.load_output is deprecated since "
+                      "version 0.8 and will be removed after version 0.10.\n"
+                      "A MemorizedResult provides similar features",
                       DeprecationWarning)
         # No metadata available here.
         return _load_output(output_dir, _get_func_fullname(self.func),

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -490,18 +490,6 @@ class MemorizedFunc(Logger):
         return (self.__class__, (self.func, self.cachedir, self.ignore,
                 self.mmap_mode, self.compress, self._verbose))
 
-    def format_signature(self, *args, **kwargs):
-        warnings.warn("MemorizedFunc.format_signature is deprecated since "
-                      "version 0.8 and will be removed after version 0.10",
-                      DeprecationWarning)
-        return format_signature(self.func, *args, **kwargs)
-
-    def format_call(self, *args, **kwargs):
-        warnings.warn("MemorizedFunc.format_call is deprecated since "
-                      "version 0.8 and will be removed after version 0.10",
-                      DeprecationWarning)
-        return format_call(self.func, args, kwargs)
-
     #-------------------------------------------------------------------------
     # Private interface
     #-------------------------------------------------------------------------
@@ -751,19 +739,6 @@ class MemorizedFunc(Logger):
                           " example so that they can fix the problem."
                           % this_duration, stacklevel=5)
         return metadata
-
-    def load_output(self, output_dir):
-        """ Read the results of a previous calculation from the directory
-            it was cached in.
-        """
-        warnings.warn("MemorizedFunc.load_output is deprecated since "
-                      "version 0.8 and will be removed after version 0.10.\n"
-                      "A MemorizedResult provides similar features",
-                      DeprecationWarning)
-        # No metadata available here.
-        return _load_output(output_dir, _get_func_fullname(self.func),
-                            timestamp=self.timestamp,
-                            mmap_mode=self.mmap_mode, verbose=self._verbose)
 
     # XXX: Need a method to check if results are available.
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -18,8 +18,10 @@ import time
 
 import nose
 
-from joblib.memory import Memory, MemorizedFunc, NotMemorizedFunc, MemorizedResult
-from joblib.memory import NotMemorizedResult, _FUNCTION_HASHES
+from joblib.memory import Memory
+from joblib.memory import MemorizedFunc, NotMemorizedFunc
+from joblib.memory import MemorizedResult, NotMemorizedResult
+from joblib.memory import _FUNCTION_HASHES, _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
 from joblib.testing import assert_raises_regex
 from joblib._compat import PY3_OR_LATER
@@ -487,8 +489,13 @@ def test_persistence():
     # Test the memorized functions can be pickled and restored.
     memory = Memory(cachedir=env['dir'], verbose=0)
     g = memory.cache(f)
+    output = g(1)
 
-    output_dir, _ = g.get_output_dir(1)
+    h = pickle.loads(pickle.dumps(g))
+
+    output_dir, _ = h.get_output_dir(1)
+    func_name = _get_func_fullname(f)
+    yield nose.tools.assert_equal, output, _load_output(output_dir, func_name)
     memory2 = pickle.loads(pickle.dumps(memory))
     yield nose.tools.assert_equal, memory.cachedir, memory2.cachedir
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -487,12 +487,8 @@ def test_persistence():
     # Test the memorized functions can be pickled and restored.
     memory = Memory(cachedir=env['dir'], verbose=0)
     g = memory.cache(f)
-    output = g(1)
-
-    h = pickle.loads(pickle.dumps(g))
 
     output_dir, _ = g.get_output_dir(1)
-    yield nose.tools.assert_equal, output, h.load_output(output_dir)
     memory2 = pickle.loads(pickle.dumps(memory))
     yield nose.tools.assert_equal, memory.cachedir, memory2.cachedir
 
@@ -545,10 +541,6 @@ def test_memorized_repr():
     result2 = func2.call_and_shelve(2)
     nose.tools.assert_equal(result.get(), result2.get())
     nose.tools.assert_equal(repr(func), repr(func2))
-
-    # Smoke test on deprecated methods
-    func.format_signature(2)
-    func.format_call(2)
 
     # Smoke test with NotMemorizedFunc
     func = NotMemorizedFunc(f)


### PR DESCRIPTION
While working on a cache memory refactoring, I noticed that some DeprecationWarning were there since a long time (commit 59adb5e9 is present starting from version 0.8.0).
This PS is just meant to let people know of a future removal.