### PR TITLE
Add a public is_cached method

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -356,6 +356,9 @@ class NotMemorizedFunc(object):
     def call_and_shelve(self, *args, **kwargs):
         return NotMemorizedResult(self.func(*args, **kwargs))
 
+    def is_cached(self, *args, **kwargs):
+        return False
+
     def __reduce__(self):
         return (self.__class__, (self.func,))
 

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -493,7 +493,7 @@ class MemorizedFunc(Logger):
         """
 
         if not (self._check_previous_func_code(stacklevel=4) and
-                                 os.path.exists(output_dir)):
+                os.path.exists(output_dir)):
             return False
         else:
             filename = os.path.join(output_dir, 'output.pkl')
@@ -546,7 +546,7 @@ class MemorizedFunc(Logger):
                 _, name = get_func_name(self.func)
                 self.warn('Computing func %s, argument hash %s in '
                           'directory %s'
-                        % (name, argument_hash, output_dir))
+                          % (name, argument_hash, output_dir))
             out, metadata = self.call(*args, **kwargs)
             if self.mmap_mode is not None:
                 # Memmap the output at the first call to be consistent with

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -480,11 +480,16 @@ class MemorizedFunc(Logger):
             Whether or not the call is already cached
         """
         output_dir, argument_hash = self._get_output_dir(*args, **kwargs)
-        return self._needs_call(output_dir, argument_hash)
+        return self._needs_call(output_dir)
 
-    def _needs_call(self, output_dir, argument_hash):
+    def _needs_call(self, output_dir):
         """Check if the function needs to be called or if its output can be
         loaded from cache
+
+        Parameters
+        ----------
+        output_dir: str
+            The directory in which this invokation's results are cached
 
         Returns
         -------
@@ -519,7 +524,7 @@ class MemorizedFunc(Logger):
         # function code has changed
         output_dir, argument_hash = self._get_output_dir(*args, **kwargs)
         metadata = None
-        if self._needs_call(output_dir, argument_hash):
+        if self._needs_call(output_dir):
             try:
                 t0 = time.time()
                 out = _load_output(output_dir, _get_func_fullname(self.func),

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -482,7 +482,7 @@ class MemorizedFunc(Logger):
         cached: bool
             Whether or not the call is already cached
         """
-        output_dir, argument_hash = self._get_output_dir(*args, **kwargs)
+        output_dir, _ = self._get_output_dir(*args, **kwargs)
         return self._needs_call(output_dir)
 
     def _needs_call(self, output_dir):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -507,6 +507,7 @@ def test_persistence():
     gp = pickle.loads(pickle.dumps(g))
     gp(1)
 
+
 def test_is_cached():
     # Test that is_cached can tell when function output is actually cached
     mem = Memory(cachedir=env['dir'], verbose=0)
@@ -523,11 +524,11 @@ def test_is_cached():
     # But with different arguments it shouldn't be
     yield nose.tools.assert_false, func.is_cached(2, 3)
 
-
     # Having cleared the cache the function should go back to being uncached
     func.clear()
     yield nose.tools.assert_false, func.is_cached(1)
     yield nose.tools.assert_false, func.is_cached(2, 3)
+ 
 
 def test_call_and_shelve():
     """Test MemorizedFunc outputting a reference to cache.

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -507,6 +507,27 @@ def test_persistence():
     gp = pickle.loads(pickle.dumps(g))
     gp(1)
 
+def test_is_cached():
+    # Test that is_cached can tell when function output is actually cached
+    mem = Memory(cachedir=env['dir'], verbose=0)
+    func = mem.cache(f)
+    func.clear()
+
+    # The function hasn't been called since the last clear so it's not cached
+    yield nose.tools.assert_false, func.is_cached(1)
+
+    # Now the function has been called so it should be cached
+    func(1)
+    yield nose.tools.assert_true, func.is_cached(1)
+
+    # But with different arguments it shouldn't be
+    yield nose.tools.assert_false, func.is_cached(2, 3)
+
+
+    # Having cleared the cache the function should go back to being uncached
+    func.clear()
+    yield nose.tools.assert_false, func.is_cached(1)
+    yield nose.tools.assert_false, func.is_cached(2, 3)
 
 def test_call_and_shelve():
     """Test MemorizedFunc outputting a reference to cache.

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -528,7 +528,7 @@ def test_is_cached():
     func.clear()
     yield nose.tools.assert_false, func.is_cached(1)
     yield nose.tools.assert_false, func.is_cached(2, 3)
- 
+
 
 def test_call_and_shelve():
     """Test MemorizedFunc outputting a reference to cache.


### PR DESCRIPTION
Make it so that client code can check if a call to a wrapped function will require the recomputation or if it can be loaded from disk.

My use case for this is allow a distributed system to more intelligently manage locks around the calculation of cache objects.
