### PR TITLE
[MRG] simplify loading of compressed files

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -560,8 +560,10 @@ def load(filename, mmap_mode=None):
     if Path is not None and isinstance(filename, Path):
         filename = str(filename)
 
-    if hasattr(filename, "read") and hasattr(filename, "seek"):
-        with _read_fileobject(filename, "", mmap_mode) as fobj:
+    if hasattr(filename, "read"):
+        fobj = filename
+        filename = getattr(fobj, 'name', '')
+        with _read_fileobject(fobj, filename, mmap_mode) as fobj:
             obj = _unpickle(fobj)
     else:
         with open(filename, 'rb') as f:

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -82,7 +82,7 @@ def _is_raw_file(fileobj):
         fileobj = getattr(fileobj, 'raw', fileobj)
         return isinstance(fileobj, io.FileIO)
     else:
-        return isinstance(fileobj, file)
+        return isinstance(fileobj, file)  # noqa
 
 
 ###############################################################################

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -166,8 +166,12 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
     if isinstance(fileobj, tuple(_COMPRESSOR_CLASSES)):
         compressor = fileobj.__class__.__name__
     else:
-        # the fileobj is supported compressor classes, let's try to determine
-        # the compressor by reading the magic number.
+        # the fileobj is not part of the supported compressor classes
+        # let's try to determine the compressor by reading the magic number at
+        # the very beginning of the file.
+        if PY3_OR_LATER and not fileobj.seekable():
+            # With Python 3 file object have to be able to seek explicitely.
+            raise ValueError("Input fileobject must be seekable.")
         compressor = _detect_compressor(fileobj)
 
     if compressor == 'compat':

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -189,13 +189,9 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
                       DeprecationWarning, stacklevel=2)
         yield filename
     else:
-        # if the passed fileobj is in the supported list of decompressor
-        # objects (GzipFile, BZ2File, LzmaFile), we simply return it.
-        if isinstance(fileobj, tuple(_COMPRESSOR_CLASSES)):
-            pass
-        # otherwise, based on the compressor detected in the file, we open the
+        # based on the compressor detected in the file, we open the
         # correct decompressor file object, wrapped in a buffer.
-        elif compressor == 'zlib':
+        if compressor == 'zlib':
             fileobj = _buffered_read_file(BinaryZlibFile(fileobj, 'rb'))
         elif compressor == 'gzip':
             fileobj = _buffered_read_file(BinaryGzipFile(fileobj, 'rb'))

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -163,9 +163,13 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
 
     """
     # Detect if the fileobj contains compressed data.
-    compressor = _detect_compressor(fileobj)
     if isinstance(fileobj, tuple(_COMPRESSOR_CLASSES)):
         compressor = fileobj.__class__.__name__
+    else:
+        # the fileobj is supported compressor classes, let's try to determine
+        # the compressor by reading the magic number.
+        compressor = _detect_compressor(fileobj)
+
     if compressor == 'compat':
         # Compatibility with old pickle mode: simply return the input
         # filename "as-is" and let the compatibility function be called by the

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -76,6 +76,15 @@ _MAX_PREFIX_LEN = max(len(prefix)
 _IO_BUFFER_SIZE = 1024 ** 2
 
 
+def _is_raw_file(fileobj):
+    """Check if fileobj is a raw file object, e.g created with open."""
+    if PY3_OR_LATER:
+        fileobj = getattr(fileobj, 'raw', fileobj)
+        return isinstance(fileobj, io.FileIO)
+    else:
+        return isinstance(fileobj, file)
+
+
 ###############################################################################
 # Cache file utilities
 def _detect_compressor(fileobj):
@@ -89,10 +98,15 @@ def _detect_compressor(fileobj):
     -------
     str in {'zlib', 'gzip', 'bz2', 'lzma', 'xz', 'compat', 'not-compressed'}
     """
-    # Ensure we read the first bytes.
-    fileobj.seek(0)
-    first_bytes = fileobj.read(_MAX_PREFIX_LEN)
-    fileobj.seek(0)
+    # Read the magic number in the first bytes of the file.
+    if hasattr(fileobj, 'peek'):
+        # Peek allows to read those bytes without moving the cursor in the
+        # file whic.
+        first_bytes = fileobj.peek(_MAX_PREFIX_LEN)
+    else:
+        # Fallback to seek if the fileobject is not peekable.
+        first_bytes = fileobj.read(_MAX_PREFIX_LEN)
+        fileobj.seek(0)
 
     if first_bytes.startswith(_ZLIB_PREFIX):
         return "zlib"
@@ -163,16 +177,7 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
 
     """
     # Detect if the fileobj contains compressed data.
-    if isinstance(fileobj, tuple(_COMPRESSOR_CLASSES)):
-        compressor = fileobj.__class__.__name__
-    else:
-        # the fileobj is not part of the supported compressor classes
-        # let's try to determine the compressor by reading the magic number at
-        # the very beginning of the file.
-        if PY3_OR_LATER and not fileobj.seekable():
-            # With Python 3 file object have to be able to seek explicitely.
-            raise ValueError("Input fileobject must be seekable.")
-        compressor = _detect_compressor(fileobj)
+    compressor = _detect_compressor(fileobj)
 
     if compressor == 'compat':
         # Compatibility with old pickle mode: simply return the input
@@ -184,40 +189,23 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
                       DeprecationWarning, stacklevel=2)
         yield filename
     else:
-        # Checking if incompatible load parameters with the type of file:
-        # mmap_mode cannot be used with compressed file or in memory buffers
-        # such as io.BytesIO.
-        if ((compressor in _COMPRESSORS or
-                isinstance(fileobj, tuple(_COMPRESSOR_CLASSES))) and
-                mmap_mode is not None):
-            warnings.warn('File "%(filename)s" is compressed using '
-                          '"%(compressor)s" which is not compatible with '
-                          'mmap_mode "%(mmap_mode)s" flag passed. mmap_mode '
-                          'option will be ignored.'
-                          % locals(), stacklevel=2)
-        if isinstance(fileobj, io.BytesIO) and mmap_mode is not None:
-            warnings.warn('In memory persistence is not compatible with '
-                          'mmap_mode "%(mmap_mode)s" flag passed. mmap_mode '
-                          'option will be ignored.'
-                          % locals(), stacklevel=2)
-
         # if the passed fileobj is in the supported list of decompressor
         # objects (GzipFile, BZ2File, LzmaFile), we simply return it.
         if isinstance(fileobj, tuple(_COMPRESSOR_CLASSES)):
-            yield fileobj
+            pass
         # otherwise, based on the compressor detected in the file, we open the
         # correct decompressor file object, wrapped in a buffer.
         elif compressor == 'zlib':
-            yield _buffered_read_file(BinaryZlibFile(fileobj, 'rb'))
+            fileobj = _buffered_read_file(BinaryZlibFile(fileobj, 'rb'))
         elif compressor == 'gzip':
-            yield _buffered_read_file(BinaryGzipFile(fileobj, 'rb'))
+            fileobj = _buffered_read_file(BinaryGzipFile(fileobj, 'rb'))
         elif compressor == 'bz2' and bz2 is not None:
             if PY3_OR_LATER:
-                yield _buffered_read_file(bz2.BZ2File(fileobj, 'rb'))
+                fileobj = _buffered_read_file(bz2.BZ2File(fileobj, 'rb'))
             else:
                 # In python 2, BZ2File doesn't support a fileobj opened in
                 # binary mode. In this case, we pass the filename.
-                yield _buffered_read_file(bz2.BZ2File(fileobj.name, 'rb'))
+                fileobj = _buffered_read_file(bz2.BZ2File(fileobj.name, 'rb'))
         elif (compressor == 'lzma' or compressor == 'xz'):
             if PY3_OR_LATER and lzma is not None:
                 # We support lzma only in python 3 because in python 2 users
@@ -225,16 +213,33 @@ def _read_fileobject(fileobj, filename, mmap_mode=None):
                 # the lzma module, but that unfortunately doesn't fully support
                 # the buffer interface required by joblib.
                 # See https://github.com/joblib/joblib/issues/403 for details.
-                yield _buffered_read_file(lzma.LZMAFile(fileobj, 'rb'))
+                fileobj = _buffered_read_file(lzma.LZMAFile(fileobj, 'rb'))
             else:
                 raise NotImplementedError("Lzma decompression is not "
                                           "supported for this version of "
                                           "python ({0}.{1})"
                                           .format(sys.version_info[0],
                                                   sys.version_info[1]))
-        # No compression detected => returning the input file object (open)
-        else:
-            yield fileobj
+        # Checking if incompatible load parameters with the type of file:
+        # mmap_mode cannot be used with compressed file or in memory buffers
+        # such as io.BytesIO.
+        if mmap_mode is not None:
+            if isinstance(fileobj, io.BytesIO):
+                warnings.warn('In memory persistence is not compatible with '
+                              'mmap_mode "%(mmap_mode)s" flag passed. '
+                              'mmap_mode option will be ignored.'
+                              % locals(), stacklevel=2)
+            elif compressor != 'not-compressed':
+                warnings.warn('mmap_mode "%(mmap_mode)s" is not compatible '
+                              'with compressed file %(filename)s. '
+                              '"%(mmap_mode)s" flag will be ignored.'
+                              % locals(), stacklevel=2)
+            elif not _is_raw_file(fileobj):
+                warnings.warn('"%(fileobj)r" is not a raw file, mmap_mode '
+                              '"%(mmap_mode)s" flag will be ignored.'
+                              % locals(), stacklevel=2)
+
+        yield fileobj
 
 
 def _write_fileobject(filename, compress=("zlib", 3)):

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -337,13 +337,12 @@ def test_compress_mmap_mode_warning():
         for warn in caught_warnings:
             nose.tools.assert_equal(warn.category, UserWarning)
             nose.tools.assert_equal(warn.message.args[0],
-                                    'File "%(filename)s" is compressed using '
-                                    '"%(compressor)s" which is not compatible '
-                                    'with mmap_mode "%(mmap_mode)s" flag '
-                                    'passed. mmap_mode option will be '
-                                    'ignored.' % {'filename': this_filename,
-                                                  'mmap_mode': 'r+',
-                                                  'compressor': 'zlib'})
+                                    'mmap_mode "%(mmap_mode)s" is not '
+                                    'compatible with compressed file '
+                                    '%(filename)s. '
+                                    '"%(mmap_mode)s" flag will be ignored.'
+                                    % {'filename': this_filename,
+                                       'mmap_mode': 'r+'})
 
 
 @with_numpy
@@ -766,15 +765,10 @@ def test_file_handle_persistence_compressed_mmap():
             for warn in caught_warnings:
                 nose.tools.assert_equal(warn.category, UserWarning)
                 nose.tools.assert_equal(warn.message.args[0],
-                                        'File "%(filename)s" is compressed '
-                                        'using "%(compressor)s" which is not '
-                                        'compatible with mmap_mode '
-                                        '"%(mmap_mode)s" flag '
-                                        'passed. mmap_mode option will be '
-                                        'ignored.' %
-                                        {'filename': "",
-                                         'mmap_mode': 'r+',
-                                         'compressor': 'GzipFile'})
+                                        '"%(fileobj)r" is not a raw file, '
+                                        'mmap_mode "%(mmap_mode)s" flag will '
+                                        'be ignored.'
+                                        % {'fileobj': f, 'mmap_mode': 'r+'})
 
 
 @with_numpy
@@ -954,20 +948,3 @@ def test_pickle_highest_protocol():
     array_reloaded = numpy_pickle.load(filename)
 
     np.testing.assert_array_equal(array_reloaded, test_array)
-
-
-def test_pickling_in_non_seekable_fileobject_raise_error():
-    # input file object have to be seekable for joblib to determine the
-    # compression method.
-
-    def non_seekable():
-        return False
-
-    f = io.BytesIO(pickle.dumps("some bytes in a memory stream"))
-    # make this io stream non seekable.
-    f.seekable = non_seekable
-    if PY3_OR_LATER:
-        assert_raises_regex(ValueError, "Input fileobject must be seekable",
-                            numpy_pickle.load, f)
-    else:
-        numpy_pickle.load(f)

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -954,3 +954,20 @@ def test_pickle_highest_protocol():
     array_reloaded = numpy_pickle.load(filename)
 
     np.testing.assert_array_equal(array_reloaded, test_array)
+
+
+def test_pickling_in_non_seekable_fileobject_raise_error():
+    # input file object have to be seekable for joblib to determine the
+    # compression method.
+
+    def non_seekable():
+        return False
+
+    f = io.BytesIO(pickle.dumps("some bytes in a memory stream"))
+    # make this io stream non seekable.
+    f.seekable = non_seekable
+    if PY3_OR_LATER:
+        assert_raises_regex(ValueError, "Input fileobject must be seekable",
+                            numpy_pickle.load, f)
+    else:
+        numpy_pickle.load(f)


### PR DESCRIPTION
This is a small optimization. Maybe we could check if the passed fileobj is seekable before detecting the compressor and raise an error if it's not the case.

Related to #398.