### PR TITLE
[MRG+1] Remove all nose imports from test scripts.

### DIFF
--- a/doc/parallel_numpy_fixture.py
+++ b/doc/parallel_numpy_fixture.py
@@ -1,9 +1,9 @@
 """Fixture module to skip memmaping test if numpy is not installed"""
 
-from nose import SkipTest
 from joblib.parallel import mp
 from joblib.test.common import setup_autokill
 from joblib.test.common import teardown_autokill
+from joblib.testing import SkipTest
 
 
 def setup_module(module):

--- a/doc/persistence_fixture.py
+++ b/doc/persistence_fixture.py
@@ -1,7 +1,7 @@
 """Fixture module to skip the persistence doctest with python 2.6."""
 
-from nose import SkipTest
 from joblib import _compat
+from joblib.testing import SkipTest
 
 
 def setup_module(module):

--- a/joblib/test/common.py
+++ b/joblib/test/common.py
@@ -3,7 +3,6 @@ Small utilities for testing.
 """
 import threading
 import signal
-import nose
 import time
 import os
 import sys
@@ -25,7 +24,7 @@ except ImportError:
     def with_numpy(func):
         """A decorator to skip tests requiring numpy."""
         def my_func():
-            raise nose.SkipTest('Test requires numpy')
+            raise SkipTest('Test requires numpy')
         return my_func
     np = None
 
@@ -48,7 +47,7 @@ except ImportError:
     def with_memory_profiler(func):
         """A decorator to skip tests requiring memory_profiler."""
         def dummy_func():
-            raise nose.SkipTest('Test requires memory_profiler.')
+            raise SkipTest('Test requires memory_profiler.')
         return dummy_func
 
     memory_usage = memory_used = None

--- a/joblib/test/common.py
+++ b/joblib/test/common.py
@@ -9,8 +9,8 @@ import sys
 import gc
 
 from joblib._multiprocessing_helpers import mp
-from nose import SkipTest
-from nose.tools import with_setup
+from joblib.testing import SkipTest, with_setup
+
 
 # A decorator to run tests only when numpy is available
 try:

--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -13,10 +13,9 @@ import os
 import shutil
 import array
 from tempfile import mkdtemp
-from nose.tools import assert_raises
 
 from joblib.disk import disk_used, memstr_to_bytes, mkdirp
-from joblib.testing import assert_true, assert_equal
+from joblib.testing import assert_true, assert_equal, assert_raises
 
 ###############################################################################
 

--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -13,13 +13,13 @@ import os
 import shutil
 import array
 from tempfile import mkdtemp
-
-import nose
+from nose.tools import assert_raises
 
 from joblib.disk import disk_used, memstr_to_bytes, mkdirp
-
+from joblib.testing import assert_true, assert_equal
 
 ###############################################################################
+
 
 def test_disk_used():
     cachedir = mkdtemp()
@@ -37,8 +37,8 @@ def test_disk_used():
         a = array.array('i', n * (1,))
         with open(os.path.join(cachedir, 'test'), 'wb') as output:
             a.tofile(output)
-        nose.tools.assert_true(disk_used(cachedir) >= target_size)
-        nose.tools.assert_true(disk_used(cachedir) < target_size + 12)
+        assert_true(disk_used(cachedir) >= target_size)
+        assert_true(disk_used(cachedir) < target_size + 12)
     finally:
         shutil.rmtree(cachedir)
 
@@ -47,9 +47,9 @@ def test_memstr_to_bytes():
     for text, value in zip(('80G', '1.4M', '120M', '53K'),
                            (80 * 1024 ** 3, int(1.4 * 1024 ** 2),
                             120 * 1024 ** 2, 53 * 1024)):
-        yield nose.tools.assert_equal, memstr_to_bytes(text), value
+        yield assert_equal, memstr_to_bytes(text), value
 
-    nose.tools.assert_raises(ValueError, memstr_to_bytes, 'foobar')
+    assert_raises(ValueError, memstr_to_bytes, 'foobar')
 
 
 def test_mkdirp():
@@ -61,7 +61,7 @@ def test_mkdirp():
         mkdirp(os.path.join(tmp, "spam", "spam"))
 
         # Not all OSErrors are ignored
-        nose.tools.assert_raises(OSError, mkdirp, "")
+        assert_raises(OSError, mkdirp, "")
 
     finally:
         shutil.rmtree(tmp)

--- a/joblib/test/test_format_stack.py
+++ b/joblib/test/test_format_stack.py
@@ -9,11 +9,10 @@ Unit tests for the stack formatting utilities
 import re
 import sys
 
-from nose.tools import assert_true
-
 from joblib.format_stack import safe_repr, _fixed_getframes, format_records
 from joblib.format_stack import format_exc
 from joblib.test.common import with_numpy, np
+from joblib.testing import assert_true
 
 ###############################################################################
 

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -114,24 +114,21 @@ def test_filter_varargs():
 
 def test_filter_kwargs():
     assert_equal(filter_args(k, [], (1, 2), dict(ee=2)),
-                            {'*': [1, 2], '**': {'ee': 2}})
-    assert_equal(filter_args(k, [], (3, 4)),
-                            {'*': [3, 4], '**': {}})
+                 {'*': [1, 2], '**': {'ee': 2}})
+    assert_equal(filter_args(k, [], (3, 4)), {'*': [3, 4], '**': {}})
 
 
 def test_filter_args_2():
     assert_equal(filter_args(j, [], (1, 2), dict(ee=2)),
-                            {'x': 1, 'y': 2, '**': {'ee': 2}})
+                 {'x': 1, 'y': 2, '**': {'ee': 2}})
 
     assert_raises(ValueError, filter_args, f, 'a', (None, ))
     # Check that we capture an undefined argument
     assert_raises(ValueError, filter_args, f, ['a'], (None, ))
     ff = functools.partial(f, 1)
     # filter_args has to special-case partial
-    assert_equal(filter_args(ff, [], (1, )),
-                            {'*': [1], '**': {}})
-    assert_equal(filter_args(ff, ['y'], (1, )),
-                            {'*': [1], '**': {}})
+    assert_equal(filter_args(ff, [], (1, )), {'*': [1], '**': {}})
+    assert_equal(filter_args(ff, ['y'], (1, )), {'*': [1], '**': {}})
 
 
 def test_func_name():
@@ -190,8 +187,7 @@ def test_bound_methods():
     """
     a = Klass()
     b = Klass()
-    assert_not_equal(filter_args(a.f, [], (1, )),
-                                filter_args(b.f, [], (1, )))
+    assert_not_equal(filter_args(a.f, [], (1, )), filter_args(b.f, [], (1, )))
 
 
 def test_filter_args_error_msg():
@@ -214,7 +210,7 @@ def test_format_signature():
     assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
     path, sgn = format_signature(g, list(range(10)), y=list(range(10)))
     assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],'
-                            ' y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
+                      ' y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
 
 @with_numpy
 def test_format_signature_numpy():

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -84,30 +84,21 @@ class Klass(object):
 # Tests
 
 def test_filter_args():
-    yield assert_equal, filter_args(f, [], (1, )),\
-                                              {'x': 1, 'y': 0}
-    yield assert_equal, filter_args(f, ['x'], (1, )),\
-                                              {'y': 0}
-    yield assert_equal, filter_args(f, ['y'], (0, )),\
-                                               {'x': 0}
-    yield assert_equal, filter_args(f, ['y'], (0, ),
-                                               dict(y=1)), {'x': 0}
-    yield assert_equal, filter_args(f, ['x', 'y'],
-                                               (0, )), {}
-    yield assert_equal, filter_args(f, [], (0,),
-                                               dict(y=1)), {'x': 0, 'y': 1}
-    yield assert_equal, filter_args(f, ['y'], (),
-                                               dict(x=2, y=1)), {'x': 2}
+    yield assert_equal, filter_args(f, [], (1, )), {'x': 1, 'y': 0}
+    yield assert_equal, filter_args(f, ['x'], (1, )), {'y': 0}
+    yield assert_equal, filter_args(f, ['y'], (0, )), {'x': 0}
+    yield assert_equal, filter_args(f, ['y'], (0, ), dict(y=1)), {'x': 0}
+    yield assert_equal, filter_args(f, ['x', 'y'], (0, )), {}
+    yield assert_equal, filter_args(f, [], (0,), dict(y=1)), {'x': 0, 'y': 1}
+    yield assert_equal, filter_args(f, ['y'], (), dict(x=2, y=1)), {'x': 2}
 
     yield assert_equal, filter_args(i, [], (2, )), {'x': 2}
-    yield assert_equal, filter_args(f2, [], (),
-                                               dict(x=1)), {'x': 1}
+    yield assert_equal, filter_args(f2, [], (), dict(x=1)), {'x': 1}
 
 
 def test_filter_args_method():
     obj = Klass()
-    assert_equal(filter_args(obj.f, [], (1, )),
-        {'x': 1, 'self': obj})
+    assert_equal(filter_args(obj.f, [], (1, )), {'x': 1, 'self': obj})
 
 
 def test_filter_varargs():
@@ -115,11 +106,9 @@ def test_filter_varargs():
                             {'x': 1, 'y': 0, '*': [], '**': {}}
     yield assert_equal, filter_args(h, [], (1, 2, 3, 4)), \
                             {'x': 1, 'y': 2, '*': [3, 4], '**': {}}
-    yield assert_equal, filter_args(h, [], (1, 25),
-                                               dict(ee=2)), \
+    yield assert_equal, filter_args(h, [], (1, 25), dict(ee=2)), \
                             {'x': 1, 'y': 25, '*': [], '**': {'ee': 2}}
-    yield assert_equal, filter_args(h, ['*'], (1, 2, 25),
-                                               dict(ee=2)), \
+    yield assert_equal, filter_args(h, ['*'], (1, 2, 25), dict(ee=2)), \
                             {'x': 1, 'y': 2, '**': {'ee': 2}}
 
 
@@ -156,16 +145,12 @@ def test_func_inspect_errors():
     assert_equal(get_func_name('a'.lower)[-1], 'lower')
     assert_equal(get_func_code('a'.lower)[1:], (None, -1))
     ff = lambda x: x
-    assert_equal(get_func_name(ff, win_characters=False)[-1],
-                            '<lambda>')
-    assert_equal(get_func_code(ff)[1],
-                            __file__.replace('.pyc', '.py'))
+    assert_equal(get_func_name(ff, win_characters=False)[-1], '<lambda>')
+    assert_equal(get_func_code(ff)[1], __file__.replace('.pyc', '.py'))
     # Simulate a function defined in __main__
     ff.__module__ = '__main__'
-    assert_equal(get_func_name(ff, win_characters=False)[-1],
-                            '<lambda>')
-    assert_equal(get_func_code(ff)[1],
-                            __file__.replace('.pyc', '.py'))
+    assert_equal(get_func_name(ff, win_characters=False)[-1], '<lambda>')
+    assert_equal(get_func_code(ff)[1], __file__.replace('.pyc', '.py'))
 
 
 if PY3_OR_LATER:

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -12,14 +12,12 @@ import tempfile
 import functools
 import sys
 
-from nose.tools import assert_raises
-
 from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import (assert_true, assert_false, assert_equal,
-                            assert_not_equal, assert_raises_regex)
+from joblib.testing import (assert_true, assert_false, assert_not_equal,
+                            assert_equal, assert_raises_regex, assert_raises)
 from joblib._compat import PY3_OR_LATER
 
 

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -8,16 +8,18 @@ Test the func_inspect module.
 
 import os
 import shutil
-import nose
 import tempfile
 import functools
 import sys
+
+from nose.tools import assert_raises
 
 from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import assert_raises_regex
+from joblib.testing import (assert_true, assert_false, assert_equal,
+                            assert_not_equal, assert_raises_regex)
 from joblib._compat import PY3_OR_LATER
 
 
@@ -84,87 +86,87 @@ class Klass(object):
 # Tests
 
 def test_filter_args():
-    yield nose.tools.assert_equal, filter_args(f, [], (1, )),\
+    yield assert_equal, filter_args(f, [], (1, )),\
                                               {'x': 1, 'y': 0}
-    yield nose.tools.assert_equal, filter_args(f, ['x'], (1, )),\
+    yield assert_equal, filter_args(f, ['x'], (1, )),\
                                               {'y': 0}
-    yield nose.tools.assert_equal, filter_args(f, ['y'], (0, )),\
+    yield assert_equal, filter_args(f, ['y'], (0, )),\
                                                {'x': 0}
-    yield nose.tools.assert_equal, filter_args(f, ['y'], (0, ),
+    yield assert_equal, filter_args(f, ['y'], (0, ),
                                                dict(y=1)), {'x': 0}
-    yield nose.tools.assert_equal, filter_args(f, ['x', 'y'],
+    yield assert_equal, filter_args(f, ['x', 'y'],
                                                (0, )), {}
-    yield nose.tools.assert_equal, filter_args(f, [], (0,),
+    yield assert_equal, filter_args(f, [], (0,),
                                                dict(y=1)), {'x': 0, 'y': 1}
-    yield nose.tools.assert_equal, filter_args(f, ['y'], (),
+    yield assert_equal, filter_args(f, ['y'], (),
                                                dict(x=2, y=1)), {'x': 2}
 
-    yield nose.tools.assert_equal, filter_args(i, [], (2, )), {'x': 2}
-    yield nose.tools.assert_equal, filter_args(f2, [], (),
+    yield assert_equal, filter_args(i, [], (2, )), {'x': 2}
+    yield assert_equal, filter_args(f2, [], (),
                                                dict(x=1)), {'x': 1}
 
 
 def test_filter_args_method():
     obj = Klass()
-    nose.tools.assert_equal(filter_args(obj.f, [], (1, )),
+    assert_equal(filter_args(obj.f, [], (1, )),
         {'x': 1, 'self': obj})
 
 
 def test_filter_varargs():
-    yield nose.tools.assert_equal, filter_args(h, [], (1, )), \
+    yield assert_equal, filter_args(h, [], (1, )), \
                             {'x': 1, 'y': 0, '*': [], '**': {}}
-    yield nose.tools.assert_equal, filter_args(h, [], (1, 2, 3, 4)), \
+    yield assert_equal, filter_args(h, [], (1, 2, 3, 4)), \
                             {'x': 1, 'y': 2, '*': [3, 4], '**': {}}
-    yield nose.tools.assert_equal, filter_args(h, [], (1, 25),
+    yield assert_equal, filter_args(h, [], (1, 25),
                                                dict(ee=2)), \
                             {'x': 1, 'y': 25, '*': [], '**': {'ee': 2}}
-    yield nose.tools.assert_equal, filter_args(h, ['*'], (1, 2, 25),
+    yield assert_equal, filter_args(h, ['*'], (1, 2, 25),
                                                dict(ee=2)), \
                             {'x': 1, 'y': 2, '**': {'ee': 2}}
 
 
 def test_filter_kwargs():
-    nose.tools.assert_equal(filter_args(k, [], (1, 2), dict(ee=2)),
+    assert_equal(filter_args(k, [], (1, 2), dict(ee=2)),
                             {'*': [1, 2], '**': {'ee': 2}})
-    nose.tools.assert_equal(filter_args(k, [], (3, 4)),
+    assert_equal(filter_args(k, [], (3, 4)),
                             {'*': [3, 4], '**': {}})
 
 
 def test_filter_args_2():
-    nose.tools.assert_equal(filter_args(j, [], (1, 2), dict(ee=2)),
+    assert_equal(filter_args(j, [], (1, 2), dict(ee=2)),
                             {'x': 1, 'y': 2, '**': {'ee': 2}})
 
-    nose.tools.assert_raises(ValueError, filter_args, f, 'a', (None, ))
+    assert_raises(ValueError, filter_args, f, 'a', (None, ))
     # Check that we capture an undefined argument
-    nose.tools.assert_raises(ValueError, filter_args, f, ['a'], (None, ))
+    assert_raises(ValueError, filter_args, f, ['a'], (None, ))
     ff = functools.partial(f, 1)
     # filter_args has to special-case partial
-    nose.tools.assert_equal(filter_args(ff, [], (1, )),
+    assert_equal(filter_args(ff, [], (1, )),
                             {'*': [1], '**': {}})
-    nose.tools.assert_equal(filter_args(ff, ['y'], (1, )),
+    assert_equal(filter_args(ff, ['y'], (1, )),
                             {'*': [1], '**': {}})
 
 
 def test_func_name():
-    yield nose.tools.assert_equal, 'f', get_func_name(f)[1]
+    yield assert_equal, 'f', get_func_name(f)[1]
     # Check that we are not confused by the decoration
-    yield nose.tools.assert_equal, 'g', get_func_name(g)[1]
+    yield assert_equal, 'g', get_func_name(g)[1]
 
 
 def test_func_inspect_errors():
     # Check that func_inspect is robust and will work on weird objects
-    nose.tools.assert_equal(get_func_name('a'.lower)[-1], 'lower')
-    nose.tools.assert_equal(get_func_code('a'.lower)[1:], (None, -1))
+    assert_equal(get_func_name('a'.lower)[-1], 'lower')
+    assert_equal(get_func_code('a'.lower)[1:], (None, -1))
     ff = lambda x: x
-    nose.tools.assert_equal(get_func_name(ff, win_characters=False)[-1],
+    assert_equal(get_func_name(ff, win_characters=False)[-1],
                             '<lambda>')
-    nose.tools.assert_equal(get_func_code(ff)[1],
+    assert_equal(get_func_code(ff)[1],
                             __file__.replace('.pyc', '.py'))
     # Simulate a function defined in __main__
     ff.__module__ = '__main__'
-    nose.tools.assert_equal(get_func_name(ff, win_characters=False)[-1],
+    assert_equal(get_func_name(ff, win_characters=False)[-1],
                             '<lambda>')
-    nose.tools.assert_equal(get_func_code(ff)[1],
+    assert_equal(get_func_code(ff)[1],
                             __file__.replace('.pyc', '.py'))
 
 
@@ -176,7 +178,7 @@ def func_with_signature(a: int, b: int) -> None: pass
 """)
 
     def test_filter_args_python_3():
-        nose.tools.assert_equal(
+        assert_equal(
             filter_args(func_with_kwonly_args,
                         [], (1, 2), {'kw1': 3, 'kw2': 4}),
             {'a': 1, 'b': 2, 'kw1': 3, 'kw2': 4})
@@ -189,12 +191,12 @@ def func_with_signature(a: int, b: int) -> None: pass
             filter_args,
             func_with_kwonly_args, [], (1, 2, 3), {'kw2': 2})
 
-        nose.tools.assert_equal(
+        assert_equal(
             filter_args(func_with_kwonly_args, ['b', 'kw2'], (1, 2),
                         {'kw1': 3, 'kw2': 4}),
             {'a': 1, 'kw1': 3})
 
-        nose.tools.assert_equal(
+        assert_equal(
             filter_args(func_with_signature, ['b'], (1, 2)),
             {'a': 1})
 
@@ -205,7 +207,7 @@ def test_bound_methods():
     """
     a = Klass()
     b = Klass()
-    nose.tools.assert_not_equal(filter_args(a.f, [], (1, )),
+    assert_not_equal(filter_args(a.f, [], (1, )),
                                 filter_args(b.f, [], (1, )))
 
 
@@ -213,22 +215,22 @@ def test_filter_args_error_msg():
     """ Make sure that filter_args returns decent error messages, for the
         sake of the user.
     """
-    nose.tools.assert_raises(ValueError, filter_args, f, [])
+    assert_raises(ValueError, filter_args, f, [])
 
 
 def test_clean_win_chars():
     string = r'C:\foo\bar\main.py'
     mangled_string = _clean_win_chars(string)
     for char in ('\\', ':', '<', '>', '!'):
-        nose.tools.assert_false(char in mangled_string)
+        assert_false(char in mangled_string)
 
 
 def test_format_signature():
     # Test signature formatting.
     path, sgn = format_signature(g, list(range(10)))
-    nose.tools.assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
+    assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
     path, sgn = format_signature(g, list(range(10)), y=list(range(10)))
-    nose.tools.assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],'
+    assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],'
                             ' y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
 
 @with_numpy
@@ -240,9 +242,9 @@ def test_format_signature_numpy():
 def test_special_source_encoding():
     from joblib.test.test_func_inspect_special_encoding import big5_f
     func_code, source_file, first_line = get_func_code(big5_f)
-    nose.tools.assert_equal(first_line, 5)
-    nose.tools.assert_true("def big5_f():" in func_code)
-    nose.tools.assert_true("test_func_inspect_special_encoding" in source_file)
+    assert_equal(first_line, 5)
+    assert_true("def big5_f():" in func_code)
+    assert_true("test_func_inspect_special_encoding" in source_file)
 
 
 def _get_code():
@@ -253,6 +255,6 @@ def _get_code():
 def test_func_code_consistency():
     from joblib.parallel import Parallel, delayed
     codes = Parallel(n_jobs=2)(delayed(_get_code)() for _ in range(5))
-    nose.tools.assert_equal(len(set(codes)), 1)
+    assert_equal(len(set(codes)), 1)
 
 

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -6,7 +6,6 @@ Test the hashing module.
 # Copyright (c) 2009 Gael Varoquaux
 # License: BSD Style, 3 clauses.
 
-import nose
 import time
 import hashlib
 import tempfile
@@ -19,12 +18,14 @@ import pickle
 import random
 from decimal import Decimal
 
-from nose.tools import assert_equal, assert_not_equal
+from nose import SkipTest
+from nose.tools import with_setup
 
 from joblib.hashing import hash
 from joblib.func_inspect import filter_args
 from joblib.memory import Memory
-from joblib.testing import assert_raises_regex
+from joblib.testing import (assert_equal, assert_not_equal,
+                            assert_raises_regex)
 from joblib.test.test_memory import env as test_memory_env
 from joblib.test.test_memory import setup_module as test_memory_setup_func
 from joblib.test.test_memory import teardown_module as test_memory_teardown_func
@@ -109,17 +110,16 @@ def test_trival_hash():
         for obj2 in obj_list:
             # Check that 2 objects have the same hash only if they are
             # the same.
-            yield nose.tools.assert_equal, hash(obj1) == hash(obj2), \
-                obj1 is obj2
+            yield assert_equal, hash(obj1) == hash(obj2), obj1 is obj2
 
 
 def test_hash_methods():
     # Check that hashing instance methods works
     a = io.StringIO(unicode('a'))
-    nose.tools.assert_equal(hash(a.flush), hash(a.flush))
+    assert_equal(hash(a.flush), hash(a.flush))
     a1 = collections.deque(range(10))
     a2 = collections.deque(range(9))
-    nose.tools.assert_not_equal(hash(a1.extend), hash(a2.extend))
+    assert_not_equal(hash(a1.extend), hash(a2.extend))
 
 
 @with_numpy
@@ -134,17 +134,16 @@ def test_hash_numpy():
     obj_list = (arr1, arr2, arr3)
     for obj1 in obj_list:
         for obj2 in obj_list:
-            yield nose.tools.assert_equal, hash(obj1) == hash(obj2), \
-                np.all(obj1 == obj2)
+            yield assert_equal, hash(obj1) == hash(obj2), np.all(obj1 == obj2)
 
     d1 = {1: arr1, 2: arr1}
     d2 = {1: arr2, 2: arr2}
-    yield nose.tools.assert_equal, hash(d1), hash(d2)
+    yield assert_equal, hash(d1), hash(d2)
 
     d3 = {1: arr2, 2: arr3}
-    yield nose.tools.assert_not_equal, hash(d1), hash(d3)
+    yield assert_not_equal, hash(d1), hash(d3)
 
-    yield nose.tools.assert_not_equal, hash(arr1), hash(arr1.T)
+    yield assert_not_equal, hash(arr1), hash(arr1.T)
 
 
 @with_numpy
@@ -156,7 +155,7 @@ def test_numpy_datetime_array():
     a_hash = hash(np.arange(10))
     arrays = (np.arange(0, 10, dtype=dtype) for dtype in dtypes)
     for array in arrays:
-        nose.tools.assert_not_equal(hash(array), a_hash)
+        assert_not_equal(hash(array), a_hash)
 
 
 @with_numpy
@@ -164,10 +163,10 @@ def test_hash_numpy_noncontiguous():
     a = np.asarray(np.arange(6000).reshape((1000, 2, 3)),
                    order='F')[:, :1, :]
     b = np.ascontiguousarray(a)
-    nose.tools.assert_not_equal(hash(a), hash(b))
+    assert_not_equal(hash(a), hash(b))
 
     c = np.asfortranarray(a)
-    nose.tools.assert_not_equal(hash(a), hash(c))
+    assert_not_equal(hash(a), hash(c))
 
 
 @with_numpy
@@ -180,10 +179,10 @@ def test_hash_memmap():
         m = np.memmap(filename, shape=(10, 10), mode='w+')
         a = np.asarray(m)
         for coerce_mmap in (False, True):
-            yield (nose.tools.assert_equal,
-                            hash(a, coerce_mmap=coerce_mmap)
-                                == hash(m, coerce_mmap=coerce_mmap),
-                            coerce_mmap)
+            yield (assert_equal,
+                   hash(a, coerce_mmap=coerce_mmap) ==
+                   hash(m, coerce_mmap=coerce_mmap),
+                   coerce_mmap)
     finally:
         if 'm' in locals():
             del m
@@ -219,7 +218,7 @@ def test_hash_numpy_performance():
     """
     # This test is not stable under windows for some reason, skip it.
     if sys.platform == 'win32':
-        raise nose.SkipTest()
+        raise SkipTest()
 
     rnd = np.random.RandomState(0)
     a = rnd.random_sample(1000000)
@@ -248,19 +247,19 @@ def test_bound_methods_hash():
     """
     a = Klass()
     b = Klass()
-    nose.tools.assert_equal(hash(filter_args(a.f, [], (1, ))),
-                            hash(filter_args(b.f, [], (1, ))))
+    assert_equal(hash(filter_args(a.f, [], (1, ))),
+                 hash(filter_args(b.f, [], (1, ))))
 
 
-@nose.tools.with_setup(test_memory_setup_func, test_memory_teardown_func)
+@with_setup(test_memory_setup_func, test_memory_teardown_func)
 def test_bound_cached_methods_hash():
     """ Make sure that calling the same _cached_ method on two different
     instances of the same class does resolve to the same hashes.
     """
     a = KlassWithCachedMethod()
     b = KlassWithCachedMethod()
-    nose.tools.assert_equal(hash(filter_args(a.f.func, [], (1, ))),
-                            hash(filter_args(b.f.func, [], (1, ))))
+    assert_equal(hash(filter_args(a.f.func, [], (1, ))),
+                 hash(filter_args(b.f.func, [], (1, ))))
 
 
 @with_numpy
@@ -270,8 +269,7 @@ def test_hash_object_dtype():
     a = np.array([np.arange(i) for i in range(6)], dtype=object)
     b = np.array([np.arange(i) for i in range(6)], dtype=object)
 
-    nose.tools.assert_equal(hash(a),
-                            hash(b))
+    assert_equal(hash(a), hash(b))
 
 
 @with_numpy
@@ -280,10 +278,10 @@ def test_numpy_scalar():
     # strange pickling paths explored, that can give hash collisions
     a = np.float64(2.0)
     b = np.float64(3.0)
-    nose.tools.assert_not_equal(hash(a), hash(b))
+    assert_not_equal(hash(a), hash(b))
 
 
-@nose.tools.with_setup(test_memory_setup_func, test_memory_teardown_func)
+@with_setup(test_memory_setup_func, test_memory_teardown_func)
 def test_dict_hash():
     # Check that dictionaries hash consistently, eventhough the ordering
     # of the keys is not garanteed
@@ -306,11 +304,10 @@ def test_dict_hash():
     a = k.f(d)
     b = k.f(a)
 
-    nose.tools.assert_equal(hash(a),
-                            hash(b))
+    assert_equal(hash(a), hash(b))
 
 
-@nose.tools.with_setup(test_memory_setup_func, test_memory_teardown_func)
+@with_setup(test_memory_setup_func, test_memory_teardown_func)
 def test_set_hash():
     # Check that sets hash consistently, even though their ordering
     # is not guaranteed
@@ -333,16 +330,16 @@ def test_set_hash():
     a = k.f(s)
     b = k.f(a)
 
-    nose.tools.assert_equal(hash(a), hash(b))
+    assert_equal(hash(a), hash(b))
 
 
 if not PY26:
-    @nose.tools.with_setup(test_memory_setup_func, test_memory_teardown_func)
+    @with_setup(test_memory_setup_func, test_memory_teardown_func)
     def test_set_decimal_hash():
         # Check that sets containing decimals hash consistently, even though
         # ordering is not guaranteed
-        nose.tools.assert_equal(hash(set([Decimal(0), Decimal('NaN')])),
-                                hash(set([Decimal('NaN'), Decimal(0)])))
+        assert_equal(hash(set([Decimal(0), Decimal('NaN')])),
+                     hash(set([Decimal('NaN'), Decimal(0)])))
 
 
 def test_string():

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -18,14 +18,11 @@ import pickle
 import random
 from decimal import Decimal
 
-from nose import SkipTest
-from nose.tools import with_setup
-
 from joblib.hashing import hash
 from joblib.func_inspect import filter_args
 from joblib.memory import Memory
 from joblib.testing import (assert_equal, assert_not_equal,
-                            assert_raises_regex)
+                            assert_raises_regex, SkipTest, with_setup)
 from joblib.test.test_memory import env as test_memory_env
 from joblib.test.test_memory import setup_module as test_memory_setup_func
 from joblib.test.test_memory import teardown_module as test_memory_teardown_func

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -163,8 +163,7 @@ def test_no_memory():
     for _ in range(4):
         current_accumulator = len(accumulator)
         gg(1)
-        yield assert_equal, len(accumulator), \
-                    current_accumulator + 1
+        yield assert_equal, len(accumulator), current_accumulator + 1
 
 
 def test_memory_kwarg():

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -17,14 +17,15 @@ import sys
 import time
 import datetime
 
-import nose
+from nose.tools import assert_raises
 
 from joblib.memory import Memory, MemorizedFunc, NotMemorizedFunc
 from joblib.memory import MemorizedResult, NotMemorizedResult, _FUNCTION_HASHES
 from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
-from joblib.testing import assert_raises_regex
+from joblib.testing import (assert_equal, assert_true,
+                            assert_false, assert_raises_regex)
 from joblib._compat import PY3_OR_LATER
 
 
@@ -85,8 +86,8 @@ def check_identity_lazy(func, accumulator):
     func = memory.cache(func)
     for i in range(3):
         for _ in range(2):
-            yield nose.tools.assert_equal, func(i), i
-            yield nose.tools.assert_equal, len(accumulator), i + 1
+            yield assert_equal, func(i), i
+            yield assert_equal, len(accumulator), i + 1
 
 
 ###############################################################################
@@ -139,12 +140,10 @@ def test_memory_integration():
             sys.stdout = orig_stdout
             sys.stderr = orig_stderr
 
-        yield nose.tools.assert_equal, len(accumulator), \
-                    current_accumulator + 1
+        yield assert_equal, len(accumulator), current_accumulator + 1
         # Also, check that Memory.eval works similarly
-        yield nose.tools.assert_equal, memory.eval(f, 1), out
-        yield nose.tools.assert_equal, len(accumulator), \
-                    current_accumulator + 1
+        yield assert_equal, memory.eval(f, 1), out
+        yield assert_equal, len(accumulator), current_accumulator + 1
 
     # Now do a smoke test with a function defined in __main__, as the name
     # mangling rules are more complex
@@ -166,7 +165,7 @@ def test_no_memory():
     for _ in range(4):
         current_accumulator = len(accumulator)
         gg(1)
-        yield nose.tools.assert_equal, len(accumulator), \
+        yield assert_equal, len(accumulator), \
                     current_accumulator + 1
 
 
@@ -184,7 +183,7 @@ def test_memory_kwarg():
     memory = Memory(cachedir=env['dir'], verbose=0)
     g = memory.cache(g)
     # Smoke test with an explicit keyword argument:
-    nose.tools.assert_equal(g(l=30, m=2), 30)
+    assert_equal(g(l=30, m=2), 30)
 
 
 def test_memory_lambda():
@@ -237,8 +236,8 @@ def test_memory_name_collision():
         a(1)
         b(1)
 
-        yield nose.tools.assert_equal, len(w), 1
-        yield nose.tools.assert_true, "collision" in str(w[-1].message)
+        yield assert_equal, len(w), 1
+        yield assert_true, "collision" in str(w[-1].message)
 
 
 def test_memory_warning_lambda_collisions():
@@ -258,13 +257,13 @@ def test_memory_warning_lambda_collisions():
         # inspect.getargspec, see
         # https://github.com/joblib/joblib/issues/247
         warnings.simplefilter("ignore", DeprecationWarning)
-        nose.tools.assert_equal(0, a(0))
-        nose.tools.assert_equal(2, b(1))
-        nose.tools.assert_equal(1, a(1))
+        assert_equal(0, a(0))
+        assert_equal(2, b(1))
+        assert_equal(1, a(1))
 
     # In recent Python versions, we can retrieve the code of lambdas,
     # thus nothing is raised
-    nose.tools.assert_equal(len(w), 4)
+    assert_equal(len(w), 4)
 
 
 def test_memory_warning_collision_detection():
@@ -293,9 +292,8 @@ def test_memory_warning_collision_detection():
         b1(1)
         a1(0)
 
-        yield nose.tools.assert_equal, len(w), 2
-        yield nose.tools.assert_true, \
-                "cannot detect" in str(w[-1].message).lower()
+        yield assert_equal, len(w), 2
+        yield assert_true, "cannot detect" in str(w[-1].message).lower()
 
 
 def test_memory_partial():
@@ -322,7 +320,7 @@ def test_memory_eval():
     m = eval('lambda x: x')
     mm = memory.cache(m)
 
-    yield nose.tools.assert_equal, 1, mm(1)
+    yield assert_equal, 1, mm(1)
 
 
 def count_and_append(x=[]):
@@ -369,8 +367,8 @@ def test_memory_numpy():
         for i in range(3):
             a = rnd.random_sample((10, 10))
             for _ in range(3):
-                yield nose.tools.assert_true, np.all(cached_n(a) == a)
-                yield nose.tools.assert_equal, len(accumulator), i + 1
+                yield assert_true, np.all(cached_n(a) == a)
+                yield assert_equal, len(accumulator), i + 1
 
 
 @with_numpy
@@ -389,11 +387,11 @@ def test_memory_numpy_check_mmap_mode():
     b = twice(a)
     c = twice(a)
 
-    nose.tools.assert_true(isinstance(c, np.memmap))
-    nose.tools.assert_equal(c.mode, 'r')
+    assert_true(isinstance(c, np.memmap))
+    assert_equal(c.mode, 'r')
 
-    nose.tools.assert_true(isinstance(b, np.memmap))
-    nose.tools.assert_equal(b.mode, 'r')
+    assert_true(isinstance(b, np.memmap))
+    assert_equal(b.mode, 'r')
 
 
 def test_memory_exception():
@@ -414,7 +412,7 @@ def test_memory_exception():
 
     for _ in range(3):
         # Call 3 times, to be sure that the Exception is always raised
-        yield nose.tools.assert_raises, MyException, h, 1
+        yield assert_raises, MyException, h, 1
 
 
 def test_memory_ignore():
@@ -426,14 +424,14 @@ def test_memory_ignore():
     def z(x, y=1):
         accumulator.append(1)
 
-    yield nose.tools.assert_equal, z.ignore, ['y']
+    yield assert_equal, z.ignore, ['y']
 
     z(0, y=1)
-    yield nose.tools.assert_equal, len(accumulator), 1
+    yield assert_equal, len(accumulator), 1
     z(0, y=1)
-    yield nose.tools.assert_equal, len(accumulator), 1
+    yield assert_equal, len(accumulator), 1
     z(0, y=2)
-    yield nose.tools.assert_equal, len(accumulator), 1
+    yield assert_equal, len(accumulator), 1
 
 
 def test_partial_decoration():
@@ -449,9 +447,9 @@ def test_partial_decoration():
         def z(x):
             pass
 
-        yield nose.tools.assert_equal, z.ignore, ignore
-        yield nose.tools.assert_equal, z._verbose, verbose
-        yield nose.tools.assert_equal, z.mmap_mode, mmap_mode
+        yield assert_equal, z.ignore, ignore
+        yield assert_equal, z._verbose, verbose
+        yield assert_equal, z.mmap_mode, mmap_mode
 
 
 def test_func_dir():
@@ -464,26 +462,23 @@ def test_func_dir():
 
     g = memory.cache(f)
     # Test that the function directory is created on demand
-    yield nose.tools.assert_equal, g._get_func_dir(), path
-    yield nose.tools.assert_true, os.path.exists(path)
+    yield assert_equal, g._get_func_dir(), path
+    yield assert_true, os.path.exists(path)
 
     # Test that the code is stored.
     # For the following test to be robust to previous execution, we clear
     # the in-memory store
     _FUNCTION_HASHES.clear()
-    yield nose.tools.assert_false, \
-        g._check_previous_func_code()
-    yield nose.tools.assert_true, \
-            os.path.exists(os.path.join(path, 'func_code.py'))
-    yield nose.tools.assert_true, \
-        g._check_previous_func_code()
+    yield assert_false, g._check_previous_func_code()
+    yield assert_true, os.path.exists(os.path.join(path, 'func_code.py'))
+    yield assert_true, g._check_previous_func_code()
 
     # Test the robustness to failure of loading previous results.
     dir, _ = g.get_output_dir(1)
     a = g(1)
-    yield nose.tools.assert_true, os.path.exists(dir)
+    yield assert_true, os.path.exists(dir)
     os.remove(os.path.join(dir, 'output.pkl'))
-    yield nose.tools.assert_equal, a, g(1)
+    yield assert_equal, a, g(1)
 
 
 def test_persistence():
@@ -496,9 +491,9 @@ def test_persistence():
 
     output_dir, _ = h.get_output_dir(1)
     func_name = _get_func_fullname(f)
-    yield nose.tools.assert_equal, output, _load_output(output_dir, func_name)
+    yield assert_equal, output, _load_output(output_dir, func_name)
     memory2 = pickle.loads(pickle.dumps(memory))
-    yield nose.tools.assert_equal, memory.cachedir, memory2.cachedir
+    yield assert_equal, memory.cachedir, memory2.cachedir
 
     # Smoke test that pickling a memory with cachedir=None works
     memory = Memory(cachedir=None, verbose=0)
@@ -519,13 +514,13 @@ def test_call_and_shelve():
                              ),
                             (MemorizedResult, NotMemorizedResult,
                              MemorizedResult, NotMemorizedResult)):
-        nose.tools.assert_equal(func(2), 5)
+        assert_equal(func(2), 5)
         result = func.call_and_shelve(2)
-        nose.tools.assert_true(isinstance(result, Result))
-        nose.tools.assert_equal(result.get(), 5)
+        assert_true(isinstance(result, Result))
+        assert_equal(result.get(), 5)
 
         result.clear()
-        nose.tools.assert_raises(KeyError, result.get)
+        assert_raises(KeyError, result.get)
         result.clear()  # Do nothing if there is no cache.
 
 
@@ -537,7 +532,7 @@ def test_memorized_pickling():
             pickle.dump(result, fp)
         with open(filename, 'rb') as fp:
             result2 = pickle.load(fp)
-        nose.tools.assert_equal(result2.get(), result.get())
+        assert_equal(result2.get(), result.get())
         os.remove(filename)
 
 
@@ -547,8 +542,8 @@ def test_memorized_repr():
 
     func2 = MemorizedFunc(f, env['dir'])
     result2 = func2.call_and_shelve(2)
-    nose.tools.assert_equal(result.get(), result2.get())
-    nose.tools.assert_equal(repr(func), repr(func2))
+    assert_equal(result.get(), result2.get())
+    assert_equal(repr(func), repr(func2))
 
     # Smoke test with NotMemorizedFunc
     func = NotMemorizedFunc(f)
@@ -639,7 +634,7 @@ def test_memory_file_modification():
 
     finally:
         sys.stdout = orig_stdout
-    nose.tools.assert_equal(my_stdout.getvalue(), '1\n2\nReloading\nx=1\n')
+    assert_equal(my_stdout.getvalue(), '1\n2\nReloading\nx=1\n')
 
 
 def _function_to_cache(a, b):
@@ -661,8 +656,8 @@ def test_memory_in_memory_function_code_change():
     mem = Memory(cachedir=env['dir'], verbose=0)
     f = mem.cache(_function_to_cache)
 
-    nose.tools.assert_equal(f(1, 2), 3)
-    nose.tools.assert_equal(f(1, 2), 3)
+    assert_equal(f(1, 2), 3)
+    assert_equal(f(1, 2), 3)
 
     with warnings.catch_warnings(record=True):
         # ignore name collision warnings
@@ -671,8 +666,8 @@ def test_memory_in_memory_function_code_change():
         # Check that inline function modification triggers a cache invalidation
 
         _function_to_cache.__code__ = _product.__code__
-        nose.tools.assert_equal(f(1, 2), 2)
-        nose.tools.assert_equal(f(1, 2), 2)
+        assert_equal(f(1, 2), 2)
+        assert_equal(f(1, 2), 2)
 
 
 def test_clear_memory_with_none_cachedir():
@@ -692,7 +687,7 @@ def func_with_signature(a: int, b: float) -> float:
         mem = Memory(cachedir=env['dir'], verbose=0)
         func_cached = mem.cache(func_with_kwonly_args)
 
-        nose.tools.assert_equal(func_cached(1, 2, kw1=3), (1, 2, 3, 'kw2'))
+        assert_equal(func_cached(1, 2, kw1=3), (1, 2, 3, 'kw2'))
 
         # Making sure that providing a keyword-only argument by
         # position raises an exception
@@ -714,15 +709,15 @@ def func_with_signature(a: int, b: float) -> float:
 
         # Test 'ignore' parameter
         func_cached = mem.cache(func_with_kwonly_args, ignore=['kw2'])
-        nose.tools.assert_equal(func_cached(1, 2, kw1=3, kw2=4), (1, 2, 3, 4))
-        nose.tools.assert_equal(func_cached(1, 2, kw1=3, kw2='ignored'), (1, 2, 3, 4))
+        assert_equal(func_cached(1, 2, kw1=3, kw2=4), (1, 2, 3, 4))
+        assert_equal(func_cached(1, 2, kw1=3, kw2='ignored'), (1, 2, 3, 4))
 
 
     def test_memory_func_with_signature():
         mem = Memory(cachedir=env['dir'], verbose=0)
         func_cached = mem.cache(func_with_signature)
 
-        nose.tools.assert_equal(func_cached(1, 2.), 3.)
+        assert_equal(func_cached(1, 2.), 3.)
 
 
 def _setup_temporary_cache_folder(num_inputs=10):
@@ -751,8 +746,7 @@ def test__get_cache_items():
     cachedir = mem.cachedir
     cache_items = _get_cache_items(cachedir)
     hash_cachedirs = [ci.path for ci in cache_items]
-    nose.tools.assert_equal(
-        set(hash_cachedirs), set(expected_hash_cachedirs))
+    assert_equal(set(hash_cachedirs), set(expected_hash_cachedirs))
 
     def get_files_size(directory):
         full_paths = [os.path.join(directory, fn)
@@ -762,8 +756,7 @@ def test__get_cache_items():
     expected_hash_cache_sizes = [get_files_size(hash_dir)
                                  for hash_dir in hash_cachedirs]
     hash_cache_sizes = [ci.size for ci in cache_items]
-    nose.tools.assert_equal(hash_cache_sizes,
-                            expected_hash_cache_sizes)
+    assert_equal(hash_cache_sizes, expected_hash_cache_sizes)
 
     output_filenames = [os.path.join(hash_dir, 'output.pkl')
                         for hash_dir in hash_cachedirs]
@@ -772,8 +765,7 @@ def test__get_cache_items():
         datetime.datetime.fromtimestamp(os.path.getatime(fn))
         for fn in output_filenames]
     last_accesses = [ci.last_access for ci in cache_items]
-    nose.tools.assert_equal(last_accesses,
-                            expected_last_accesses)
+    assert_equal(last_accesses, expected_last_accesses)
 
 
 def test__get_cache_items_to_delete():
@@ -784,25 +776,23 @@ def test__get_cache_items_to_delete():
     # folder is about 1000 bytes + metadata)
     cache_items_to_delete = _get_cache_items_to_delete(cachedir, '2K')
     nb_hashes = len(expected_hash_cachedirs)
-    nose.tools.assert_true(set.issubset(set(cache_items_to_delete),
-                                        set(cache_items)))
-    nose.tools.assert_equal(len(cache_items_to_delete), nb_hashes - 1)
+    assert_true(set.issubset(set(cache_items_to_delete), set(cache_items)))
+    assert_equal(len(cache_items_to_delete), nb_hashes - 1)
 
     # Sanity check bytes_limit=2048 is the same as bytes_limit='2K'
     cache_items_to_delete_2048b = _get_cache_items_to_delete(cachedir, 2048)
-    nose.tools.assert_equal(sorted(cache_items_to_delete),
-                            sorted(cache_items_to_delete_2048b))
+    assert_equal(sorted(cache_items_to_delete),
+                 sorted(cache_items_to_delete_2048b))
 
     # bytes_limit greater than the size of the cache
     cache_items_to_delete_empty = _get_cache_items_to_delete(cachedir, '1M')
-    nose.tools.assert_equal(cache_items_to_delete_empty, [])
+    assert_equal(cache_items_to_delete_empty, [])
 
     # All the cache items need to be deleted
     bytes_limit_too_small = 500
     cache_items_to_delete_500b = _get_cache_items_to_delete(
         cachedir, bytes_limit_too_small)
-    nose.tools.assert_true(set(cache_items_to_delete_500b),
-                           set(cache_items))
+    assert_true(set(cache_items_to_delete_500b), set(cache_items))
 
     # Test LRU property: surviving cache items should all have a more
     # recent last_access that the ones that have been deleted
@@ -810,7 +800,7 @@ def test__get_cache_items_to_delete():
     surviving_cache_items = set(cache_items).difference(
         cache_items_to_delete_6000b)
 
-    nose.tools.assert_true(
+    assert_true(
         max(ci.last_access for ci in cache_items_to_delete_6000b) <=
         min(ci.last_access for ci in surviving_cache_items))
 
@@ -823,28 +813,25 @@ def test_memory_reduce_size():
     # By default mem.bytes_limit is None and reduce_size is a noop
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
-    nose.tools.assert_equal(sorted(ref_cache_items),
-                            sorted(cache_items))
+    assert_equal(sorted(ref_cache_items), sorted(cache_items))
 
     # No cache items deleted if bytes_limit greater than the size of
     # the cache
     mem.bytes_limit = '1M'
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
-    nose.tools.assert_equal(sorted(ref_cache_items),
-                            sorted(cache_items))
+    assert_equal(sorted(ref_cache_items), sorted(cache_items))
 
     # bytes_limit is set so that only two cache items are kept
     mem.bytes_limit = '3K'
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
-    nose.tools.assert_true(set.issubset(set(cache_items),
-                                        set(ref_cache_items)))
-    nose.tools.assert_equal(len(cache_items), 2)
+    assert_true(set.issubset(set(cache_items), set(ref_cache_items)))
+    assert_equal(len(cache_items), 2)
 
     # bytes_limit set so that no cache item is kept
     bytes_limit_too_small = 500
     mem.bytes_limit = bytes_limit_too_small
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
-    nose.tools.assert_equal(cache_items, [])
+    assert_equal(cache_items, [])

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -17,15 +17,13 @@ import sys
 import time
 import datetime
 
-from nose.tools import assert_raises
-
 from joblib.memory import Memory, MemorizedFunc, NotMemorizedFunc
 from joblib.memory import MemorizedResult, NotMemorizedResult, _FUNCTION_HASHES
 from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
-from joblib.testing import (assert_equal, assert_true,
-                            assert_false, assert_raises_regex)
+from joblib.testing import (assert_equal, assert_true, assert_false,
+                            assert_raises, assert_raises_regex)
 from joblib._compat import PY3_OR_LATER
 
 

--- a/joblib/test/test_my_exceptions.py
+++ b/joblib/test/test_my_exceptions.py
@@ -1,9 +1,8 @@
 """
 Test my automatically generate exceptions
 """
-from nose.tools import assert_true
-
 from joblib import my_exceptions
+from joblib.testing import assert_true
 
 
 class CustomException(Exception):

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -18,12 +18,11 @@ import socket
 from contextlib import closing
 
 from nose import SkipTest
-from nose.tools import assert_raises
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_memory_profiler, memory_used
 from joblib.testing import (assert_equal, assert_true, assert_false,
-                            assert_raises_regex)
+                            assert_raises, assert_raises_regex)
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -17,12 +17,10 @@ import pickle
 import socket
 from contextlib import closing
 
-from nose import SkipTest
-
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_memory_profiler, memory_used
 from joblib.testing import (assert_equal, assert_true, assert_false,
-                            assert_raises, assert_raises_regex)
+                            assert_raises, assert_raises_regex, SkipTest)
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -337,12 +337,10 @@ def test_compress_mmap_mode_warning():
         for warn in caught_warnings:
             assert_equal(warn.category, UserWarning)
             assert_equal(warn.message.args[0],
-                                    'mmap_mode "%(mmap_mode)s" is not '
-                                    'compatible with compressed file '
-                                    '%(filename)s. '
-                                    '"%(mmap_mode)s" flag will be ignored.'
-                                    % {'filename': this_filename,
-                                       'mmap_mode': 'r+'})
+                         'mmap_mode "%(mmap_mode)s" is not compatible with '
+                         'compressed file %(filename)s. "%(mmap_mode)s" flag '
+                         'will be ignored.' % {'filename': this_filename,
+                                               'mmap_mode': 'r+'})
 
 
 @with_numpy
@@ -357,16 +355,14 @@ def test_cache_size_warning():
             warnings.simplefilter("always")
             numpy_pickle.dump(a, filename, cache_size=cache_size)
             expected_nb_warnings = 1 if cache_size is not None else 0
-            assert_equal(len(caught_warnings),
-                                    expected_nb_warnings)
+            assert_equal(len(caught_warnings), expected_nb_warnings)
             for warn in caught_warnings:
                 assert_equal(warn.category, DeprecationWarning)
                 assert_equal(warn.message.args[0],
-                                        "Please do not set 'cache_size' in "
-                                        "joblib.dump, this parameter has no "
-                                        "effect and will be removed. "
-                                        "You used 'cache_size={0}'".format(
-                                            cache_size))
+                             "Please do not set 'cache_size' in joblib.dump, "
+                             "this parameter has no effect and will be "
+                             "removed. You used 'cache_size={0}'".format(
+                             cache_size))
 
 
 @with_numpy

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -10,7 +10,6 @@ import re
 import tempfile
 import io
 import warnings
-import nose
 import gzip
 import zlib
 import bz2
@@ -18,9 +17,13 @@ import pickle
 import socket
 from contextlib import closing
 
+from nose import SkipTest
+from nose.tools import assert_raises
+
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_memory_profiler, memory_used
-from joblib.testing import assert_raises_regex
+from joblib.testing import (assert_equal, assert_true, assert_false,
+                            assert_raises_regex)
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.
@@ -151,13 +154,12 @@ def test_standard_types():
             # We compare the pickled instance to the reloaded one only if it
             # can be compared to a copied one
             if member == copy.deepcopy(member):
-                yield nose.tools.assert_equal, member, _member
+                yield assert_equal, member, _member
 
 
 def test_value_error():
     # Test inverting the input arguments to dump
-    nose.tools.assert_raises(ValueError, numpy_pickle.dump, 'foo',
-                             dict())
+    assert_raises(ValueError, numpy_pickle.dump, 'foo', dict())
 
 
 def test_compress_level_error():
@@ -185,18 +187,18 @@ def test_numpy_persistence():
                                           compress=compress)
 
             # All is cached in one file
-            nose.tools.assert_equal(len(filenames), 1)
+            assert_equal(len(filenames), 1)
             # Check that only one file was created
-            nose.tools.assert_equal(filenames[0], this_filename)
+            assert_equal(filenames[0], this_filename)
             # Check that this file does exist
-            nose.tools.assert_true(
+            assert_true(
                 os.path.exists(os.path.join(env['dir'], filenames[0])))
 
             # Unpickle the object
             obj_ = numpy_pickle.load(this_filename)
             # Check that the items are indeed arrays
             for item in obj_:
-                nose.tools.assert_true(isinstance(item, np.ndarray))
+                assert_true(isinstance(item, np.ndarray))
             # And finally, check that all the values are equal.
             np.testing.assert_array_equal(np.array(obj), np.array(obj_))
 
@@ -208,13 +210,13 @@ def test_numpy_persistence():
             filenames = numpy_pickle.dump(obj, this_filename,
                                           compress=compress)
             # All is cached in one file
-            nose.tools.assert_equal(len(filenames), 1)
+            assert_equal(len(filenames), 1)
 
             obj_ = numpy_pickle.load(this_filename)
             if (type(obj) is not np.memmap and
                     hasattr(obj, '__array_prepare__')):
                 # We don't reconstruct memmaps
-                nose.tools.assert_true(isinstance(obj_, type(obj)))
+                assert_true(isinstance(obj_, type(obj)))
 
             np.testing.assert_array_equal(obj_, obj)
 
@@ -223,10 +225,10 @@ def test_numpy_persistence():
         filenames = numpy_pickle.dump(obj, this_filename,
                                       compress=compress)
         # All is cached in one file
-        nose.tools.assert_equal(len(filenames), 1)
+        assert_equal(len(filenames), 1)
 
         obj_loaded = numpy_pickle.load(this_filename)
-        nose.tools.assert_true(isinstance(obj_loaded, type(obj)))
+        assert_true(isinstance(obj_loaded, type(obj)))
         np.testing.assert_array_equal(obj_loaded.array_float, obj.array_float)
         np.testing.assert_array_equal(obj_loaded.array_int, obj.array_int)
         np.testing.assert_array_equal(obj_loaded.array_obj, obj.array_obj)
@@ -250,20 +252,20 @@ def test_memmap_persistence():
     numpy_pickle.dump(a, filename)
     b = numpy_pickle.load(filename, mmap_mode='r')
 
-    nose.tools.assert_true(isinstance(b, np.memmap))
+    assert_true(isinstance(b, np.memmap))
 
     # Test with an object containing multiple numpy arrays
     filename = env['filename'] + str(random.randint(0, 1000))
     obj = ComplexTestObject()
     numpy_pickle.dump(obj, filename)
     obj_loaded = numpy_pickle.load(filename, mmap_mode='r')
-    nose.tools.assert_true(isinstance(obj_loaded, type(obj)))
-    nose.tools.assert_true(isinstance(obj_loaded.array_float, np.memmap))
-    nose.tools.assert_false(obj_loaded.array_float.flags.writeable)
-    nose.tools.assert_true(isinstance(obj_loaded.array_int, np.memmap))
-    nose.tools.assert_false(obj_loaded.array_int.flags.writeable)
+    assert_true(isinstance(obj_loaded, type(obj)))
+    assert_true(isinstance(obj_loaded.array_float, np.memmap))
+    assert_false(obj_loaded.array_float.flags.writeable)
+    assert_true(isinstance(obj_loaded.array_int, np.memmap))
+    assert_false(obj_loaded.array_int.flags.writeable)
     # Memory map not allowed for numpy object arrays
-    nose.tools.assert_false(isinstance(obj_loaded.array_obj, np.memmap))
+    assert_false(isinstance(obj_loaded.array_obj, np.memmap))
     np.testing.assert_array_equal(obj_loaded.array_float,
                                   obj.array_float)
     np.testing.assert_array_equal(obj_loaded.array_int,
@@ -273,9 +275,9 @@ def test_memmap_persistence():
 
     # Test we can write in memmaped arrays
     obj_loaded = numpy_pickle.load(filename, mmap_mode='r+')
-    nose.tools.assert_true(obj_loaded.array_float.flags.writeable)
+    assert_true(obj_loaded.array_float.flags.writeable)
     obj_loaded.array_float[0:10] = 10.0
-    nose.tools.assert_true(obj_loaded.array_int.flags.writeable)
+    assert_true(obj_loaded.array_int.flags.writeable)
     obj_loaded.array_int[0:10] = 10
 
     obj_reloaded = numpy_pickle.load(filename, mmap_mode='r')
@@ -286,10 +288,10 @@ def test_memmap_persistence():
 
     # Test w+ mode is caught and the mode has switched to r+
     numpy_pickle.load(filename, mmap_mode='w+')
-    nose.tools.assert_true(obj_loaded.array_int.flags.writeable)
-    nose.tools.assert_equal(obj_loaded.array_int.mode, 'r+')
-    nose.tools.assert_true(obj_loaded.array_float.flags.writeable)
-    nose.tools.assert_equal(obj_loaded.array_float.mode, 'r+')
+    assert_true(obj_loaded.array_int.flags.writeable)
+    assert_equal(obj_loaded.array_int.mode, 'r+')
+    assert_true(obj_loaded.array_float.flags.writeable)
+    assert_equal(obj_loaded.array_float.mode, 'r+')
 
 
 @with_numpy
@@ -305,10 +307,10 @@ def test_memmap_persistence_mixed_dtypes():
     a_clone, b_clone = numpy_pickle.load(filename, mmap_mode='r')
 
     # the floating point array has been memory mapped
-    nose.tools.assert_true(isinstance(a_clone, np.memmap))
+    assert_true(isinstance(a_clone, np.memmap))
 
     # the object-dtype array has been loaded in memory
-    nose.tools.assert_false(isinstance(b_clone, np.memmap))
+    assert_false(isinstance(b_clone, np.memmap))
 
 
 @with_numpy
@@ -321,7 +323,7 @@ def test_masked_array_persistence():
     filename = env['filename'] + str(random.randint(0, 1000))
     numpy_pickle.dump(a, filename)
     b = numpy_pickle.load(filename, mmap_mode='r')
-    nose.tools.assert_true(isinstance(b, np.ma.masked_array))
+    assert_true(isinstance(b, np.ma.masked_array))
 
 
 @with_numpy
@@ -334,10 +336,10 @@ def test_compress_mmap_mode_warning():
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
         numpy_pickle.load(this_filename, mmap_mode='r+')
-        nose.tools.assert_equal(len(caught_warnings), 1)
+        assert_equal(len(caught_warnings), 1)
         for warn in caught_warnings:
-            nose.tools.assert_equal(warn.category, UserWarning)
-            nose.tools.assert_equal(warn.message.args[0],
+            assert_equal(warn.category, UserWarning)
+            assert_equal(warn.message.args[0],
                                     'mmap_mode "%(mmap_mode)s" is not '
                                     'compatible with compressed file '
                                     '%(filename)s. '
@@ -358,11 +360,11 @@ def test_cache_size_warning():
             warnings.simplefilter("always")
             numpy_pickle.dump(a, filename, cache_size=cache_size)
             expected_nb_warnings = 1 if cache_size is not None else 0
-            nose.tools.assert_equal(len(caught_warnings),
+            assert_equal(len(caught_warnings),
                                     expected_nb_warnings)
             for warn in caught_warnings:
-                nose.tools.assert_equal(warn.category, DeprecationWarning)
-                nose.tools.assert_equal(warn.message.args[0],
+                assert_equal(warn.category, DeprecationWarning)
+                assert_equal(warn.message.args[0],
                                         "Please do not set 'cache_size' in "
                                         "joblib.dump, this parameter has no "
                                         "effect and will be removed. "
@@ -389,13 +391,13 @@ def test_memory_usage():
             # The memory used to dump the object shouldn't exceed the buffer
             # size used to write array chunks (16MB).
             write_buf_size = _IO_BUFFER_SIZE + 16 * 1024 ** 2 / 1e6
-            nose.tools.assert_true(mem_used <= write_buf_size)
+            assert_true(mem_used <= write_buf_size)
 
             mem_used = memory_used(numpy_pickle.load, obj_filename)
             # memory used should be less than array size + buffer size used to
             # read the array chunk by chunk.
             read_buf_size = 32 + _IO_BUFFER_SIZE  # MiB
-            nose.tools.assert_true(mem_used < size + read_buf_size)
+            assert_true(mem_used < size + read_buf_size)
 
 
 @with_numpy
@@ -421,14 +423,14 @@ def test_compressed_pickle_dump_and_load():
 
     try:
         dumped_filenames = numpy_pickle.dump(expected_list, fname, compress=1)
-        nose.tools.assert_equal(len(dumped_filenames), 1)
+        assert_equal(len(dumped_filenames), 1)
         result_list = numpy_pickle.load(fname)
         for result, expected in zip(result_list, expected_list):
             if isinstance(expected, np.ndarray):
-                nose.tools.assert_equal(result.dtype, expected.dtype)
+                assert_equal(result.dtype, expected.dtype)
                 np.testing.assert_equal(result, expected)
             else:
-                nose.tools.assert_equal(result, expected)
+                assert_equal(result, expected)
     finally:
         os.remove(fname)
 
@@ -442,8 +444,7 @@ def _check_pickle(filename, expected_list):
     if (not PY3_OR_LATER and (filename.endswith('.xz') or
                               filename.endswith('.lzma'))):
         # lzma is not supported for python versions < 3.3
-        nose.tools.assert_raises(NotImplementedError,
-                                 numpy_pickle.load, filename)
+        assert_raises(NotImplementedError, numpy_pickle.load, filename)
         return
 
     version_match = re.match(r'.+py(\d)(\d).+', filename)
@@ -462,30 +463,28 @@ def _check_pickle(filename, expected_list):
                 result_list = numpy_pickle.load(filename)
                 expected_nb_warnings = 1 if ("0.9" in filename or
                                              "0.8.4" in filename) else 0
-                nose.tools.assert_equal(len(caught_warnings),
-                                        expected_nb_warnings)
+                assert_equal(len(caught_warnings), expected_nb_warnings)
             for warn in caught_warnings:
-                nose.tools.assert_equal(warn.category, DeprecationWarning)
-                nose.tools.assert_equal(warn.message.args[0],
-                                        "The file '{0}' has been generated "
-                                        "with a joblib version less than "
-                                        "0.10. Please regenerate this pickle "
-                                        "file.".format(filename))
+                assert_equal(warn.category, DeprecationWarning)
+                assert_equal(warn.message.args[0],
+                             "The file '{0}' has been generated with a joblib "
+                             "version less than 0.10. Please regenerate this "
+                             "pickle file.".format(filename))
             for result, expected in zip(result_list, expected_list):
                 if isinstance(expected, np.ndarray):
-                    nose.tools.assert_equal(result.dtype, expected.dtype)
+                    assert_equal(result.dtype, expected.dtype)
                     np.testing.assert_equal(result, expected)
                 else:
-                    nose.tools.assert_equal(result, expected)
+                    assert_equal(result, expected)
         except Exception as exc:
             # When trying to read with python 3 a pickle generated
             # with python 2 we expect a user-friendly error
             if (py_version_used_for_reading == 3 and
                     py_version_used_for_writing == 2):
-                nose.tools.assert_true(isinstance(exc, ValueError))
+                assert_true(isinstance(exc, ValueError))
                 message = ('You may be trying to read with '
                            'python 3 a joblib pickle generated with python 2.')
-                nose.tools.assert_true(message in str(exc))
+                assert_true(message in str(exc))
             else:
                 raise
     else:
@@ -498,7 +497,7 @@ def _check_pickle(filename, expected_list):
         except ValueError as e:
             message = 'unsupported pickle protocol: {0}'.format(
                 pickle_writing_protocol)
-            nose.tools.assert_true(message in str(e.args))
+            assert_true(message in str(e.args))
 
 
 @with_numpy
@@ -546,7 +545,7 @@ def test_compress_tuple_argument():
                           compress=compress)
         # Verify the file contains the right magic number
         with open(filename, 'rb') as f:
-            nose.tools.assert_equal(_detect_compressor(f), compress[0])
+            assert_equal(_detect_compressor(f), compress[0])
 
     # Verify setting a wrong compress tuple raises a ValueError.
     assert_raises_regex(ValueError,
@@ -591,15 +590,14 @@ def test_joblib_compression_formats():
                                       compress=(cmethod, compress))
                     # Verify the file contains the right magic number
                     with open(dump_filename, 'rb') as f:
-                        nose.tools.assert_equal(
-                            _detect_compressor(f), cmethod)
+                        assert_equal(_detect_compressor(f), cmethod)
                     # Verify the reloaded object is correct
                     obj_reloaded = numpy_pickle.load(dump_filename)
-                    nose.tools.assert_true(isinstance(obj_reloaded, type(obj)))
+                    assert_true(isinstance(obj_reloaded, type(obj)))
                     if isinstance(obj, np.ndarray):
                         np.testing.assert_array_equal(obj_reloaded, obj)
                     else:
-                        nose.tools.assert_equal(obj_reloaded, obj)
+                        assert_equal(obj_reloaded, obj)
                     os.remove(dump_filename)
 
 
@@ -639,7 +637,7 @@ def test_load_externally_decompressed_files():
         # Test that the uncompressed pickle can be loaded and
         # that the result is correct.
         obj_reloaded = numpy_pickle.load(filename_raw)
-        nose.tools.assert_equal(obj, obj_reloaded)
+        assert_equal(obj, obj_reloaded)
 
         # Do some cleanup
         os.remove(filename_raw)
@@ -674,12 +672,11 @@ def test_compression_using_file_extension():
             numpy_pickle.dump(obj, dump_fname)
             # Verify the file contains the right magic number
             with open(dump_fname, 'rb') as f:
-                nose.tools.assert_equal(
-                    _detect_compressor(f), cmethod)
+                assert_equal(_detect_compressor(f), cmethod)
             # Verify the reloaded object is correct
             obj_reloaded = numpy_pickle.load(dump_fname)
-            nose.tools.assert_true(isinstance(obj_reloaded, type(obj)))
-            nose.tools.assert_equal(obj_reloaded, obj)
+            assert_true(isinstance(obj_reloaded, type(obj)))
+            assert_equal(obj_reloaded, obj)
             os.remove(dump_fname)
 
 
@@ -715,8 +712,8 @@ def test_file_handle_persistence():
                 np.testing.assert_array_equal(obj_reloaded, obj)
                 np.testing.assert_array_equal(obj_reloaded_2, obj)
             else:
-                nose.tools.assert_equal(obj_reloaded, obj)
-                nose.tools.assert_equal(obj_reloaded_2, obj)
+                assert_equal(obj_reloaded, obj)
+                assert_equal(obj_reloaded_2, obj)
 
             os.remove(filename)
 
@@ -733,7 +730,7 @@ def test_in_memory_persistence():
         if isinstance(obj, np.ndarray):
             np.testing.assert_array_equal(obj_reloaded, obj)
         else:
-            nose.tools.assert_equal(obj_reloaded, obj)
+            assert_equal(obj_reloaded, obj)
 
 
 @with_numpy
@@ -762,14 +759,13 @@ def test_file_handle_persistence_compressed_mmap():
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter("always")
             numpy_pickle.load(f, mmap_mode='r+')
-            nose.tools.assert_equal(len(caught_warnings), 1)
+            assert_equal(len(caught_warnings), 1)
             for warn in caught_warnings:
-                nose.tools.assert_equal(warn.category, UserWarning)
-                nose.tools.assert_equal(warn.message.args[0],
-                                        '"%(fileobj)r" is not a raw file, '
-                                        'mmap_mode "%(mmap_mode)s" flag will '
-                                        'be ignored.'
-                                        % {'fileobj': f, 'mmap_mode': 'r+'})
+                assert_equal(warn.category, UserWarning)
+                assert_equal(warn.message.args[0],
+                             '"%(fileobj)r" is not a raw file, mmap_mode '
+                             '"%(mmap_mode)s" flag will be ignored.'
+                             % {'fileobj': f, 'mmap_mode': 'r+'})
 
 
 @with_numpy
@@ -782,14 +778,13 @@ def test_file_handle_persistence_in_memory_mmap():
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
         numpy_pickle.load(buf, mmap_mode='r+')
-        nose.tools.assert_equal(len(caught_warnings), 1)
+        assert_equal(len(caught_warnings), 1)
         for warn in caught_warnings:
-            nose.tools.assert_equal(warn.category, UserWarning)
-            nose.tools.assert_equal(warn.message.args[0],
-                                    'In memory persistence is not compatible '
-                                    'with mmap_mode "%(mmap_mode)s" '
-                                    'flag passed. mmap_mode option will be '
-                                    'ignored.' % {'mmap_mode': 'r+'})
+            assert_equal(warn.category, UserWarning)
+            assert_equal(warn.message.args[0],
+                         'In memory persistence is not compatible with '
+                         'mmap_mode "%(mmap_mode)s" flag passed. mmap_mode '
+                         'option will be ignored.' % {'mmap_mode': 'r+'})
 
 
 def test_binary_zlibfile():
@@ -797,19 +792,16 @@ def test_binary_zlibfile():
 
     # Test bad compression levels
     for bad_value in (-1, 10, 15, 'a', (), {}):
-        nose.tools.assert_raises(ValueError,
-                                 BinaryZlibFile, filename, 'wb',
-                                 compresslevel=bad_value)
+        assert_raises(ValueError, BinaryZlibFile, filename, 'wb',
+                      compresslevel=bad_value)
 
     # Test invalid modes
     for bad_mode in ('a', 'x', 'r', 'w', 1, 2):
-        nose.tools.assert_raises(ValueError,
-                                 BinaryZlibFile, filename, bad_mode)
+        assert_raises(ValueError, BinaryZlibFile, filename, bad_mode)
 
     # Test wrong filename type (not a string or a file)
     for bad_file in (1, (), {}):
-        nose.tools.assert_raises(TypeError,
-                                 BinaryZlibFile, bad_file, 'rb')
+        assert_raises(TypeError, BinaryZlibFile, bad_file, 'rb')
 
     for d in (b'a little data as bytes.',
               # More bytes
@@ -820,54 +812,51 @@ def test_binary_zlibfile():
             with open(filename, 'wb') as f:
                 with BinaryZlibFile(f, 'wb',
                                     compresslevel=compress_level) as fz:
-                    nose.tools.assert_true(fz.writable())
+                    assert_true(fz.writable())
                     fz.write(d)
-                    nose.tools.assert_equal(fz.fileno(), f.fileno())
-                    nose.tools.assert_raises(io.UnsupportedOperation,
-                                             fz._check_can_read)
-                    nose.tools.assert_raises(io.UnsupportedOperation,
-                                             fz._check_can_seek)
-                nose.tools.assert_true(fz.closed)
-                nose.tools.assert_raises(ValueError,
-                                         fz._check_not_closed)
+                    assert_equal(fz.fileno(), f.fileno())
+                    assert_raises(io.UnsupportedOperation, fz._check_can_read)
+                    assert_raises(io.UnsupportedOperation, fz._check_can_seek)
+                assert_true(fz.closed)
+                assert_raises(ValueError, fz._check_not_closed)
 
             with open(filename, 'rb') as f:
                 with BinaryZlibFile(f) as fz:
-                    nose.tools.assert_true(fz.readable())
+                    assert_true(fz.readable())
                     if PY3_OR_LATER:
-                        nose.tools.assert_true(fz.seekable())
-                    nose.tools.assert_equal(fz.fileno(), f.fileno())
-                    nose.tools.assert_equal(fz.read(), d)
-                    nose.tools.assert_raises(io.UnsupportedOperation,
-                                             fz._check_can_write)
+                        assert_true(fz.seekable())
+                    assert_equal(fz.fileno(), f.fileno())
+                    assert_equal(fz.read(), d)
+                    assert_raises(io.UnsupportedOperation,
+                                  fz._check_can_write)
                     if PY3_OR_LATER:
                         # io.BufferedIOBase doesn't have seekable() method in
                         # python 2
-                        nose.tools.assert_true(fz.seekable())
+                        assert_true(fz.seekable())
                         fz.seek(0)
-                        nose.tools.assert_equal(fz.tell(), 0)
-                nose.tools.assert_true(fz.closed)
+                        assert_equal(fz.tell(), 0)
+                assert_true(fz.closed)
 
             os.remove(filename)
 
             # Test with a filename as input
             with BinaryZlibFile(filename, 'wb',
                                 compresslevel=compress_level) as fz:
-                nose.tools.assert_true(fz.writable())
+                assert_true(fz.writable())
                 fz.write(d)
 
             with BinaryZlibFile(filename, 'rb') as fz:
-                nose.tools.assert_equal(fz.read(), d)
-                nose.tools.assert_true(fz.seekable())
+                assert_equal(fz.read(), d)
+                assert_true(fz.seekable())
 
             # Test without context manager
             fz = BinaryZlibFile(filename, 'wb', compresslevel=compress_level)
-            nose.tools.assert_true(fz.writable())
+            assert_true(fz.writable())
             fz.write(d)
             fz.close()
 
             fz = BinaryZlibFile(filename, 'rb')
-            nose.tools.assert_equal(fz.read(), d)
+            assert_equal(fz.read(), d)
             fz.close()
 
 
@@ -900,7 +889,7 @@ def test_numpy_subclass():
     a = SubArray((10,))
     numpy_pickle.dump(a, filename)
     c = numpy_pickle.load(filename)
-    nose.tools.assert_true(isinstance(c, SubArray))
+    assert_true(isinstance(c, SubArray))
     np.testing.assert_array_equal(c, a)
 
 
@@ -913,9 +902,9 @@ def test_pathlib():
         filename = env['filename']
         value = 123
         numpy_pickle.dump(value, Path(filename))
-        nose.tools.assert_equal(numpy_pickle.load(filename), value)
+        assert_equal(numpy_pickle.load(filename), value)
         numpy_pickle.dump(value, filename)
-        nose.tools.assert_equal(numpy_pickle.load(Path(filename)), value)
+        assert_equal(numpy_pickle.load(Path(filename)), value)
 
 
 @with_numpy
@@ -928,8 +917,8 @@ def test_non_contiguous_array_pickling():
                     np.asfortranarray([[1, 2], [3, 4]])[1:],
                     # Non contiguous array with works fine with nditer
                     np.ones((10, 50, 20), order='F')[:, :1, :]]:
-        nose.tools.assert_false(array.flags.c_contiguous)
-        nose.tools.assert_false(array.flags.f_contiguous)
+        assert_false(array.flags.c_contiguous)
+        assert_false(array.flags.f_contiguous)
         numpy_pickle.dump(array, filename)
         array_reloaded = numpy_pickle.load(filename)
         np.testing.assert_array_equal(array_reloaded, array)
@@ -955,7 +944,7 @@ def test_pickle_highest_protocol():
 def test_pickle_in_socket():
     # test that joblib can pickle in sockets
     if not PY3_OR_LATER:
-        raise nose.SkipTest("Cannot peek or seek in socket in python 2.")
+        raise SkipTest("Cannot peek or seek in socket in python 2.")
 
     test_array = np.arange(10)
     _ADDR = ("localhost", 12345)

--- a/joblib/test/test_numpy_pickle_compat.py
+++ b/joblib/test/test_numpy_pickle_compat.py
@@ -3,14 +3,13 @@
 import shutil
 import os
 import random
-import nose
 
 from tempfile import mkdtemp
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.
 from joblib import numpy_pickle_compat
-
+from joblib.testing import assert_equal
 
 ###############################################################################
 # Test fixtures
@@ -37,4 +36,4 @@ def test_z_file():
         numpy_pickle_compat.write_zfile(f, data)
     with open(filename, 'rb') as f:
         data_read = numpy_pickle_compat.read_zfile(f)
-    nose.tools.assert_equal(data, data_read)
+    assert_equal(data, data_read)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -14,11 +14,15 @@ from math import sqrt
 import threading
 import warnings
 
+from nose import SkipTest
+from nose.tools import assert_raises
+
 from joblib import parallel
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_multiprocessing
 from joblib.testing import check_subprocess_call
+from joblib.testing import assert_equal, assert_true, assert_false
 from joblib._compat import PY3_OR_LATER
 from multiprocessing import TimeoutError
 from time import sleep
@@ -62,9 +66,6 @@ from joblib.parallel import register_parallel_backend, parallel_backend
 
 from joblib.parallel import mp, cpu_count, BACKENDS, effective_n_jobs
 from joblib.my_exceptions import JoblibException
-
-import nose
-from nose.tools import assert_equal, assert_true, assert_false, assert_raises
 
 
 ALL_VALID_BACKENDS = [None] + sorted(BACKENDS.keys())
@@ -286,17 +287,15 @@ def test_parallel_pickling():
 def test_parallel_timeout_success():
     # Check that timeout isn't thrown when function is fast enough
     for backend in ['multiprocessing', 'threading']:
-        nose.tools.assert_equal(
-            10,
-            len(Parallel(n_jobs=2, backend=backend, timeout=10)
-                (delayed(sleep)(0.001) for x in range(10))))
+        assert_equal(10, len(Parallel(n_jobs=2, backend=backend, timeout=10)
+                         (delayed(sleep)(0.001) for x in range(10))))
 
 
 @with_multiprocessing
 def test_parallel_timeout_fail():
     # Check that timeout properly fails when function is too slow
     for backend in ['multiprocessing', 'threading']:
-        nose.tools.assert_raises(
+        assert_raises(
             TimeoutError,
             Parallel(n_jobs=2, backend=backend, timeout=0.01),
             (delayed(sleep)(10) for x in range(10))
@@ -438,7 +437,7 @@ def check_dispatch_multiprocessing(backend):
         lazily.
     """
     if mp is None:
-        raise nose.SkipTest()
+        raise SkipTest()
     manager = mp.Manager()
     queue = manager.list()
 
@@ -520,7 +519,7 @@ def test_multiple_spawning():
     # subprocesses will raise an error, to avoid infinite loops on
     # systems that do not support fork
     if not int(os.environ.get('JOBLIB_MULTIPROCESSING', 1)):
-        raise nose.SkipTest()
+        raise SkipTest()
     assert_raises(ImportError, Parallel(n_jobs=2, pre_dispatch='all'),
                   [delayed(_reload_joblib)() for i in range(10)])
 
@@ -735,8 +734,7 @@ def test_default_mp_context():
 @with_numpy
 def test_no_blas_crash_or_freeze_with_multiprocessing():
     if sys.version_info < (3, 4):
-        raise nose.SkipTest('multiprocessing can cause BLAS freeze on'
-                            ' old Python')
+        raise SkipTest('multiprocessing can cause BLAS freeze on old Python')
 
     # Use the spawn backend that is both robust and available on all platforms
     spawn_backend = mp.get_context('spawn')
@@ -763,7 +761,7 @@ def test_parallel_with_interactively_defined_functions():
     # session, we want to be able to use them with joblib.Parallel
     if posix is None:
         # This test pass only when fork is the process start method
-        raise nose.SkipTest('Not a POSIX platform')
+        raise SkipTest('Not a POSIX platform')
 
     code = '\n\n'.join([
         'from joblib import Parallel, delayed',
@@ -811,7 +809,7 @@ def test_nested_parallel_warnings():
     # why we use check_subprocess_call instead
     if posix is None:
         # This test pass only when fork is the process start method
-        raise nose.SkipTest('Not a POSIX platform')
+        raise SkipTest('Not a POSIX platform')
 
     template_code = """
 import sys

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -14,15 +14,12 @@ from math import sqrt
 import threading
 import warnings
 
-from nose import SkipTest
-
 from joblib import parallel
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_multiprocessing
-from joblib.testing import check_subprocess_call
 from joblib.testing import (assert_equal, assert_true, assert_false,
-                            assert_raises)
+                            assert_raises, check_subprocess_call, SkipTest)
 from joblib._compat import PY3_OR_LATER
 from multiprocessing import TimeoutError
 from time import sleep
@@ -288,7 +285,7 @@ def test_parallel_timeout_success():
     # Check that timeout isn't thrown when function is fast enough
     for backend in ['multiprocessing', 'threading']:
         assert_equal(10, len(Parallel(n_jobs=2, backend=backend, timeout=10)
-                         (delayed(sleep)(0.001) for x in range(10))))
+                             (delayed(sleep)(0.001) for x in range(10))))
 
 
 @with_multiprocessing

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -15,14 +15,14 @@ import threading
 import warnings
 
 from nose import SkipTest
-from nose.tools import assert_raises
 
 from joblib import parallel
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_multiprocessing
 from joblib.testing import check_subprocess_call
-from joblib.testing import assert_equal, assert_true, assert_false
+from joblib.testing import (assert_equal, assert_true, assert_false,
+                            assert_raises)
 from joblib._compat import PY3_OR_LATER
 from multiprocessing import TimeoutError
 from time import sleep

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -284,19 +284,18 @@ def test_parallel_pickling():
 def test_parallel_timeout_success():
     # Check that timeout isn't thrown when function is fast enough
     for backend in ['multiprocessing', 'threading']:
-        assert_equal(10, len(Parallel(n_jobs=2, backend=backend, timeout=10)
-                             (delayed(sleep)(0.001) for x in range(10))))
+        assert_equal(10,
+                     len(Parallel(n_jobs=2, backend=backend, timeout=10)
+                         (delayed(sleep)(0.001) for x in range(10))))
 
 
 @with_multiprocessing
 def test_parallel_timeout_fail():
     # Check that timeout properly fails when function is too slow
     for backend in ['multiprocessing', 'threading']:
-        assert_raises(
-            TimeoutError,
-            Parallel(n_jobs=2, backend=backend, timeout=0.01),
-            (delayed(sleep)(10) for x in range(10))
-        )
+        assert_raises(TimeoutError,
+                      Parallel(n_jobs=2, backend=backend, timeout=0.01),
+                      (delayed(sleep)(10) for x in range(10)))
 
 
 def test_error_capture():

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -2,13 +2,13 @@ import os
 import shutil
 import tempfile
 
-from nose.tools import with_setup, assert_raises
 from joblib.test.common import with_numpy, np
 from joblib.test.common import setup_autokill
 from joblib.test.common import teardown_autokill
 from joblib.test.common import with_multiprocessing
 from joblib.test.common import with_dev_shm
-from joblib.testing import assert_equal, assert_true, assert_false
+from joblib.testing import (assert_equal, assert_true, assert_false,
+                            assert_raises, with_setup)
 
 from joblib._multiprocessing_helpers import mp
 if mp is not None:

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -2,16 +2,13 @@ import os
 import shutil
 import tempfile
 
-from nose.tools import with_setup
-from nose.tools import assert_equal
-from nose.tools import assert_raises
-from nose.tools import assert_false
-from nose.tools import assert_true
+from nose.tools import with_setup, assert_raises
 from joblib.test.common import with_numpy, np
 from joblib.test.common import setup_autokill
 from joblib.test.common import teardown_autokill
 from joblib.test.common import with_multiprocessing
 from joblib.test.common import with_dev_shm
+from joblib.testing import assert_equal, assert_true, assert_false
 
 from joblib._multiprocessing_helpers import mp
 if mp is not None:

--- a/joblib/test/test_testing.py
+++ b/joblib/test/test_testing.py
@@ -1,9 +1,8 @@
 import sys
 import re
 
-from nose.tools import assert_raises
-
-from joblib.testing import assert_raises_regex, check_subprocess_call
+from joblib.testing import (assert_raises, assert_raises_regex,
+                            check_subprocess_call)
 
 
 def test_check_subprocess_call():

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -8,8 +8,16 @@ import os.path
 import re
 import subprocess
 import threading
+import unittest
 
 from joblib._compat import PY3_OR_LATER
+
+
+_dummy = unittest.TestCase('__init__')
+assert_true = _dummy.assertTrue
+assert_false = _dummy.assertFalse
+assert_equal = _dummy.assertEqual
+assert_not_equal = _dummy.assertNotEqual
 
 
 def warnings_to_stdout():

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -11,11 +11,6 @@ import threading
 import unittest
 
 import nose
-try:
-    SkipTest = unittest.case.SkipTest
-except AttributeError:
-    # Python <= 2.6, we still need nose here
-    SkipTest = nose.SkipTest
 
 
 from joblib._compat import PY3_OR_LATER
@@ -26,6 +21,34 @@ assert_true = _dummy.assertTrue
 assert_false = _dummy.assertFalse
 assert_equal = _dummy.assertEqual
 assert_not_equal = _dummy.assertNotEqual
+assert_raises = _dummy.assertRaises
+
+try:
+    assert_raises_regex = _dummy.assertRaisesRegexp
+except AttributeError:
+    def assert_raises_regex(expected_exception, expected_regexp,
+                            callable_obj=None, *args, **kwargs):
+        """Helper function to check for message patterns in exceptions"""
+        not_raised = False
+        try:
+            callable_obj(*args, **kwargs)
+            not_raised = True
+        except Exception as e:
+            error_message = str(e)
+            if not re.compile(expected_regexp).search(error_message):
+                raise AssertionError("Error message should match pattern "
+                                     "%r. %r does not." %
+                                     (expected_regexp, error_message))
+        if not_raised:
+            raise AssertionError("Should have raised %r" %
+                                 expected_exception(expected_regexp))
+
+try:
+    SkipTest = unittest.case.SkipTest
+except AttributeError:
+    # Python <= 2.6, we still need nose here
+    SkipTest = nose.SkipTest
+
 with_setup = nose.tools.with_setup
 
 
@@ -39,51 +62,6 @@ def warnings_to_stdout():
 
     warnings.showwarning = showwarning
     #warnings.simplefilter('always')
-
-
-try:
-    from nose.tools import assert_raises_regex
-except ImportError:
-    # For Python 2.7
-    try:
-        from nose.tools import assert_raises_regexp as assert_raises_regex
-    except ImportError:
-        # for Python 2.6
-        def assert_raises_regex(expected_exception, expected_regexp,
-                                callable_obj=None, *args, **kwargs):
-            """Helper function to check for message patterns in exceptions"""
-
-            not_raised = False
-            try:
-                callable_obj(*args, **kwargs)
-                not_raised = True
-            except Exception as e:
-                error_message = str(e)
-                if not re.compile(expected_regexp).search(error_message):
-                    raise AssertionError("Error message should match pattern "
-                                         "%r. %r does not." %
-                                         (expected_regexp, error_message))
-            if not_raised:
-                raise AssertionError("Should have raised %r" %
-                                     expected_exception(expected_regexp))
-
-
-try:
-    from nose.tools import assert_raises
-except ImportError:
-    # for Python 2.6
-    def assert_raises(expected_exception, callable_obj=None, *args, **kwargs):
-        """Helper function to check for exceptions raised by methods"""
-        not_raised = False
-        try:
-            callable_obj(*args, **kwargs)
-            not_raised = True
-        except Exception as e:
-            if not e.__class__ == expected_exception:
-                raise AssertionError("Expected exception to be %r, found %r " %
-                                     (expected_exception, e.__class__))
-        if not_raised:
-            raise AssertionError("Should have raised %r" % expected_exception)
 
 
 def check_subprocess_call(cmd, timeout=1, stdout_regex=None,

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -10,6 +10,14 @@ import subprocess
 import threading
 import unittest
 
+import nose
+try:
+    SkipTest = unittest.case.SkipTest
+except AttributeError:
+    # Python <= 2.6, we still need nose here
+    SkipTest = nose.SkipTest
+
+
 from joblib._compat import PY3_OR_LATER
 
 
@@ -18,6 +26,7 @@ assert_true = _dummy.assertTrue
 assert_false = _dummy.assertFalse
 assert_equal = _dummy.assertEqual
 assert_not_equal = _dummy.assertNotEqual
+with_setup = nose.tools.with_setup
 
 
 def warnings_to_stdout():

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -59,6 +59,24 @@ except ImportError:
                                      expected_exception(expected_regexp))
 
 
+try:
+    from nose.tools import assert_raises
+except ImportError:
+    # for Python 2.6
+    def assert_raises(expected_exception, callable_obj=None, *args, **kwargs):
+        """Helper function to check for exceptions raised by methods"""
+        not_raised = False
+        try:
+            callable_obj(*args, **kwargs)
+            not_raised = True
+        except Exception as e:
+            if not e.__class__ == expected_exception:
+                raise AssertionError("Expected exception to be %r, found %r " %
+                                     (expected_exception, e.__class__))
+        if not_raised:
+            raise AssertionError("Should have raised %r" % expected_exception)
+
+
 def check_subprocess_call(cmd, timeout=1, stdout_regex=None,
                           stderr_regex=None):
     """Runs a command in a subprocess with timeout in seconds.


### PR DESCRIPTION
#### Starter PR on #411 

To initiate the migration form nose to py.test, this PR first of all removes all the direct usages of "nose" in all test scripts. It wraps the following utilities of **nose / unittest** modules in **joblib/testing.py**
- `assert_true`, `assert_false`
- `assert_equal`, `assert_not_equal`
- `assert_raises`
- `with_setup`, `SkipTest`

#### All the imports in scripts housed under directory **joblib/tests** such as:
```python
from nose.tools import assert_equal
from nose import with_setup
import nose
# blah blah blah

nose.SkipTest()
nose.tools.assert_raises(*args, **kwargs)
```

have been replaced in a uniform fashion:
```python
from joblib.testing import (assert_equal, assert_raises,
                            SkipTest, with_setup) # preserve pep8 length
# no nose imports now
# blah blah blah

SkipTest()
assert_raises(*args, **kwargs)
```

- No unused imports from `joblib.testing`
- Everything from `joblib.testing` is imported as `from x import y, z`

This can ease up the migration and is the first PR iniiating the process.