### PR TITLE
[MRG+1] make multiprocessing backend robust to main thread name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@ Loïc Estève
     parameter and then need to clean explicitly the cache via the
     ``Memory.reduce_size`` method.
 
+Olivier Grisel
+
+    Make the multiprocessing backend work even when the name of the main
+    thread is not the Python default. Thanks to Roman Yurchak for the
+    suggestion.
+
+
 Release 0.10.3
 --------------
 

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -277,10 +277,10 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin,
                     stacklevel=3)
             return 1
 
-        elif threading.current_thread().name != 'MainThread':
+        if not isinstance(threading.current_thread(), threading._MainThread):
             # Prevent posix fork inside in non-main posix threads
             warnings.warn(
-                'Multiprocessing backed parallel loops cannot be nested'
+                'Multiprocessing-backed parallel loops cannot be nested'
                 ' below threads, setting n_jobs=1',
                 stacklevel=3)
             return 1


### PR DESCRIPTION
This is to address the following comment:

https://github.com/joblib/joblib/issues/180#issuecomment-253266247