### PR TITLE
Catch only ImportErrors

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -18,7 +18,7 @@ from numbers import Integral
 from contextlib import contextmanager
 try:
     import cPickle as pickle
-except:
+except ImportError:
     import pickle
 
 from ._multiprocessing_helpers import mp

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -26,7 +26,7 @@ from time import sleep
 try:
     import cPickle as pickle
     PickleError = TypeError
-except:
+except ImportError:
     import pickle
     PickleError = pickle.PicklingError
 


### PR DESCRIPTION
Other exceptions should be raised rather than triggering the alternative
import.