### PR TITLE
[RFC] cpickle based dump/load

### DIFF
--- a/benchmarks/bench_pickle.py
+++ b/benchmarks/bench_pickle.py
@@ -11,6 +11,13 @@ import numpy as np
 import joblib
 import gc
 
+# Patch for benchmarking
+
+joblib.dump = joblib.dump2
+joblib.load = joblib.load2
+
+#
+
 from joblib.disk import disk_used
 
 try:

--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -124,6 +124,10 @@ from .logger import Logger
 from .hashing import hash
 from .numpy_pickle import dump
 from .numpy_pickle import load
+from .numpy_pickle_v2 import dump as dump2
+from .numpy_pickle_v2 import load as load2
+from .numpy_pickle_v2 import dump
+from .numpy_pickle_v2 import load
 from .parallel import Parallel
 from .parallel import delayed
 from .parallel import cpu_count

--- a/joblib/numpy_pickle_v2.py
+++ b/joblib/numpy_pickle_v2.py
@@ -12,8 +12,6 @@ import warnings
 from functools import partial
 from os.path import split, splitext, dirname, abspath, join
 
-import IPython
-
 try:
     from pathlib import Path
 except ImportError:
@@ -202,15 +200,11 @@ class NumpyArrayWrapper(object):
                             self.np.frombuffer(data, dtype=self.dtype,
                                                     count=read_count)
                         del data
-                try:
-                    if self.order == 'F':
-                        array.shape = self.shape[::-1]
-                        array = array.transpose()
-                    else:
-                        array.shape = self.shape
-                except Exception:
-                    IPython.embed()
-
+                if self.order == 'F':
+                    array.shape = self.shape[::-1]
+                    array = array.transpose()
+                else:
+                    array.shape = self.shape
         return array
 
     def read_mmap(self, directory, mmap_mode):

--- a/joblib/numpy_pickle_v2.py
+++ b/joblib/numpy_pickle_v2.py
@@ -1,0 +1,668 @@
+"""Utilities for fast persistence of big data, with optional compression."""
+
+# Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
+# Copyright (c) 2009 Gael Varoquaux
+# License: BSD Style, 3 clauses.
+import contextlib
+import pickle
+import os
+import sys
+import threading
+import warnings
+from functools import partial
+from os.path import split, splitext, dirname, abspath, join
+
+import IPython
+
+try:
+    from pathlib import Path
+except ImportError:
+    Path = None
+
+from .numpy_pickle_utils import _COMPRESSORS
+from .numpy_pickle_utils import BinaryZlibFile
+from .numpy_pickle_utils import Unpickler, Pickler
+from .numpy_pickle_utils import _read_fileobject, _write_fileobject
+from .numpy_pickle_utils import _read_bytes, BUFFER_SIZE
+from .numpy_pickle_compat import load_compatibility
+from .numpy_pickle_compat import NDArrayWrapper
+# For compatibility with old versions of joblib, we need ZNDArrayWrapper
+# to be visible in the current namespace.
+# Explicitly skipping next line from flake8 as it triggers an F401 warning
+# which we don't care.
+from .numpy_pickle_compat import ZNDArrayWrapper  # noqa
+from ._compat import _basestring, PY3_OR_LATER
+
+if PY3_OR_LATER:
+    import pickle as fast_pickle
+else:
+    try:
+        import cPickle as fast_pickle
+    except ImportError:
+        warnings.warn("Can't use cpickle using default pickle. "
+                      "This could lead to performance problems.")
+        import pickle as fast_pickle
+
+storage = threading.local()
+
+###############################################################################
+# Utility objects for persistence.
+
+
+def read_np_dump(new_args, new_kwargs):
+    directory = dirname(abspath(storage.filename))
+    mmap_mode = storage.mmap_mode
+    file_opener = storage.file_opener
+    return NumpyArrayWrapper(*new_args, **new_kwargs).read(directory, mmap_mode, file_opener=file_opener)
+
+
+class NumpyArrayWrapper(object):
+    """An object to be persisted instead of numpy arrays.
+
+    This object is used to hack into the pickle machinery and read numpy
+    array data from our custom persistence format.
+    More precisely, this object is used for:
+    * carrying the information of the persisted array: subclass, shape, order,
+    dtype. Those ndarray metadata are used to correctly reconstruct the array
+    with low level numpy functions.
+    * determining if memmap is allowed on the array.
+    * reading the array bytes from a file.
+    * reading the array using memorymap from a file.
+    * writing the array bytes to a file.
+
+    Attributes
+    ----------
+    subclass: numpy.ndarray subclass
+        Determine the subclass of the wrapped array.
+    shape: numpy.ndarray shape
+        Determine the shape of the wrapped array.
+    order: {'C', 'F'}
+        Determine the order of wrapped array data. 'C' is for C order, 'F' is
+        for fortran order.
+    dtype: numpy.ndarray dtype
+        Determine the data type of the wrapped array.
+    allow_mmap: bool
+        Determine if memory mapping is allowed on the wrapped array.
+        Default: False.
+    """
+
+    def __init__(self, subclass, shape, order, dtype, filename, allow_mmap=False):
+        """Constructor. Store the useful information for later."""
+        self.subclass = subclass
+        self.shape = shape
+        self.order = order
+        self.dtype = dtype
+        self.allow_mmap = allow_mmap
+        _, self.filename = split(filename)
+
+        try:
+            import numpy
+            self.np = numpy
+        except ImportError:
+            self.np = None
+
+    def __reduce__(self):
+        return (read_np_dump, (
+            (
+                self.subclass,
+                self.shape,
+                self.order,
+                self.dtype,
+            ),
+            {
+                'allow_mmap': self.allow_mmap,
+                'filename': self.filename
+            }
+        ),)
+
+
+    # def __getnewargs__(self):
+    #     return (
+    #         (
+    #             self.subclass,
+    #             self.shape,
+    #             self.order,
+    #             self.dtype,
+    #         ),
+    #         {
+    #             'allow_mmap': self.allow_mmap,
+    #             'filename': self.filename
+    #         }
+    #     )
+
+
+    def write_array(self, array, directory, file_opener=partial(open, mode='bw')):
+        """Write array bytes to pickler file handle.
+
+        This function is an adaptation of the numpy write_array function
+        available in version 1.10.1 in numpy/lib/format.py.
+        """
+        # Set buffer size to 16 MiB to hide the Python loop overhead.
+
+        with file_opener(os.path.join(directory, self.filename)) as file_handle:
+            buffersize = max(16 * 1024 ** 2 // array.itemsize, 1)
+            if array.dtype.hasobject:
+                # We contain Python objects so we cannot write out the data
+                # directly. Instead, we will pickle it out with version 2 of the
+                # pickle protocol.
+                fast_pickle.dump(array, file_handle, protocol=2)
+            else:
+                for chunk in self.np.nditer(array,
+                                               flags=['external_loop',
+                                                      'buffered',
+                                                      'zerosize_ok'],
+                                               buffersize=buffersize,
+                                               order=self.order):
+                    file_handle.write(chunk.tostring('C'))
+
+    def read_array(self, directory, file_opener=partial(open, mode='br')):
+        """Read array from unpickler file handle.
+
+        This function is an adaptation of the numpy read_array function
+        available in version 1.10.1 in numpy/lib/format.py.
+        """
+        if len(self.shape) == 0:
+            count = 1
+        else:
+            count = self.np.multiply.reduce(self.shape)
+        # Now read the actual data.
+
+        with file_opener(join(directory, self.filename)) as file_handle:
+            if self.dtype.hasobject:
+                # The array contained Python objects. We need to unpickle the data.
+                array = fast_pickle.load(file_handle)
+            else:
+                if (not PY3_OR_LATER and
+                        self.np.compat.isfileobj(file_handle)):
+                    # In python 2, gzip.GzipFile is considered as a file so one
+                    # can use numpy.fromfile().
+                    # For file objects, use np.fromfile function.
+                    # This function is faster than the memory-intensive
+                    # method below.
+                    array = self.np.fromfile(file_handle,
+                                                  dtype=self.dtype, count=count)
+                else:
+                    # This is not a real file. We have to read it the
+                    # memory-intensive way.
+                    # crc32 module fails on reads greater than 2 ** 32 bytes,
+                    # breaking large reads from gzip streams. Chunk reads to
+                    # BUFFER_SIZE bytes to avoid issue and reduce memory overhead
+                    # of the read. In non-chunked case count < max_read_count, so
+                    # only one read is performed.
+                    max_read_count = BUFFER_SIZE // min(BUFFER_SIZE,
+                                                        self.dtype.itemsize)
+
+                    array = self.np.empty(count, dtype=self.dtype)
+                    for i in range(0, count, max_read_count):
+                        read_count = min(max_read_count, count - i)
+                        read_size = int(read_count * self.dtype.itemsize)
+                        data = _read_bytes(file_handle,
+                                           read_size, "array data")
+                        array[i:i + read_count] = \
+                            self.np.frombuffer(data, dtype=self.dtype,
+                                                    count=read_count)
+                        del data
+                try:
+                    if self.order == 'F':
+                        array.shape = self.shape[::-1]
+                        array = array.transpose()
+                    else:
+                        array.shape = self.shape
+                except Exception:
+                    IPython.embed()
+
+        return array
+
+    def read_mmap(self, directory, mmap_mode):
+        """Read an array using numpy memmap."""
+        full_filename = join(directory, self.filename)
+        if mmap_mode == 'w+':
+            mmap_mode = 'r+'
+
+        marray = self.np.memmap(full_filename,
+                                 dtype=self.dtype,
+                                 shape=self.shape,
+                                 order=self.order,
+                                 mode=mmap_mode,)
+
+        return marray
+
+    def read(self, directory, mmap_mode, file_opener=partial(open, mode='rb')):
+        """Read the array corresponding to this wrapper.
+
+        Use the unpickler to get all information to correctly read the array.
+
+        Parameters
+        ----------
+        unpickler: NumpyUnpickler
+
+        Returns
+        -------
+        array: numpy.ndarray
+
+        """
+        # When requested, only use memmap mode if allowed.
+        if mmap_mode is not None and self.allow_mmap:
+            array = self.read_mmap(directory, mmap_mode)
+        else:
+            array = self.read_array(directory, file_opener)
+
+        # Manage array subclass case
+        if (hasattr(array, '__array_prepare__') and
+            self.subclass not in (self.np.ndarray,
+                                  self.np.memmap)):
+            # We need to reconstruct another subclass
+            new_array = self.np.core.multiarray._reconstruct(
+                self.subclass, (0,), 'b')
+            return new_array.__array_prepare__(array)
+        else:
+            return array
+
+###############################################################################
+# Pickler classes
+
+
+class NumpyPicklerCompatible(Pickler):
+    """A pickler to persist big data efficiently.
+
+    The main features of this object are:
+    * persistence of numpy arrays in a single file.
+    * optional compression with a special care on avoiding memory copies.
+
+    Attributes
+    ----------
+    fp: file
+        File object handle used for serializing the input object.
+    protocol: int
+        Pickle protocol used. Default is pickle.DEFAULT_PROTOCOL under
+        python 3, pickle.HIGHEST_PROTOCOL otherwise.
+    """
+
+    dispatch = Pickler.dispatch.copy()
+
+    def __init__(self, filename, file_handle, file_opener, protocol=None):
+        self.filename = filename
+        self.file_opener = file_opener
+
+        self.buffered = isinstance(file_handle, BinaryZlibFile)
+        self.array_count = 0
+
+        # By default we want a pickle protocol that only changes with
+        # the major python version and not the minor one
+        if protocol is None:
+            protocol = (pickle.DEFAULT_PROTOCOL if PY3_OR_LATER
+                        else pickle.HIGHEST_PROTOCOL)
+
+        Pickler.__init__(self, file_handle, protocol=protocol)
+        # delayed import of numpy, to avoid tight coupling
+        try:
+            import numpy as np
+        except ImportError:
+            np = None
+        self.np = np
+
+    def _create_array_wrapper(self, array):
+        """Create and returns a numpy array wrapper from a numpy array."""
+        order = 'F' if (array.flags.f_contiguous and
+                        not array.flags.c_contiguous) else 'C'
+        allow_mmap = not self.buffered and not array.dtype.hasobject
+        self.array_count += 1
+        filename = "{}.array{:0>3}.part".format(self.filename, self.array_count)
+        wrapper = NumpyArrayWrapper(type(array),
+                                    array.shape, order, array.dtype,
+                                    allow_mmap=allow_mmap,
+                                    filename=filename)
+
+        return wrapper
+
+    def save(self, obj):
+        """Subclass the Pickler `save` method.
+
+        This is a total abuse of the Pickler class in order to use the numpy
+        persistence function `save` instead of the default pickle
+        implementation. The numpy array is replaced by a custom wrapper in the
+        pickle persistence stack and the serialized array is written right
+        after in the file. Warning: the file produced does not follow the
+        pickle format. As such it can not be read with `pickle.load`.
+        """
+        if self.np is not None and type(obj) in (self.np.ndarray,
+                                                 self.np.matrix,
+                                                 self.np.memmap):
+            if type(obj) is self.np.memmap:
+                # Pickling doesn't work with memmapped arrays
+                obj = self.np.asanyarray(obj)
+
+            # The array wrapper is pickled instead of the real array.
+            wrapper = self._create_array_wrapper(obj)
+
+            # Wrapper is always pure-old python object
+            Pickler.save(self, wrapper)
+
+            # A framer was introduced with pickle protocol 4 and we want to
+            # ensure the wrapper object is written before the numpy array
+            # buffer in the pickle file.
+            # See https://www.python.org/dev/peps/pep-3154/#framing to get
+            # more information on the framer behavior.
+            if self.proto >= 4:
+                self.framer.commit_frame(force=True)
+
+            # And then array bytes are written right after the wrapper.
+            wrapper.write_array(obj, dirname(abspath(self.filename)), file_opener=self.file_opener)
+            return
+
+        return Pickler.save(self, obj)
+
+
+if PY3_OR_LATER and sys.version_info[1] >= 3:
+    class NumpyPicklerFast(fast_pickle.Pickler):
+        """A pickler to persist big data efficiently.
+
+        The main features of this object are:
+        * persistence of numpy arrays in a single file.
+        * optional compression with a special care on avoiding memory copies.
+
+        Attributes
+        ----------
+        fp: file
+            File object handle used for serializing the input object.
+        protocol: int
+            Pickle protocol used. Default is pickle.DEFAULT_PROTOCOL under
+            python 3, pickle.HIGHEST_PROTOCOL otherwise.
+        """
+
+        def __init__(self, filename, file_handle, file_opener, protocol=None):
+            super(NumpyPicklerFast, self).__init__(file_handle, protocol=protocol)
+
+            import copyreg
+            self.dispatch_table = copyreg.dispatch_table.copy()
+            self.dispatch_table[0] = 0
+
+            self.filename = filename
+            self.file_opener = file_opener
+
+            self.buffered = isinstance(file_handle, BinaryZlibFile)
+            self.array_count = 0
+
+            # By default we want a pickle protocol that only changes with
+            # the major python version and not the minor one
+            if protocol is None:
+                protocol = (pickle.DEFAULT_PROTOCOL if PY3_OR_LATER
+                            else pickle.HIGHEST_PROTOCOL)
+
+            # delayed import of numpy, to avoid tight coupling
+            try:
+                import numpy as np
+            except ImportError:
+                np = None
+            self.np = np
+
+            def reduce_array(array):
+                wrapper = self._create_array_wrapper(array)
+                wrapper.write_array(array, dirname(abspath(self.filename)), file_opener=self.file_opener)
+
+                return wrapper.__reduce__()
+
+            if self.np:
+                self.dispatch_table[self.np.ndarray] = reduce_array
+                self.dispatch_table[self.np.matrix] = reduce_array
+                self.dispatch_table[self.np.memmap] = reduce_array
+
+        def _create_array_wrapper(self, array):
+            """Create and returns a numpy array wrapper from a numpy array."""
+            order = 'F' if (array.flags.f_contiguous and
+                            not array.flags.c_contiguous) else 'C'
+            allow_mmap = not self.buffered and not array.dtype.hasobject
+            self.array_count += 1
+            filename = "{}.array{:0>3}.part".format(self.filename, self.array_count)
+            wrapper = NumpyArrayWrapper(type(array),
+                                        array.shape, order, array.dtype,
+                                        allow_mmap=allow_mmap,
+                                        filename=filename)
+
+            return wrapper
+
+
+    NumpyPickler = NumpyPicklerFast
+else:
+    NumpyPickler = NumpyPicklerCompatible
+
+
+###############################################################################
+# Utility functions
+
+def dump(value, filename, compress=0, protocol=None, cache_size=None):
+    """Persist an arbitrary Python object into one file.
+
+    Parameters
+    -----------
+    value: any Python object
+        The object to store to disk.
+    filename: str or pathlib.Path
+        The path of the file in which it is to be stored. The compression
+        method corresponding to one of the supported filename extensions ('.z',
+        '.gz', '.bz2', '.xz' or '.lzma') will be used automatically.
+    compress: int from 0 to 9 or bool or 2-tuple, optional
+        Optional compression level for the data. 0 or False is no compression.
+        Higher value means more compression, but also slower read and
+        write times. Using a value of 3 is often a good compromise.
+        See the notes for more details.
+        If compress is True, the compression level used is 3.
+        If compress is a 2-tuple, the first element must correspond to a string
+        between supported compressors (e.g 'zlib', 'gzip', 'bz2', 'lzma'
+        'xz'), the second element must be an integer from 0 to 9, corresponding
+        to the compression level.
+    protocol: positive int
+        Pickle protocol, see pickle.dump documentation for more details.
+    cache_size: positive int, optional
+        This option is deprecated in 0.10 and has no effect.
+
+    Returns
+    -------
+    filenames: list of strings
+        The list of file names in which the data is stored. If
+        compress is false, each array is stored in a different file.
+
+    See Also
+    --------
+    joblib.load : corresponding loader
+
+    Notes
+    -----
+    Memmapping on load cannot be used for compressed files. Thus
+    using compression can significantly slow down loading. In
+    addition, compressed files take extra extra memory during
+    dump and load.
+
+    """
+
+    if Path is not None and isinstance(filename, Path):
+        filename = str(filename)
+
+    is_filename = isinstance(filename, _basestring)
+    is_fileobj = hasattr(filename, "write")
+
+    compress_method = 'zlib'  # zlib is the default compression method.
+    if compress is True:
+        # By default, if compress is enabled, we want to be using 3 by default
+        compress_level = 3
+    elif isinstance(compress, tuple):
+        # a 2-tuple was set in compress
+        if len(compress) != 2:
+            raise ValueError(
+                'Compress argument tuple should contain exactly 2 elements: '
+                '(compress method, compress level), you passed {0}'
+                .format(compress))
+        compress_method, compress_level = compress
+    else:
+        compress_level = compress
+
+    if compress_level is not False and compress_level not in range(10):
+        # Raising an error if a non valid compress level is given.
+        raise ValueError(
+            'Non valid compress level given: "{0}". Possible values are '
+            '{1}.'.format(compress_level, list(range(10))))
+
+    if compress_method not in _COMPRESSORS:
+        # Raising an error if an unsupported compression method is given.
+        raise ValueError(
+            'Non valid compression method given: "{0}". Possible values are '
+            '{1}.'.format(compress_method, _COMPRESSORS))
+
+    if not is_filename and not is_fileobj:
+        # People keep inverting arguments, and the resulting error is
+        # incomprehensible
+        raise ValueError(
+            'Second argument should be a filename or a file-like object, '
+            '%s (type %s) was given.'
+            % (filename, type(filename))
+        )
+
+    if is_filename and not isinstance(compress, tuple):
+        # In case no explicit compression was requested using both compression
+        # method and level in a tuple and the filename has an explicit
+        # extension, we select the corresponding compressor.
+        if filename.endswith('.z'):
+            compress_method = 'zlib'
+        elif filename.endswith('.gz'):
+            compress_method = 'gzip'
+        elif filename.endswith('.bz2'):
+            compress_method = 'bz2'
+        elif filename.endswith('.lzma'):
+            compress_method = 'lzma'
+        elif filename.endswith('.xz'):
+            compress_method = 'xz'
+        else:
+            # no matching compression method found, we unset the variable to
+            # be sure no compression level is set afterwards.
+            compress_method = None
+
+        if compress_method in _COMPRESSORS and compress_level == 0:
+            # we choose a default compress_level of 3 in case it was not given
+            # as an argument (using compress).
+            compress_level = 3
+
+    if not PY3_OR_LATER and compress_method in ('lzma', 'xz'):
+        raise NotImplementedError("{0} compression is only available for "
+                                  "python version >= 3.3. You are using "
+                                  "{1}.{2}".format(compress_method,
+                                                   sys.version_info[0],
+                                                   sys.version_info[1]))
+
+    if cache_size is not None:
+        # Cache size is deprecated starting from version 0.10
+        warnings.warn("Please do not set 'cache_size' in joblib.dump, "
+                      "this parameter has no effect and will be removed. "
+                      "You used 'cache_size={0}'".format(cache_size),
+                      DeprecationWarning, stacklevel=2)
+    file_opener = partial(open, mode='wb')
+
+    if compress_level != 0:
+        file_opener = partial(_write_fileobject, compress=(compress_method, compress_level))
+
+    with file_opener(filename) as file_handle:
+        NumpyPickler(filename, file_handle, file_opener, protocol=protocol).dump(value)
+
+    # For compatibility, the list of created filenames (e.g with one element
+    # after 0.10.0) is returned by default.
+    return [filename]
+
+
+def _unpickle(fobj, filename="", mmap_mode=None):
+    """Internal unpickling function."""
+    # We are careful to open the file handle early and keep it open to
+    # avoid race-conditions on renames.
+    # That said, if data is stored in companion files, which can be
+    # the case with the old persistence format, moving the directory
+    # will create a race when joblib tries to access the companion
+    # files.
+    obj = None
+    try:
+        obj = fast_pickle.load(fobj)
+    except UnicodeDecodeError as exc:
+        # More user-friendly error message
+        if PY3_OR_LATER:
+            new_exc = ValueError(
+                'You may be trying to read with '
+                'python 3 a joblib pickle generated with python 2. '
+                'This feature is not supported by joblib.')
+            new_exc.__cause__ = exc
+            raise new_exc
+        # Reraise exception with Python 2
+        raise
+
+    return obj
+
+
+def load(filename, mmap_mode=None):
+    """Reconstruct a Python object from a file persisted with joblib.dump.
+
+    Parameters
+    -----------
+    filename: str or pathlib.Path
+        The path of the file from which to load the object
+    mmap_mode: {None, 'r+', 'r', 'w+', 'c'}, optional
+        If not None, the arrays are memory-mapped from the disk. This
+        mode has no effect for compressed files. Note that in this
+        case the reconstructed object might not longer match exactly
+        the originally pickled object.
+
+    Returns
+    -------
+    result: any Python object
+        The object stored in the file.
+
+    See Also
+    --------
+    joblib.dump : function to save an object
+
+    Notes
+    -----
+
+    This function can load numpy array files saved separately during the
+    dump. If the mmap_mode argument is given, it is passed to np.load and
+    arrays are loaded as memmaps. As a consequence, the reconstructed
+    object might not match the original pickled object. Note that if the
+    file was saved with compression, the arrays cannot be memmaped.
+    """
+    if Path is not None and isinstance(filename, Path):
+        filename = str(filename)
+
+    try:
+        storage.filename = filename
+        storage.mmap_mode = mmap_mode
+
+        if hasattr(filename, "read"):
+            fobj = filename
+            filename = getattr(fobj, 'name', '')
+            with _read_fileobject(fobj, filename, mmap_mode) as fobj:
+                obj = _unpickle(fobj)
+        else:
+            @contextlib.contextmanager
+            def file_opener(filename):
+                file_ = None
+                try:
+                    file_ = open(filename, 'rb')
+                    with _read_fileobject(file_, filename, mmap_mode) as fobj:
+                        yield fobj
+                finally:
+                    if file_ is not None:
+                        file_.close()
+
+            storage.file_opener = file_opener
+
+            with file_opener(filename) as fobj:
+                if isinstance(fobj, _basestring):
+                    # if the returned file object is a string, this means we
+                    # try to load a pickle file generated with an version of
+                    # Joblib so we load it with joblib compatibility function.
+                    return load_compatibility(fobj)
+                obj = _unpickle(fobj, filename, mmap_mode)
+    finally:
+        del storage.filename
+        del storage.mmap_mode
+        try:
+            del storage.file_opener
+        except Exception:
+            pass
+
+    return obj

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -960,6 +960,7 @@ def test_pickle_in_socket():
     test_array = np.arange(10)
     _ADDR = ("localhost", 12345)
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     listener.bind(_ADDR)
     listener.listen(1)
 

--- a/joblib/test/test_numpy_pickle_v2.py
+++ b/joblib/test/test_numpy_pickle_v2.py
@@ -334,16 +334,12 @@ def test_compress_mmap_mode_warning():
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
         numpy_pickle.load(this_filename, mmap_mode='r+')
-        nose.tools.assert_equal(len(caught_warnings), 1)
+        nose.tools.assert_greater_equal(len(caught_warnings), 1)
         for warn in caught_warnings:
             nose.tools.assert_equal(warn.category, UserWarning)
-            nose.tools.assert_equal(warn.message.args[0],
-                                    'mmap_mode "%(mmap_mode)s" is not '
-                                    'compatible with compressed file '
-                                    '%(filename)s. '
-                                    '"%(mmap_mode)s" flag will be ignored.'
-                                    % {'filename': this_filename,
-                                       'mmap_mode': 'r+'})
+            nose.tools.assert_in('mmap_mode "%(mmap_mode)s" is not '
+                                 'compatible with compressed file ' %
+                                 {'mmap_mode': 'r+'}, warn.message.args[0])
 
 
 @with_numpy
@@ -621,6 +617,7 @@ def _zlib_file_decompress(source_filename, target_filename):
         fo.write(buf)
 
 
+@unittest.skip('Need think more how to work with combined files')
 def test_load_externally_decompressed_files():
     # Test that BinaryZlibFile generates valid gzip and zlib compressed files.
     obj = "a string to persist"
@@ -796,7 +793,7 @@ def test_file_name_persistence_compressed_mmap():
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
         numpy_pickle.load(filename, mmap_mode='r+')
-        nose.tools.assert_equal(len(caught_warnings), 1)
+        nose.tools.assert_greater_equal(len(caught_warnings), 1)
         for warn in caught_warnings:
             nose.tools.assert_equal(warn.category, UserWarning)
             nose.tools.assert_in('mmap_mode "%(mmap_mode)s" is not compatible with '

--- a/joblib/test/test_numpy_pickle_v2.py
+++ b/joblib/test/test_numpy_pickle_v2.py
@@ -1,0 +1,1011 @@
+"""Test the numpy pickler as a replacement of the standard pickler."""
+import unittest
+from tempfile import mkdtemp
+import copy
+import shutil
+import os
+import random
+import sys
+import re
+import tempfile
+import io
+import warnings
+import nose
+import gzip
+import zlib
+import bz2
+import pickle
+import socket
+from contextlib import closing
+
+from joblib.test.common import np, with_numpy
+from joblib.test.common import with_memory_profiler, memory_used
+from joblib.testing import assert_raises_regex
+
+# numpy_pickle is not a drop-in replacement of pickle, as it takes
+# filenames instead of open files as arguments.
+from joblib import numpy_pickle_v2 as numpy_pickle
+from joblib.test import data
+
+from joblib._compat import PY3_OR_LATER, PY26
+from joblib.numpy_pickle_utils import _IO_BUFFER_SIZE, BinaryZlibFile
+from joblib.numpy_pickle_utils import _detect_compressor, _COMPRESSORS
+
+###############################################################################
+# Define a list of standard types.
+# Borrowed from dill, initial author: Micheal McKerns:
+# http://dev.danse.us/trac/pathos/browser/dill/dill_test2.py
+
+typelist = []
+
+# testing types
+_none = None
+typelist.append(_none)
+_type = type
+typelist.append(_type)
+_bool = bool(1)
+typelist.append(_bool)
+_int = int(1)
+typelist.append(_int)
+try:
+    _long = long(1)
+    typelist.append(_long)
+except NameError:
+    # long is not defined in python 3
+    pass
+_float = float(1)
+typelist.append(_float)
+_complex = complex(1)
+typelist.append(_complex)
+_string = str(1)
+typelist.append(_string)
+try:
+    _unicode = unicode(1)
+    typelist.append(_unicode)
+except NameError:
+    # unicode is not defined in python 3
+    pass
+_tuple = ()
+typelist.append(_tuple)
+_list = []
+typelist.append(_list)
+_dict = {}
+typelist.append(_dict)
+try:
+    _file = file
+    typelist.append(_file)
+except NameError:
+    pass  # file does not exists in Python 3
+try:
+    _buffer = buffer
+    typelist.append(_buffer)
+except NameError:
+    # buffer does not exists in Python 3
+    pass
+_builtin = len
+typelist.append(_builtin)
+
+
+def _function(x):
+    yield x
+
+
+class _class:
+    def _method(self):
+        pass
+
+
+class _newclass(object):
+    def _method(self):
+        pass
+
+
+typelist.append(_function)
+typelist.append(_class)
+typelist.append(_newclass)  # <type 'type'>
+_instance = _class()
+typelist.append(_instance)
+_object = _newclass()
+typelist.append(_object)  # <type 'class'>
+
+
+###############################################################################
+# Test fixtures
+
+env = dict()
+
+
+def setup_module():
+    """ Test setup.
+    """
+    env['dir'] = mkdtemp()
+    env['filename'] = os.path.join(env['dir'], 'test.pkl')
+    print(80 * '_')
+    print('setup numpy_pickle')
+    print(80 * '_')
+
+
+def teardown_module():
+    """ Test teardown.
+    """
+    shutil.rmtree(env['dir'])
+    # del env['dir']
+    # del env['filename']
+    print(80 * '_')
+    print('teardown numpy_pickle')
+    print(80 * '_')
+
+
+###############################################################################
+# Tests
+
+def test_standard_types():
+    # Test pickling and saving with standard types.
+    filename = env['filename']
+    for compress in [0, 1]:
+        for member in typelist:
+            # Change the file name to avoid side effects between tests
+            this_filename = filename + str(random.randint(0, 1000))
+            numpy_pickle.dump(member, this_filename, compress=compress)
+            _member = numpy_pickle.load(this_filename)
+            # We compare the pickled instance to the reloaded one only if it
+            # can be compared to a copied one
+            if member == copy.deepcopy(member):
+                yield nose.tools.assert_equal, member, _member
+
+
+def test_value_error():
+    # Test inverting the input arguments to dump
+    nose.tools.assert_raises(ValueError, numpy_pickle.dump, 'foo',
+                             dict())
+
+
+def test_compress_level_error():
+    # Verify that passing an invalid compress argument raises an error.
+    wrong_compress = (-1, 10, 'wrong')
+    for wrong in wrong_compress:
+        exception_msg = 'Non valid compress level given: "{0}"'.format(wrong)
+        assert_raises_regex(ValueError,
+                            exception_msg,
+                            numpy_pickle.dump, 'dummy', 'foo', compress=wrong)
+
+
+@with_numpy
+def test_numpy_persistence():
+    filename = env['filename']
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample((10, 2))
+    for compress in (False, True, 0, 3):
+        # We use 'a.T' to have a non C-contiguous array.
+        for index, obj in enumerate(((a,), (a.T,), (a, a), [a, a, a])):
+            # Change the file name to avoid side effects between tests
+            this_filename = filename + str(random.randint(0, 1000))
+
+            filenames = numpy_pickle.dump(obj, this_filename,
+                                          compress=compress)
+
+            # All is cached in one file
+            nose.tools.assert_equal(len(filenames), 1)
+            # Check that only one file was created
+            nose.tools.assert_equal(filenames[0], this_filename)
+            # Check that this file does exist
+            nose.tools.assert_true(
+                os.path.exists(os.path.join(env['dir'], filenames[0])))
+
+            # Unpickle the object
+            obj_ = numpy_pickle.load(this_filename)
+            # Check that the items are indeed arrays
+            for item in obj_:
+                nose.tools.assert_true(isinstance(item, np.ndarray))
+            # And finally, check that all the values are equal.
+            np.testing.assert_array_equal(np.array(obj), np.array(obj_))
+
+        # Now test with array subclasses
+        for obj in (np.matrix(np.zeros(10)),
+                    np.memmap(filename + str(random.randint(0, 1000)) + 'mmap',
+                              mode='w+', shape=4, dtype=np.float)):
+            this_filename = filename + str(random.randint(0, 1000))
+            filenames = numpy_pickle.dump(obj, this_filename,
+                                          compress=compress)
+            # All is cached in one file
+            nose.tools.assert_equal(len(filenames), 1)
+
+            obj_ = numpy_pickle.load(this_filename)
+            if (type(obj) is not np.memmap and
+                    hasattr(obj, '__array_prepare__')):
+                # We don't reconstruct memmaps
+                nose.tools.assert_true(isinstance(obj_, type(obj)))
+
+            np.testing.assert_array_equal(obj_, obj)
+
+        # Test with an object containing multiple numpy arrays
+        obj = ComplexTestObject()
+        filenames = numpy_pickle.dump(obj, this_filename,
+                                      compress=compress)
+        # All is cached in one file
+        nose.tools.assert_equal(len(filenames), 1)
+
+        obj_loaded = numpy_pickle.load(this_filename)
+        nose.tools.assert_true(isinstance(obj_loaded, type(obj)))
+        np.testing.assert_array_equal(obj_loaded.array_float, obj.array_float)
+        np.testing.assert_array_equal(obj_loaded.array_int, obj.array_int)
+        np.testing.assert_array_equal(obj_loaded.array_obj, obj.array_obj)
+
+
+@with_numpy
+def test_numpy_persistence_bufferred_array_compression():
+    big_array = np.ones((_IO_BUFFER_SIZE + 100), dtype=np.uint8)
+    filename = env['filename'] + str(random.randint(0, 1000))
+    numpy_pickle.dump(big_array, filename, compress=True)
+    arr_reloaded = numpy_pickle.load(filename)
+
+    np.testing.assert_array_equal(big_array, arr_reloaded)
+
+
+@with_numpy
+def test_memmap_persistence():
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample(10)
+    filename = env['filename'] + str(random.randint(0, 1000))
+    numpy_pickle.dump(a, filename)
+    b = numpy_pickle.load(filename, mmap_mode='r')
+
+    nose.tools.assert_true(isinstance(b, np.memmap))
+
+    # Test with an object containing multiple numpy arrays
+    filename = env['filename'] + str(random.randint(0, 1000))
+    obj = ComplexTestObject()
+    numpy_pickle.dump(obj, filename)
+    obj_loaded = numpy_pickle.load(filename, mmap_mode='r')
+    nose.tools.assert_true(isinstance(obj_loaded, type(obj)))
+    nose.tools.assert_true(isinstance(obj_loaded.array_float, np.memmap))
+    nose.tools.assert_false(obj_loaded.array_float.flags.writeable)
+    nose.tools.assert_true(isinstance(obj_loaded.array_int, np.memmap))
+    nose.tools.assert_false(obj_loaded.array_int.flags.writeable)
+    # Memory map not allowed for numpy object arrays
+    nose.tools.assert_false(isinstance(obj_loaded.array_obj, np.memmap))
+    np.testing.assert_array_equal(obj_loaded.array_float,
+                                  obj.array_float)
+    np.testing.assert_array_equal(obj_loaded.array_int,
+                                  obj.array_int)
+    np.testing.assert_array_equal(obj_loaded.array_obj,
+                                  obj.array_obj)
+
+    # Test we can write in memmaped arrays
+    obj_loaded = numpy_pickle.load(filename, mmap_mode='r+')
+    nose.tools.assert_true(obj_loaded.array_float.flags.writeable)
+    obj_loaded.array_float[0:10] = 10.0
+    nose.tools.assert_true(obj_loaded.array_int.flags.writeable)
+    obj_loaded.array_int[0:10] = 10
+
+    obj_reloaded = numpy_pickle.load(filename, mmap_mode='r')
+    np.testing.assert_array_equal(obj_reloaded.array_float,
+                                  obj_loaded.array_float)
+    np.testing.assert_array_equal(obj_reloaded.array_int,
+                                  obj_loaded.array_int)
+
+    # Test w+ mode is caught and the mode has switched to r+
+    numpy_pickle.load(filename, mmap_mode='w+')
+    nose.tools.assert_true(obj_loaded.array_int.flags.writeable)
+    nose.tools.assert_equal(obj_loaded.array_int.mode, 'r+')
+    nose.tools.assert_true(obj_loaded.array_float.flags.writeable)
+    nose.tools.assert_equal(obj_loaded.array_float.mode, 'r+')
+
+
+@with_numpy
+def test_memmap_persistence_mixed_dtypes():
+    # loading datastructures that have sub-arrays with dtype=object
+    # should not prevent memmaping on fixed size dtype sub-arrays.
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample(10)
+    b = np.array([1, 'b'], dtype=object)
+    construct = (a, b)
+    filename = env['filename'] + str(random.randint(0, 1000))
+    numpy_pickle.dump(construct, filename)
+    a_clone, b_clone = numpy_pickle.load(filename, mmap_mode='r')
+
+    # the floating point array has been memory mapped
+    nose.tools.assert_true(isinstance(a_clone, np.memmap))
+
+    # the object-dtype array has been loaded in memory
+    nose.tools.assert_false(isinstance(b_clone, np.memmap))
+
+
+@with_numpy
+def test_masked_array_persistence():
+    # The special-case picker fails, because saving masked_array
+    # not implemented, but it just delegates to the standard pickler.
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample(10)
+    a = np.ma.masked_greater(a, 0.5)
+    filename = env['filename'] + str(random.randint(0, 1000))
+    numpy_pickle.dump(a, filename)
+    b = numpy_pickle.load(filename, mmap_mode='r')
+    nose.tools.assert_true(isinstance(b, np.ma.masked_array))
+
+
+@with_numpy
+def test_compress_mmap_mode_warning():
+    # Test the warning in case of compress + mmap_mode
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample(10)
+    this_filename = env['filename'] + str(random.randint(0, 1000))
+    numpy_pickle.dump(a, this_filename, compress=1)
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        numpy_pickle.load(this_filename, mmap_mode='r+')
+        nose.tools.assert_equal(len(caught_warnings), 1)
+        for warn in caught_warnings:
+            nose.tools.assert_equal(warn.category, UserWarning)
+            nose.tools.assert_equal(warn.message.args[0],
+                                    'mmap_mode "%(mmap_mode)s" is not '
+                                    'compatible with compressed file '
+                                    '%(filename)s. '
+                                    '"%(mmap_mode)s" flag will be ignored.'
+                                    % {'filename': this_filename,
+                                       'mmap_mode': 'r+'})
+
+
+@with_numpy
+def test_cache_size_warning():
+    # Check deprecation warning raised when cache size is not None
+    filename = env['filename'] + str(random.randint(0, 1000))
+    rnd = np.random.RandomState(0)
+    a = rnd.random_sample((10, 2))
+
+    for cache_size in (None, 0, 10):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            numpy_pickle.dump(a, filename, cache_size=cache_size)
+            expected_nb_warnings = 1 if cache_size is not None else 0
+            nose.tools.assert_equal(len(caught_warnings),
+                                    expected_nb_warnings)
+            for warn in caught_warnings:
+                nose.tools.assert_equal(warn.category, DeprecationWarning)
+                nose.tools.assert_equal(warn.message.args[0],
+                                        "Please do not set 'cache_size' in "
+                                        "joblib.dump, this parameter has no "
+                                        "effect and will be removed. "
+                                        "You used 'cache_size={0}'".format(
+                                            cache_size))
+
+
+@with_numpy
+@with_memory_profiler
+def test_memory_usage():
+    # Verify memory stays within expected bounds.
+    filename = env['filename']
+    small_array = np.ones((10, 10))
+    big_array = np.ones(shape=100 * int(1e6), dtype=np.uint8)
+    small_matrix = np.matrix(small_array)
+    big_matrix = np.matrix(big_array)
+    for compress in (True, False):
+        for obj in (small_array, big_array, small_matrix, big_matrix):
+            size = obj.nbytes / 1e6
+            obj_filename = filename + str(np.random.randint(0, 1000))
+            mem_used = memory_used(numpy_pickle.dump,
+                                   obj, obj_filename, compress=compress)
+
+            # The memory used to dump the object shouldn't exceed the buffer
+            # size used to write array chunks (16MB).
+            write_buf_size = _IO_BUFFER_SIZE + 16 * 1024 ** 2 / 1e6
+            nose.tools.assert_true(mem_used <= write_buf_size)
+
+            mem_used = memory_used(numpy_pickle.load, obj_filename)
+            # memory used should be less than array size + buffer size used to
+            # read the array chunk by chunk.
+            read_buf_size = 32 + _IO_BUFFER_SIZE  # MiB
+            nose.tools.assert_true(mem_used < size + read_buf_size)
+
+
+@with_numpy
+def test_compressed_pickle_dump_and_load():
+    expected_list = [np.arange(5, dtype=np.dtype('<i8')),
+                     np.arange(5, dtype=np.dtype('>i8')),
+                     np.arange(5, dtype=np.dtype('<f8')),
+                     np.arange(5, dtype=np.dtype('>f8')),
+                     np.array([1, 'abc', {'a': 1, 'b': 2}], dtype='O'),
+                     # .tostring actually returns bytes and is a
+                     # compatibility alias for .tobytes which was
+                     # added in 1.9.0
+                     np.arange(256, dtype=np.uint8).tostring(),
+                     # np.matrix is a subclass of np.ndarray, here we want
+                     # to verify this type of object is correctly unpickled
+                     # among versions.
+                     np.matrix([0, 1, 2], dtype=np.dtype('<i8')),
+                     np.matrix([0, 1, 2], dtype=np.dtype('>i8')),
+                     u"C'est l'\xe9t\xe9 !"]
+
+    with tempfile.NamedTemporaryFile(suffix='.gz', dir=env['dir']) as f:
+        fname = f.name
+
+    try:
+        dumped_filenames = numpy_pickle.dump(expected_list, fname, compress=1)
+        nose.tools.assert_equal(len(dumped_filenames), 1)
+        result_list = numpy_pickle.load(fname)
+        for result, expected in zip(result_list, expected_list):
+            if isinstance(expected, np.ndarray):
+                nose.tools.assert_equal(result.dtype, expected.dtype)
+                np.testing.assert_equal(result, expected)
+            else:
+                nose.tools.assert_equal(result, expected)
+    finally:
+        os.remove(fname)
+
+
+def _check_pickle(filename, expected_list):
+    """Helper function to test joblib pickle content.
+
+    Note: currently only pickles containing an iterable are supported
+    by this function.
+    """
+    if (not PY3_OR_LATER and (filename.endswith('.xz') or
+                              filename.endswith('.lzma'))):
+        # lzma is not supported for python versions < 3.3
+        nose.tools.assert_raises(NotImplementedError,
+                                 numpy_pickle.load, filename)
+        return
+
+    version_match = re.match(r'.+py(\d)(\d).+', filename)
+    py_version_used_for_writing = int(version_match.group(1))
+    py_version_used_for_reading = sys.version_info[0]
+
+    py_version_to_default_pickle_protocol = {2: 2, 3: 3}
+    pickle_reading_protocol = py_version_to_default_pickle_protocol.get(
+        py_version_used_for_reading, 4)
+    pickle_writing_protocol = py_version_to_default_pickle_protocol.get(
+        py_version_used_for_writing, 4)
+    if pickle_reading_protocol >= pickle_writing_protocol:
+        try:
+            with warnings.catch_warnings(record=True) as caught_warnings:
+                warnings.simplefilter("always")
+                result_list = numpy_pickle.load(filename)
+                expected_nb_warnings = 1 if ("0.9" in filename or
+                                             "0.8.4" in filename) else 0
+                nose.tools.assert_equal(len(caught_warnings),
+                                        expected_nb_warnings)
+            for warn in caught_warnings:
+                nose.tools.assert_equal(warn.category, DeprecationWarning)
+                nose.tools.assert_equal(warn.message.args[0],
+                                        "The file '{0}' has been generated "
+                                        "with a joblib version less than "
+                                        "0.10. Please regenerate this pickle "
+                                        "file.".format(filename))
+            for result, expected in zip(result_list, expected_list):
+                if isinstance(expected, np.ndarray):
+                    nose.tools.assert_equal(result.dtype, expected.dtype)
+                    np.testing.assert_equal(result, expected)
+                else:
+                    nose.tools.assert_equal(result, expected)
+        except Exception as exc:
+            # When trying to read with python 3 a pickle generated
+            # with python 2 we expect a user-friendly error
+            if (py_version_used_for_reading == 3 and
+                    py_version_used_for_writing == 2):
+                nose.tools.assert_true(isinstance(exc, ValueError))
+                message = ('You may be trying to read with '
+                           'python 3 a joblib pickle generated with python 2.')
+                nose.tools.assert_true(message in str(exc))
+            else:
+                raise
+    else:
+        # Pickle protocol used for writing is too high. We expect a
+        # "unsupported pickle protocol" error message
+        try:
+            numpy_pickle.load(filename)
+            raise AssertionError('Numpy pickle loading should '
+                                 'have raised a ValueError exception')
+        except ValueError as e:
+            message = 'unsupported pickle protocol: {0}'.format(
+                pickle_writing_protocol)
+            nose.tools.assert_true(message in str(e.args))
+
+
+@with_numpy
+def test_joblib_pickle_across_python_versions():
+    # We need to be specific about dtypes in particular endianness
+    # because the pickles can be generated on one architecture and
+    # the tests run on another one. See
+    # https://github.com/joblib/joblib/issues/279.
+    expected_list = [np.arange(5, dtype=np.dtype('<i8')),
+                     np.arange(5, dtype=np.dtype('<f8')),
+                     np.array([1, 'abc', {'a': 1, 'b': 2}], dtype='O'),
+                     # .tostring actually returns bytes and is a
+                     # compatibility alias for .tobytes which was
+                     # added in 1.9.0
+                     np.arange(256, dtype=np.uint8).tostring(),
+                     # np.matrix is a subclass of np.ndarray, here we want
+                     # to verify this type of object is correctly unpickled
+                     # among versions.
+                     np.matrix([0, 1, 2], dtype=np.dtype('<i8')),
+                     u"C'est l'\xe9t\xe9 !"]
+
+    # Testing all the compressed and non compressed
+    # pickles in joblib/test/data. These pickles were generated by
+    # the joblib/test/data/create_numpy_pickle.py script for the
+    # relevant python, joblib and numpy versions.
+    test_data_dir = os.path.dirname(os.path.abspath(data.__file__))
+
+    pickle_extensions = ('.pkl', '.gz', '.gzip', '.bz2', '.xz', '.lzma')
+    pickle_filenames = [os.path.join(test_data_dir, fn)
+                        for fn in os.listdir(test_data_dir)
+                        if any(fn.endswith(ext) for ext in pickle_extensions)]
+
+    for fname in pickle_filenames:
+        _check_pickle(fname, expected_list)
+
+
+def test_compress_tuple_argument():
+    compress_tuples = (('zlib', 3),
+                       ('gzip', 3))
+
+    # Verify the tuple is correctly taken into account.
+    filename = env['filename'] + str(random.randint(0, 1000))
+    for compress in compress_tuples:
+        numpy_pickle.dump("dummy", filename,
+                          compress=compress)
+        # Verify the file contains the right magic number
+        with open(filename, 'rb') as f:
+            nose.tools.assert_equal(_detect_compressor(f), compress[0])
+
+    # Verify setting a wrong compress tuple raises a ValueError.
+    assert_raises_regex(ValueError,
+                        'Compress argument tuple should contain exactly '
+                        '2 elements',
+                        numpy_pickle.dump, "dummy", filename,
+                        compress=('zlib', 3, 'extra'))
+
+    # Verify a tuple with a wrong compress method raises a ValueError.
+    msg = 'Non valid compression method given: "{0}"'.format('wrong')
+    assert_raises_regex(ValueError, msg,
+                        numpy_pickle.dump, "dummy", filename,
+                        compress=('wrong', 3))
+
+    # Verify a tuple with a wrong compress level raises a ValueError.
+    msg = 'Non valid compress level given: "{0}"'.format('wrong')
+    assert_raises_regex(ValueError, msg,
+                        numpy_pickle.dump, "dummy", filename,
+                        compress=('zlib', 'wrong'))
+
+
+@with_numpy
+def test_joblib_compression_formats():
+    compresslevels = (1, 3, 6)
+    filename = env['filename'] + str(random.randint(0, 1000))
+    objects = (np.ones(shape=(100, 100), dtype='f8'),
+               range(10),
+               {'a': 1, 2: 'b'}, [], (), {}, 0, 1.0)
+
+    for compress in compresslevels:
+        for cmethod in _COMPRESSORS:
+            dump_filename = filename + "." + cmethod
+            for obj in objects:
+                if not PY3_OR_LATER and cmethod in ('xz', 'lzma'):
+                    # Lzma module only available for python >= 3.3
+                    msg = "{0} compression is only available".format(cmethod)
+                    assert_raises_regex(NotImplementedError, msg,
+                                        numpy_pickle.dump, obj, dump_filename,
+                                        compress=(cmethod, compress))
+                else:
+                    numpy_pickle.dump(obj, dump_filename,
+                                      compress=(cmethod, compress))
+                    # Verify the file contains the right magic number
+                    with open(dump_filename, 'rb') as f:
+                        nose.tools.assert_equal(
+                            _detect_compressor(f), cmethod)
+                    # Verify the reloaded object is correct
+                    obj_reloaded = numpy_pickle.load(dump_filename)
+                    nose.tools.assert_true(isinstance(obj_reloaded, type(obj)))
+                    if isinstance(obj, np.ndarray):
+                        np.testing.assert_array_equal(obj_reloaded, obj)
+                    else:
+                        nose.tools.assert_equal(obj_reloaded, obj)
+                    os.remove(dump_filename)
+
+
+def _gzip_file_decompress(source_filename, target_filename):
+    """Decompress a gzip file."""
+    with closing(gzip.GzipFile(source_filename, "rb")) as fo:
+        buf = fo.read()
+
+    with open(target_filename, "wb") as fo:
+        fo.write(buf)
+
+
+def _zlib_file_decompress(source_filename, target_filename):
+    """Decompress a zlib file."""
+    with open(source_filename, 'rb') as fo:
+        buf = zlib.decompress(fo.read())
+
+    with open(target_filename, 'wb') as fo:
+        fo.write(buf)
+
+
+def test_load_externally_decompressed_files():
+    # Test that BinaryZlibFile generates valid gzip and zlib compressed files.
+    obj = "a string to persist"
+    filename_raw = env['filename'] + str(random.randint(0, 1000))
+    compress_list = (('.z', _zlib_file_decompress),
+                     ('.gz', _gzip_file_decompress))
+
+    for extension, decompress in compress_list:
+        filename_compressed = filename_raw + extension
+        # Use automatic extension detection to compress with the right method.
+        numpy_pickle.dump(obj, filename_compressed)
+
+        # Decompress with the corresponding method
+        decompress(filename_compressed, filename_raw)
+
+        # Test that the uncompressed pickle can be loaded and
+        # that the result is correct.
+        obj_reloaded = numpy_pickle.load(filename_raw)
+        nose.tools.assert_equal(obj, obj_reloaded)
+
+        # Do some cleanup
+        os.remove(filename_raw)
+        if os.path.exists(filename_compressed):
+            os.remove(filename_compressed)
+
+
+def test_compression_using_file_extension():
+    # test that compression method corresponds to the given filename extension.
+    extensions_dict = {
+        # valid compressor extentions
+        '.z': 'zlib',
+        '.gz': 'gzip',
+        '.bz2': 'bz2',
+        '.lzma': 'lzma',
+        '.xz': 'xz',
+        # invalid compressor extensions
+        '.pkl': 'not-compressed',
+        '': 'not-compressed'
+    }
+    filename = env['filename'] + str(random.randint(0, 1000))
+    obj = "object to dump"
+
+    for ext, cmethod in extensions_dict.items():
+        dump_fname = filename + ext
+        if not PY3_OR_LATER and cmethod in ('xz', 'lzma'):
+            # Lzma module only available for python >= 3.3
+            msg = "{0} compression is only available".format(cmethod)
+            assert_raises_regex(NotImplementedError, msg,
+                                numpy_pickle.dump, obj, dump_fname)
+        else:
+            numpy_pickle.dump(obj, dump_fname)
+            # Verify the file contains the right magic number
+            with open(dump_fname, 'rb') as f:
+                nose.tools.assert_equal(
+                    _detect_compressor(f), cmethod)
+            # Verify the reloaded object is correct
+            obj_reloaded = numpy_pickle.load(dump_fname)
+            nose.tools.assert_true(isinstance(obj_reloaded, type(obj)))
+            nose.tools.assert_equal(obj_reloaded, obj)
+            os.remove(dump_fname)
+
+
+@unittest.skip("This format doesn't supports serialization to a stream")
+@with_numpy
+def test_file_handle_persistence():
+    objs = [np.random.random((10, 10)),
+            "some data",
+            np.matrix([0, 1, 2])]
+    fobjs = [open]
+    if not PY26:
+        fobjs += [bz2.BZ2File, gzip.GzipFile]
+    if PY3_OR_LATER:
+        import lzma
+        fobjs += [lzma.LZMAFile]
+    filename = env['filename'] + str(random.randint(0, 1000))
+
+    for obj in objs:
+        for fobj in fobjs:
+            with fobj(filename, 'wb') as f:
+                numpy_pickle.dump(obj, f)
+
+            # using the same decompressor prevents from internally
+            # decompress again.
+            with fobj(filename, 'rb') as f:
+                obj_reloaded = numpy_pickle.load(f)
+
+            # when needed, the correct decompressor should be used when
+            # passing a raw file handle.
+            with open(filename, 'rb') as f:
+                obj_reloaded_2 = numpy_pickle.load(f)
+
+            if isinstance(obj, np.ndarray):
+                np.testing.assert_array_equal(obj_reloaded, obj)
+                np.testing.assert_array_equal(obj_reloaded_2, obj)
+            else:
+                nose.tools.assert_equal(obj_reloaded, obj)
+                nose.tools.assert_equal(obj_reloaded_2, obj)
+
+            os.remove(filename)
+
+
+@unittest.skip("This format doesn't supports serialization to a stream")
+@with_numpy
+def test_in_memory_persistence():
+    objs = [np.random.random((10, 10)),
+            "some data",
+            np.matrix([0, 1, 2])]
+    for obj in objs:
+        f = io.BytesIO()
+        numpy_pickle.dump(obj, f)
+        obj_reloaded = numpy_pickle.load(f)
+        if isinstance(obj, np.ndarray):
+            np.testing.assert_array_equal(obj_reloaded, obj)
+        else:
+            nose.tools.assert_equal(obj_reloaded, obj)
+
+
+@unittest.skip("This format doesn't supports serialization to a stream")
+@with_numpy
+def test_file_handle_persistence_mmap():
+    obj = np.random.random((10, 10))
+    filename = env['filename'] + str(random.randint(0, 1000))
+
+    with open(filename, 'wb') as f:
+        numpy_pickle.dump(obj, f)
+
+    with open(filename, 'rb') as f:
+        obj_reloaded = numpy_pickle.load(f, mmap_mode='r+')
+
+    np.testing.assert_array_equal(obj_reloaded, obj)
+
+@with_numpy
+def test_file_name_persistence_mmap():
+    obj = np.random.random((10, 10))
+    filename = env['filename'] + str(random.randint(0, 1000))
+
+    numpy_pickle.dump(obj, filename)
+    obj_reloaded = numpy_pickle.load(filename, mmap_mode='r+')
+
+    np.testing.assert_array_equal(obj_reloaded, obj)
+
+
+@unittest.skip("This format doesn't supports serialization to a stream")
+@with_numpy
+def test_file_handle_persistence_compressed_mmap():
+    obj = np.random.random((10, 10))
+    filename = env['filename'] + str(random.randint(0, 1000))
+
+    with open(filename, 'wb') as f:
+        numpy_pickle.dump(obj, f, compress=('gzip', 3))
+
+    with closing(gzip.GzipFile(filename, 'rb')) as f:
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            numpy_pickle.load(f, mmap_mode='r+')
+            nose.tools.assert_equal(len(caught_warnings), 1)
+            for warn in caught_warnings:
+                nose.tools.assert_equal(warn.category, UserWarning)
+                nose.tools.assert_equal(warn.message.args[0],
+                                        '"%(fileobj)r" is not a raw file, '
+                                        'mmap_mode "%(mmap_mode)s" flag will '
+                                        'be ignored.'
+                                        % {'fileobj': f, 'mmap_mode': 'r+'})
+
+
+@with_numpy
+def test_file_name_persistence_compressed_mmap():
+    obj = np.random.random((10, 10))
+    filename = env['filename'] + str(random.randint(0, 1000))
+
+    numpy_pickle.dump(obj, filename, compress=('gzip', 3))
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        numpy_pickle.load(filename, mmap_mode='r+')
+        nose.tools.assert_equal(len(caught_warnings), 1)
+        for warn in caught_warnings:
+            nose.tools.assert_equal(warn.category, UserWarning)
+            nose.tools.assert_in('mmap_mode "%(mmap_mode)s" is not compatible with '
+                                 'compressed file'
+                                 % {'mmap_mode': 'r+'},
+                                 warn.message.args[0])
+
+
+@unittest.skip("This format doesn't supports serialization to a stream")
+@with_numpy
+def test_file_handle_persistence_in_memory_mmap():
+    obj = np.random.random((10, 10))
+    buf = io.BytesIO()
+
+    numpy_pickle.dump(obj, buf)
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        numpy_pickle.load(buf, mmap_mode='r+')
+        nose.tools.assert_equal(len(caught_warnings), 1)
+        for warn in caught_warnings:
+            nose.tools.assert_equal(warn.category, UserWarning)
+            nose.tools.assert_equal(warn.message.args[0],
+                                    'In memory persistence is not compatible '
+                                    'with mmap_mode "%(mmap_mode)s" '
+                                    'flag passed. mmap_mode option will be '
+                                    'ignored.' % {'mmap_mode': 'r+'})
+
+
+def test_binary_zlibfile():
+    filename = env['filename'] + str(random.randint(0, 1000))
+
+    # Test bad compression levels
+    for bad_value in (-1, 10, 15, 'a', (), {}):
+        nose.tools.assert_raises(ValueError,
+                                 BinaryZlibFile, filename, 'wb',
+                                 compresslevel=bad_value)
+
+    # Test invalid modes
+    for bad_mode in ('a', 'x', 'r', 'w', 1, 2):
+        nose.tools.assert_raises(ValueError,
+                                 BinaryZlibFile, filename, bad_mode)
+
+    # Test wrong filename type (not a string or a file)
+    for bad_file in (1, (), {}):
+        nose.tools.assert_raises(TypeError,
+                                 BinaryZlibFile, bad_file, 'rb')
+
+    for d in (b'a little data as bytes.',
+              # More bytes
+              10000 * "{0}"
+              .format(random.randint(0, 1000) * 1000).encode('latin-1')):
+        # Regular cases
+        for compress_level in (1, 3, 9):
+            with open(filename, 'wb') as f:
+                with BinaryZlibFile(f, 'wb',
+                                    compresslevel=compress_level) as fz:
+                    nose.tools.assert_true(fz.writable())
+                    fz.write(d)
+                    nose.tools.assert_equal(fz.fileno(), f.fileno())
+                    nose.tools.assert_raises(io.UnsupportedOperation,
+                                             fz._check_can_read)
+                    nose.tools.assert_raises(io.UnsupportedOperation,
+                                             fz._check_can_seek)
+                nose.tools.assert_true(fz.closed)
+                nose.tools.assert_raises(ValueError,
+                                         fz._check_not_closed)
+
+            with open(filename, 'rb') as f:
+                with BinaryZlibFile(f) as fz:
+                    nose.tools.assert_true(fz.readable())
+                    if PY3_OR_LATER:
+                        nose.tools.assert_true(fz.seekable())
+                    nose.tools.assert_equal(fz.fileno(), f.fileno())
+                    nose.tools.assert_equal(fz.read(), d)
+                    nose.tools.assert_raises(io.UnsupportedOperation,
+                                             fz._check_can_write)
+                    if PY3_OR_LATER:
+                        # io.BufferedIOBase doesn't have seekable() method in
+                        # python 2
+                        nose.tools.assert_true(fz.seekable())
+                        fz.seek(0)
+                        nose.tools.assert_equal(fz.tell(), 0)
+                nose.tools.assert_true(fz.closed)
+
+            os.remove(filename)
+
+            # Test with a filename as input
+            with BinaryZlibFile(filename, 'wb',
+                                compresslevel=compress_level) as fz:
+                nose.tools.assert_true(fz.writable())
+                fz.write(d)
+
+            with BinaryZlibFile(filename, 'rb') as fz:
+                nose.tools.assert_equal(fz.read(), d)
+                nose.tools.assert_true(fz.seekable())
+
+            # Test without context manager
+            fz = BinaryZlibFile(filename, 'wb', compresslevel=compress_level)
+            nose.tools.assert_true(fz.writable())
+            fz.write(d)
+            fz.close()
+
+            fz = BinaryZlibFile(filename, 'rb')
+            nose.tools.assert_equal(fz.read(), d)
+            fz.close()
+
+
+###############################################################################
+# Test dumping array subclasses
+if np is not None:
+
+    class SubArray(np.ndarray):
+
+        def __reduce__(self):
+            return _load_sub_array, (np.asarray(self), )
+
+    def _load_sub_array(arr):
+        d = SubArray(arr.shape)
+        d[:] = arr
+        return d
+
+    class ComplexTestObject:
+        """A complex object containing numpy arrays as attributes."""
+
+        def __init__(self):
+            self.array_float = np.arange(100, dtype='float64')
+            self.array_int = np.ones(100, dtype='int32')
+            self.array_obj = np.array(['a', 10, 20.0], dtype='object')
+
+
+@with_numpy
+def test_numpy_subclass():
+    filename = env['filename']
+    a = SubArray((10,))
+    numpy_pickle.dump(a, filename)
+    c = numpy_pickle.load(filename)
+    nose.tools.assert_true(isinstance(c, SubArray))
+    np.testing.assert_array_equal(c, a)
+
+
+def test_pathlib():
+    try:
+        from pathlib import Path
+    except ImportError:
+        pass
+    else:
+        filename = env['filename']
+        value = 123
+        numpy_pickle.dump(value, Path(filename))
+        nose.tools.assert_equal(numpy_pickle.load(filename), value)
+        numpy_pickle.dump(value, filename)
+        nose.tools.assert_equal(numpy_pickle.load(Path(filename)), value)
+
+
+@with_numpy
+def test_non_contiguous_array_pickling():
+    filename = env['filename'] + str(random.randint(0, 1000))
+
+    for array in [  # Array that triggers a contiguousness issue with nditer,
+                    # see https://github.com/joblib/joblib/pull/352 and see
+                    # https://github.com/joblib/joblib/pull/353
+                    np.asfortranarray([[1, 2], [3, 4]])[1:],
+                    # Non contiguous array with works fine with nditer
+                    np.ones((10, 50, 20), order='F')[:, :1, :]]:
+        nose.tools.assert_false(array.flags.c_contiguous)
+        nose.tools.assert_false(array.flags.f_contiguous)
+        numpy_pickle.dump(array, filename)
+        array_reloaded = numpy_pickle.load(filename)
+        np.testing.assert_array_equal(array_reloaded, array)
+        os.remove(filename)
+
+
+@with_numpy
+def test_pickle_highest_protocol():
+    # ensure persistence of a numpy array is valid even when using
+    # the pickle HIGHEST_PROTOCOL.
+    # see https://github.com/joblib/joblib/issues/362
+
+    filename = env['filename'] + str(random.randint(0, 1000))
+    test_array = np.zeros(10)
+
+    numpy_pickle.dump(test_array, filename, protocol=pickle.HIGHEST_PROTOCOL)
+    array_reloaded = numpy_pickle.load(filename)
+
+    np.testing.assert_array_equal(array_reloaded, test_array)
+
+
+@unittest.skip("This format doesn't supports serialization to a stream")
+@with_numpy
+def test_pickle_in_socket():
+    # test that joblib can pickle in sockets
+    if not PY3_OR_LATER:
+        raise nose.SkipTest("Cannot peek or seek in socket in python 2.")
+
+    test_array = np.arange(10)
+    _ADDR = ("localhost", 12345)
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(_ADDR)
+    listener.listen(1)
+
+    client = socket.create_connection(_ADDR)
+    server, client_addr = listener.accept()
+
+    with server.makefile("wb") as sf:
+        numpy_pickle.dump(test_array, sf)
+
+    with client.makefile("rb") as cf:
+        array_reloaded = numpy_pickle.load(cf)
+
+    np.testing.assert_array_equal(array_reloaded, test_array)


### PR DESCRIPTION
## TL;DR
This is a prototype of a cpickle based dump/load without streaming support. Feedback required.


## cPickle based dump/load

Hello,

I tried to use `joblib.Memory` for some general propose memoization and persistence and I found out that `joblib.dump` and `joblib.load` is quite slow because of using pickle instead of cpickle.

I spent some time investigating the problem and I started with current implementation, ideas from #342 and my own ideas. And the result is this prototype.

### Approach and implementation description

* Idea is not to override `save` and `load_build` methods but provide special `__reduce__` method and constructor function for deserialization.
* It is not possible to access internal pickler/unpickler state with cpickle so we could not reuse the same file stream and have to store all numpy data in dedicated file(s).
* Access to unpickler state is required from array constructor to load numpy objects from a dedicated file because a file path and an open mode (or a file handle) are required to load data and not known at serialization time. That's why threadlocal storage is used as a global variable.
* On python < 3.3 is't not possible to declare `reduce` function outside of a class so we have to use pure python pickler implementation for older python versions.

#### Pros:
 * same features as current dump/load except streaming (single file output)
 * same performance for numpy structures
 * much faster read for non-numpy structures with any python version
 * much faster write for non-numpy structures with python >= 3.3

#### Cons:
 * little bit hacky (I don't see a way to avoid magic with thread local storage for state passing)
 * impossible to save all data into single file (for that we need to hack pickle implementation details and that's impossible for cpickle)

#### Not addressed in prototype:
 * full backward compatibility
 * hashing algorithm also should be optimized for fast `joblib.Memory`


## Benchmarks:

Benchmarks were performed on my laptop with Xorg/KDE running so an error is relatively big. 


### master with python2

```bash

$ python -V
Python 2.7.12+
$ python benchmarks/bench_pickle.py -dl --size 100000
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  0.653,  0.2759,       nan,       nan,   1.3
       Big dict,       zlib 3,  0.682,  0.3721,       nan,       nan,   0.4
       Big dict,       mmap r,  0.594,  0.2731,       nan,       nan,   1.3
       Big list,          Raw,  0.186,  0.0623,       nan,       nan,   0.2
       Big list,       zlib 3,  0.210,  0.0866,       nan,       nan,   0.0
       Big list,       mmap r,  0.187,  0.0613,       nan,       nan,   0.2
$ python benchmarks/bench_pickle.py -dl --size 100000 --valuestring
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  0.805,  0.4065,       nan,       nan,   3.1
       Big dict,       zlib 3,  0.962,  0.5572,       nan,       nan,   1.4
       Big dict,       mmap r,  0.802,  0.4078,       nan,       nan,   3.1
       Big list,          Raw,  0.383,  0.1879,       nan,       nan,   2.0
       Big list,       zlib 3,  0.482,  0.2631,       nan,       nan,   0.9
       Big list,       mmap r,  0.385,  0.1876,       nan,       nan,   2.0
$ python benchmarks/bench_pickle.py -dl --size 100000 --valuearray -m
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  6.837,  3.5940,       nan,       nan,  81.7
       Big dict,       zlib 3,  10.106,  5.9666,       nan,       nan,  74.5
       Big list,          Raw,  6.105,  3.3316,       nan,       nan,  80.6
       Big list,       zlib 3,  9.408,  5.1081,       nan,       nan,  73.8
$ python benchmarks/bench_pickle.py -aA
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
      Big array,          Raw,  2.550,  1.6270,       nan,       nan,  762.9
      Big array,       zlib 3,  29.386,  5.9822,       nan,       nan,  723.6
      Big array,       mmap r,  2.248,  0.0016,       nan,       nan,  762.9
   2 big arrays,          Raw,  3.713,  1.7900,       nan,       nan,  839.2
   2 big arrays,       zlib 3,  31.627,  6.7293,       nan,       nan,  795.9
   2 big arrays,       mmap r,  2.512,  0.0018,       nan,       nan,  839.2

```

### prototype with python2

```bash

$ python -V
Python 2.7.12+
$ python benchmarks/bench_pickle.py -dl --size 100000
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  0.613,  0.0654,       nan,       nan,   1.3
       Big dict,       zlib 3,  0.688,  0.2351,       nan,       nan,   0.4
       Big dict,       mmap r,  0.606,  0.0649,       nan,       nan,   1.3
       Big list,          Raw,  0.194,  0.0151,       nan,       nan,   0.2
       Big list,       zlib 3,  0.214,  0.0600,       nan,       nan,   0.0
       Big list,       mmap r,  0.190,  0.0146,       nan,       nan,   0.2
$ python benchmarks/bench_pickle.py -dl --size 100000 --valuestring
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  0.820,  0.0975,       nan,       nan,   3.1
       Big dict,       zlib 3,  0.978,  0.3568,       nan,       nan,   1.4
       Big dict,       mmap r,  0.942,  0.1011,       nan,       nan,   3.1
       Big list,          Raw,  0.476,  0.0444,       nan,       nan,   2.0
       Big list,       zlib 3,  0.490,  0.2025,       nan,       nan,   1.0
       Big list,       mmap r,  0.399,  0.0437,       nan,       nan,   2.0
$ python benchmarks/bench_pickle.py -dl --size 100000 --valuearray -m
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  7.605,  1.7739,       nan,       nan,  81.9
       Big dict,       zlib 3,  10.653,  4.0667,       nan,       nan,  73.8
       Big list,          Raw,  6.689,  1.7060,       nan,       nan,  80.8
       Big list,       zlib 3,  9.942,  3.8809,       nan,       nan,  73.4
$ python benchmarks/bench_pickle.py -aA
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
      Big array,          Raw,  2.032,  1.9293,       nan,       nan,  763.0
      Big array,       zlib 3,  32.844,  6.0443,       nan,       nan,  723.6
      Big array,       mmap r,  3.266,  0.0023,       nan,       nan,  763.0
   2 big arrays,          Raw,  2.237,  1.7739,       nan,       nan,  839.2
   2 big arrays,       zlib 3,  34.270,  6.6405,       nan,       nan,  795.9
   2 big arrays,       mmap r,  2.118,  0.0025,       nan,       nan,  839.2

```

### master with python3

```bash

$ python -V
Python 3.5.2+
$ python benchmarks/bench_pickle.py -dl --size 100000
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  0.752,  0.3601,       nan,       nan,   1.6
       Big dict,       zlib 3,  0.719,  0.4883,       nan,       nan,   0.6
       Big dict,       mmap r,  0.639,  0.3605,       nan,       nan,   1.6
       Big list,          Raw,  0.193,  0.0819,       nan,       nan,   0.2
       Big list,       zlib 3,  0.212,  0.1129,       nan,       nan,   0.0
       Big list,       mmap r,  0.194,  0.0823,       nan,       nan,   0.2
$ python benchmarks/bench_pickle.py -dl --size 100000 --valuestring
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  0.886,  0.5511,       nan,       nan,   3.7
       Big dict,       zlib 3,  1.023,  0.7266,       nan,       nan,   1.6
       Big dict,       mmap r,  0.880,  0.5467,       nan,       nan,   3.7
       Big list,          Raw,  0.404,  0.2643,       nan,       nan,   2.3
       Big list,       zlib 3,  0.494,  0.3537,       nan,       nan,   1.0
       Big list,       mmap r,  0.404,  0.2642,       nan,       nan,   2.3
$ python benchmarks/bench_pickle.py -dl --size 100000 --valuearray -m
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  6.679,  5.1654,       nan,       nan,  82.0
       Big dict,       zlib 3,  10.805,  7.0672,       nan,       nan,  74.8
       Big list,          Raw,  6.687,  5.2708,       nan,       nan,  80.6
       Big list,       zlib 3,  9.946,  6.2664,       nan,       nan,  73.9
$ python benchmarks/bench_pickle.py -aA
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
      Big array,          Raw,  2.410,  1.8254,       nan,       nan,  762.9
      Big array,       zlib 3,  29.553,  6.1150,       nan,       nan,  723.6
      Big array,       mmap r,  2.714,  0.0015,       nan,       nan,  762.9
   2 big arrays,          Raw,  2.691,  1.8529,       nan,       nan,  839.2
   2 big arrays,       zlib 3,  32.913,  6.7173,       nan,       nan,  795.9
   2 big arrays,       mmap r,  2.396,  0.0018,       nan,       nan,  839.2


```

### ptototype with python3

```bash

$ python -V
Python 3.5.2+
$ python benchmarks/bench_pickle.py -dl --size 100000
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  0.031,  0.0334,       nan,       nan,   1.6
       Big dict,       zlib 3,  0.062,  0.0573,       nan,       nan,   0.6
       Big dict,       mmap r,  0.036,  0.0406,       nan,       nan,   1.6
       Big list,          Raw,  0.005,  0.0051,       nan,       nan,   0.2
       Big list,       zlib 3,  0.006,  0.0053,       nan,       nan,   0.0
       Big list,       mmap r,  0.004,  0.0047,       nan,       nan,   0.2
$ python benchmarks/bench_pickle.py -dl --size 100000 --valuestring
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  0.061,  0.0565,       nan,       nan,   3.7
       Big dict,       zlib 3,  0.167,  0.0749,       nan,       nan,   1.6
       Big dict,       mmap r,  0.074,  0.0585,       nan,       nan,   3.7
       Big list,          Raw,  0.028,  0.0220,       nan,       nan,   2.3
       Big list,       zlib 3,  0.088,  0.0366,       nan,       nan,   1.0
       Big list,       mmap r,  0.023,  0.0183,       nan,       nan,   2.3
$ python benchmarks/bench_pickle.py -dl --size 100000 --valuearray -m
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
       Big dict,          Raw,  1.297,  2.1245,       nan,       nan,  82.2
       Big dict,       zlib 3,  4.225,  3.0151,       nan,       nan,  74.1
       Big list,          Raw,  1.355,  2.3261,       nan,       nan,  80.8
       Big list,       zlib 3,  4.196,  3.2450,       nan,       nan,  73.4
$ python benchmarks/bench_pickle.py -aA
        Dataset,     strategy,  write,    read, mem_write,  mem_read,  disk
      Big array,          Raw,  1.778,  1.7705,       nan,       nan,  763.0
      Big array,       zlib 3,  30.877,  6.2192,       nan,       nan,  723.6
      Big array,       mmap r,  2.105,  0.0022,       nan,       nan,  763.0
   2 big arrays,          Raw,  2.007,  1.8471,       nan,       nan,  839.2
   2 big arrays,       zlib 3,  32.511,  7.3159,       nan,       nan,  795.9
   2 big arrays,       mmap r,  1.871,  0.0023,       nan,       nan,  839.2


```