### PR TITLE
[MRG+1] Fix tests when multiprocessing is disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - PYTHON_VERSION="3.4"
     - PYTHON_VERSION="3.5" NUMPY_VERSION="1.10" COVERAGE="true"
     # multiprocesssing disabled via the JOBLIB_MULTIPROCESSING environment variable
-    - PYTHON_VERSION="3.5" NUMPY_VERSION="1.10" COVERAGE="true" JOBLIB_MULTIPROCESSING=0
+    - PYTHON_VERSION="3.5" NUMPY_VERSION="1.10" JOBLIB_MULTIPROCESSING=0
     # flake8 linting on diff wrt common ancestor with upstream/master
     - SKIP_TESTS="true" FLAKE8_VERSION="*" PYTHON_VERSION="3.5"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
     # NUMPY_VERSION not set means numpy is not installed
     - PYTHON_VERSION="3.4"
     - PYTHON_VERSION="3.5" NUMPY_VERSION="1.10" COVERAGE="true"
+    # multiprocesssing disabled via the JOBLIB_MULTIPROCESSING environment variable
+    - PYTHON_VERSION="3.5" NUMPY_VERSION="1.10" COVERAGE="true" JOBLIB_MULTIPROCESSING=0
     # flake8 linting on diff wrt common ancestor with upstream/master
     - SKIP_TESTS="true" FLAKE8_VERSION="*" PYTHON_VERSION="3.5"
 

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -15,4 +15,6 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
         mv setup.cfg{.new,}
     fi
     make
+    # Run the tests again with multiprocessing disabled
+    JOBLIB_MULTIPROCESSING=0 make
 fi

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -15,6 +15,4 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
         mv setup.cfg{.new,}
     fi
     make
-    # Run the tests again with multiprocessing disabled
-    JOBLIB_MULTIPROCESSING=0 make
 fi

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -265,6 +265,9 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin,
         This also checks if we are attempting to create a nested parallel
         loop.
         """
+        if mp is None:
+            return 1
+
         if mp.current_process().daemon:
             # Daemonic processes cannot have children
             warnings.warn(

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -259,6 +259,7 @@ def test_parallel_timeout_success():
                 (delayed(sleep)(0.001) for x in range(10))))
 
 
+@with_multiprocessing
 def test_parallel_timeout_fail():
     # Check that timeout properly fails when function is too slow
     for backend in ['multiprocessing', 'threading']:
@@ -548,6 +549,7 @@ def check_backend_context_manager(backend_name):
             assert_equal(type(p._backend), FakeParallelBackend)
 
 
+@with_multiprocessing
 def test_backend_context_manager():
     all_test_backends = ['test_backend_%d' % i for i in range(3)]
     for test_backend in all_test_backends:
@@ -675,6 +677,7 @@ def test_dispatch_race_condition():
                                    pre_dispatch="2*n_jobs")
 
 
+@with_multiprocessing
 def test_default_mp_context():
     p = Parallel(n_jobs=2, backend='multiprocessing')
     context = p._backend_args.get('context')
@@ -695,6 +698,7 @@ def test_default_mp_context():
         assert_equal(context, None)
 
 
+@with_multiprocessing
 @with_numpy
 def test_no_blas_crash_or_freeze_with_multiprocessing():
     if sys.version_info < (3, 4):


### PR DESCRIPTION
From https://github.com/joblib/joblib/issues/391#issuecomment-250953533:

> I am observing first issue (AttributeError: 'NoneType' object has no attribute 'current_process') also while building fresh sklearn against the fresh joblib 0.10.2. To not starve build hosts I set JOBLIB_MULTIPROCESSING=0 which is just supposed to turn joblib multiprocessing off, while still performing the execution (worked e.g. with joblib 0.9.4 and before). Unfortunately logic in 0.10.2 seems to be flawed since if 0 it sets mp to None, but then without check tries to access its attributes.

> I guess it would be nice if there also was a test which would set this variable to 0 and attempts perform computation(s).