### PR TITLE
Ensure LICENSE file is included in the built wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,9 @@ doctest-fixtures=_fixture
 [wheel]
 universal=1
 
+[metadata]
+license_file = doc/sphinxext/LICENSE.txt
+
 [flake8]
 # For PEP8 error codes see
 # http://pep8.readthedocs.org/en/latest/intro.html#error-codes


### PR DESCRIPTION
The wheel does not contain the required license text otherwise. 
This setup.cfg setting ensures the wheel metadata will include
the license text.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>