### PR TITLE
Ensure LICENSE text is included with the code.

### DIFF
--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -97,6 +97,44 @@ Main features
 ..
     >>> import shutil ; shutil.rmtree('/tmp/joblib/')
 
+
+Licensing
+----------
+
+joblib is **BSD-licenced** (3 clause):
+
+    This software is OSI Certified Open Source Software.
+    OSI Certified is a certification mark of the Open Source Initiative.
+
+    Copyright (c) 2009-2011, joblib developpers
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of Gael Varoquaux. nor the names of other joblib
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+    **This software is provided by the copyright holders and contributors
+    "as is" and any express or implied warranties, including, but not
+    limited to, the implied warranties of merchantability and fitness for
+    a particular purpose are disclaimed. In no event shall the copyright
+    owner or contributors be liable for any direct, indirect, incidental,
+    special, exemplary, or consequential damages (including, but not
+    limited to, procurement of substitute goods or services; loss of use,
+    data, or profits; or business interruption) however caused and on any
+    theory of liability, whether in contract, strict liability, or tort
+    (including negligence or otherwise) arising in any way out of the use
+    of this software, even if advised of the possibility of such
+    damage.**
 """
 
 # PEP0440 compatible formatted version, see:


### PR DESCRIPTION
Otherwise the LICENSE text is absent entirely from a built wheel
or built egg.
The alternative (for wheels) could be to use a text file and 
update the setup.cfg  metadata as suggested in that other PR:
https://github.com/joblib/joblib/pull/425

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>