### PR TITLE
[MRG] Replace assert_* methods with "assert" keyword statements.

### DIFF
--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -15,7 +15,7 @@ import array
 from tempfile import mkdtemp
 
 from joblib.disk import disk_used, memstr_to_bytes, mkdirp
-from joblib.testing import assert_true, assert_equal, assert_raises
+from joblib.testing import assert_equal, assert_raises
 
 ###############################################################################
 
@@ -36,8 +36,8 @@ def test_disk_used():
         a = array.array('i', n * (1,))
         with open(os.path.join(cachedir, 'test'), 'wb') as output:
             a.tofile(output)
-        assert_true(disk_used(cachedir) >= target_size)
-        assert_true(disk_used(cachedir) < target_size + 12)
+        assert disk_used(cachedir) >= target_size
+        assert disk_used(cachedir) < target_size + 12
     finally:
         shutil.rmtree(cachedir)
 

--- a/joblib/test/test_format_stack.py
+++ b/joblib/test/test_format_stack.py
@@ -12,9 +12,9 @@ import sys
 from joblib.format_stack import safe_repr, _fixed_getframes, format_records
 from joblib.format_stack import format_exc
 from joblib.test.common import with_numpy, np
-from joblib.testing import assert_true
 
 ###############################################################################
+
 
 class Vicious(object):
     def __repr__(self):
@@ -80,4 +80,4 @@ def test_format_exc_with_compiled_code():
         # The name of the extension can be something like
         # mtrand.cpython-33m.so
         pattern = 'mtrand[a-z0-9._-]*\.(so|pyd)'
-        assert_true(re.search(pattern, formatted_exc))
+        assert re.search(pattern, formatted_exc)

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -10,14 +10,13 @@ import os
 import shutil
 import tempfile
 import functools
-import sys
 
 from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import (assert_true, assert_false, assert_not_equal,
-                            assert_equal, assert_raises_regex, assert_raises)
+from joblib.testing import (assert_false, assert_not_equal, assert_equal,
+                            assert_raises_regex, assert_raises)
 from joblib._compat import PY3_OR_LATER
 
 
@@ -222,8 +221,8 @@ def test_special_source_encoding():
     from joblib.test.test_func_inspect_special_encoding import big5_f
     func_code, source_file, first_line = get_func_code(big5_f)
     assert_equal(first_line, 5)
-    assert_true("def big5_f():" in func_code)
-    assert_true("test_func_inspect_special_encoding" in source_file)
+    assert "def big5_f():" in func_code
+    assert "test_func_inspect_special_encoding" in source_file
 
 
 def _get_code():

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -15,7 +15,7 @@ from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import (assert_equal, assert_raises_regex, assert_raises)
+from joblib.testing import assert_equal, assert_raises_regex, assert_raises
 from joblib._compat import PY3_OR_LATER
 
 

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -15,7 +15,7 @@ from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import (assert_false, assert_not_equal, assert_equal,
+from joblib.testing import (assert_not_equal, assert_equal,
                             assert_raises_regex, assert_raises)
 from joblib._compat import PY3_OR_LATER
 
@@ -200,7 +200,7 @@ def test_clean_win_chars():
     string = r'C:\foo\bar\main.py'
     mangled_string = _clean_win_chars(string)
     for char in ('\\', ':', '<', '>', '!'):
-        assert_false(char in mangled_string)
+        assert char not in mangled_string
 
 
 def test_format_signature():

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -15,8 +15,7 @@ from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import (assert_not_equal, assert_equal,
-                            assert_raises_regex, assert_raises)
+from joblib.testing import (assert_equal, assert_raises_regex, assert_raises)
 from joblib._compat import PY3_OR_LATER
 
 
@@ -97,7 +96,7 @@ def test_filter_args():
 
 def test_filter_args_method():
     obj = Klass()
-    assert_equal(filter_args(obj.f, [], (1, )), {'x': 1, 'self': obj})
+    assert filter_args(obj.f, [], (1, )) == {'x': 1, 'self': obj}
 
 
 def test_filter_varargs():
@@ -112,22 +111,22 @@ def test_filter_varargs():
 
 
 def test_filter_kwargs():
-    assert_equal(filter_args(k, [], (1, 2), dict(ee=2)),
-                 {'*': [1, 2], '**': {'ee': 2}})
-    assert_equal(filter_args(k, [], (3, 4)), {'*': [3, 4], '**': {}})
+    assert (filter_args(k, [], (1, 2), dict(ee=2)) ==
+            {'*': [1, 2], '**': {'ee': 2}})
+    assert filter_args(k, [], (3, 4)) == {'*': [3, 4], '**': {}}
 
 
 def test_filter_args_2():
-    assert_equal(filter_args(j, [], (1, 2), dict(ee=2)),
-                 {'x': 1, 'y': 2, '**': {'ee': 2}})
+    assert (filter_args(j, [], (1, 2), dict(ee=2)) ==
+            {'x': 1, 'y': 2, '**': {'ee': 2}})
 
     assert_raises(ValueError, filter_args, f, 'a', (None, ))
     # Check that we capture an undefined argument
     assert_raises(ValueError, filter_args, f, ['a'], (None, ))
     ff = functools.partial(f, 1)
     # filter_args has to special-case partial
-    assert_equal(filter_args(ff, [], (1, )), {'*': [1], '**': {}})
-    assert_equal(filter_args(ff, ['y'], (1, )), {'*': [1], '**': {}})
+    assert filter_args(ff, [], (1, )) == {'*': [1], '**': {}}
+    assert filter_args(ff, ['y'], (1, )) == {'*': [1], '**': {}}
 
 
 def test_func_name():
@@ -138,16 +137,23 @@ def test_func_name():
 
 def test_func_inspect_errors():
     # Check that func_inspect is robust and will work on weird objects
-    assert_equal(get_func_name('a'.lower)[-1], 'lower')
-    assert_equal(get_func_code('a'.lower)[1:], (None, -1))
+    assert get_func_name('a'.lower)[-1] == 'lower'
+    assert get_func_code('a'.lower)[1:] == (None, -1)
     ff = lambda x: x
-    assert_equal(get_func_name(ff, win_characters=False)[-1], '<lambda>')
-    assert_equal(get_func_code(ff)[1], __file__.replace('.pyc', '.py'))
+    assert get_func_name(ff, win_characters=False)[-1] == '<lambda>'
+    assert get_func_code(ff)[1] == __file__.replace('.pyc', '.py')
     # Simulate a function defined in __main__
     ff.__module__ = '__main__'
-    assert_equal(get_func_name(ff, win_characters=False)[-1], '<lambda>')
-    assert_equal(get_func_code(ff)[1], __file__.replace('.pyc', '.py'))
+    assert get_func_name(ff, win_characters=False)[-1] == '<lambda>'
+    assert get_func_code(ff)[1] == __file__.replace('.pyc', '.py')
 
+
+def func_with_kwonly_args(a, b, kw1='kw1', kw2='kw2'):
+    pass
+
+
+def func_with_signature(a, b):
+    pass
 
 if PY3_OR_LATER:
     exec("""
@@ -157,9 +163,9 @@ def func_with_signature(a: int, b: int) -> None: pass
 """)
 
     def test_filter_args_python_3():
-        assert_equal(
-            filter_args(func_with_kwonly_args,
-                        [], (1, 2), {'kw1': 3, 'kw2': 4}),
+        assert (
+            filter_args(func_with_kwonly_args, [], (1, 2),
+                        {'kw1': 3, 'kw2': 4}) ==
             {'a': 1, 'b': 2, 'kw1': 3, 'kw2': 4})
 
         # filter_args doesn't care about keyword-only arguments so you
@@ -170,14 +176,12 @@ def func_with_signature(a: int, b: int) -> None: pass
             filter_args,
             func_with_kwonly_args, [], (1, 2, 3), {'kw2': 2})
 
-        assert_equal(
+        assert (
             filter_args(func_with_kwonly_args, ['b', 'kw2'], (1, 2),
-                        {'kw1': 3, 'kw2': 4}),
+                        {'kw1': 3, 'kw2': 4}) ==
             {'a': 1, 'kw1': 3})
 
-        assert_equal(
-            filter_args(func_with_signature, ['b'], (1, 2)),
-            {'a': 1})
+        assert (filter_args(func_with_signature, ['b'], (1, 2)) == {'a': 1})
 
 
 def test_bound_methods():
@@ -186,7 +190,7 @@ def test_bound_methods():
     """
     a = Klass()
     b = Klass()
-    assert_not_equal(filter_args(a.f, [], (1, )), filter_args(b.f, [], (1, )))
+    assert filter_args(a.f, [], (1, )) != filter_args(b.f, [], (1, ))
 
 
 def test_filter_args_error_msg():
@@ -206,10 +210,11 @@ def test_clean_win_chars():
 def test_format_signature():
     # Test signature formatting.
     path, sgn = format_signature(g, list(range(10)))
-    assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
+    assert sgn == 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])'
     path, sgn = format_signature(g, list(range(10)), y=list(range(10)))
-    assert_equal(sgn, 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],'
-                      ' y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
+    assert sgn == 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],' \
+                  ' y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])'
+
 
 @with_numpy
 def test_format_signature_numpy():
@@ -220,7 +225,7 @@ def test_format_signature_numpy():
 def test_special_source_encoding():
     from joblib.test.test_func_inspect_special_encoding import big5_f
     func_code, source_file, first_line = get_func_code(big5_f)
-    assert_equal(first_line, 5)
+    assert first_line == 5
     assert "def big5_f():" in func_code
     assert "test_func_inspect_special_encoding" in source_file
 
@@ -233,6 +238,4 @@ def _get_code():
 def test_func_code_consistency():
     from joblib.parallel import Parallel, delayed
     codes = Parallel(n_jobs=2)(delayed(_get_code)() for _ in range(5))
-    assert_equal(len(set(codes)), 1)
-
-
+    assert len(set(codes)) == 1

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -113,10 +113,10 @@ def test_trival_hash():
 def test_hash_methods():
     # Check that hashing instance methods works
     a = io.StringIO(unicode('a'))
-    assert_equal(hash(a.flush), hash(a.flush))
+    assert hash(a.flush) == hash(a.flush)
     a1 = collections.deque(range(10))
     a2 = collections.deque(range(9))
-    assert_not_equal(hash(a1.extend), hash(a2.extend))
+    assert hash(a1.extend) != hash(a2.extend)
 
 
 @with_numpy
@@ -152,7 +152,7 @@ def test_numpy_datetime_array():
     a_hash = hash(np.arange(10))
     arrays = (np.arange(0, 10, dtype=dtype) for dtype in dtypes)
     for array in arrays:
-        assert_not_equal(hash(array), a_hash)
+        assert hash(array) != a_hash
 
 
 @with_numpy
@@ -160,10 +160,10 @@ def test_hash_numpy_noncontiguous():
     a = np.asarray(np.arange(6000).reshape((1000, 2, 3)),
                    order='F')[:, :1, :]
     b = np.ascontiguousarray(a)
-    assert_not_equal(hash(a), hash(b))
+    assert hash(a) != hash(b)
 
     c = np.asfortranarray(a)
-    assert_not_equal(hash(a), hash(c))
+    assert hash(a) != hash(c)
 
 
 @with_numpy
@@ -244,8 +244,8 @@ def test_bound_methods_hash():
     """
     a = Klass()
     b = Klass()
-    assert_equal(hash(filter_args(a.f, [], (1, ))),
-                 hash(filter_args(b.f, [], (1, ))))
+    assert (hash(filter_args(a.f, [], (1, ))) ==
+            hash(filter_args(b.f, [], (1, ))))
 
 
 @with_setup(test_memory_setup_func, test_memory_teardown_func)
@@ -255,8 +255,8 @@ def test_bound_cached_methods_hash():
     """
     a = KlassWithCachedMethod()
     b = KlassWithCachedMethod()
-    assert_equal(hash(filter_args(a.f.func, [], (1, ))),
-                 hash(filter_args(b.f.func, [], (1, ))))
+    assert (hash(filter_args(a.f.func, [], (1, ))) ==
+            hash(filter_args(b.f.func, [], (1, ))))
 
 
 @with_numpy
@@ -266,7 +266,7 @@ def test_hash_object_dtype():
     a = np.array([np.arange(i) for i in range(6)], dtype=object)
     b = np.array([np.arange(i) for i in range(6)], dtype=object)
 
-    assert_equal(hash(a), hash(b))
+    assert hash(a) == hash(b)
 
 
 @with_numpy
@@ -275,7 +275,7 @@ def test_numpy_scalar():
     # strange pickling paths explored, that can give hash collisions
     a = np.float64(2.0)
     b = np.float64(3.0)
-    assert_not_equal(hash(a), hash(b))
+    assert hash(a) != hash(b)
 
 
 @with_setup(test_memory_setup_func, test_memory_teardown_func)
@@ -301,7 +301,7 @@ def test_dict_hash():
     a = k.f(d)
     b = k.f(a)
 
-    assert_equal(hash(a), hash(b))
+    assert hash(a) == hash(b)
 
 
 @with_setup(test_memory_setup_func, test_memory_teardown_func)
@@ -327,7 +327,7 @@ def test_set_hash():
     a = k.f(s)
     b = k.f(a)
 
-    assert_equal(hash(a), hash(b))
+    assert hash(a) == hash(b)
 
 
 if not PY26:
@@ -335,8 +335,8 @@ if not PY26:
     def test_set_decimal_hash():
         # Check that sets containing decimals hash consistently, even though
         # ordering is not guaranteed
-        assert_equal(hash(set([Decimal(0), Decimal('NaN')])),
-                     hash(set([Decimal('NaN'), Decimal(0)])))
+        assert (hash(set([Decimal(0), Decimal('NaN')])) ==
+                hash(set([Decimal('NaN'), Decimal(0)])))
 
 
 def test_string():
@@ -346,7 +346,7 @@ def test_string():
     a = {string: 'bar'}
     b = {string: 'bar'}
     c = pickle.loads(pickle.dumps(b))
-    assert_equal(hash([a, b]), hash([a, c]))
+    assert hash([a, b]) == hash([a, c])
 
 
 @with_numpy
@@ -357,7 +357,7 @@ def test_dtype():
     a = np.dtype([('f1', np.uint), ('f2', np.int32)])
     b = a
     c = pickle.loads(pickle.dumps(a))
-    assert_equal(hash([a, c]), hash([a, b]))
+    assert hash([a, c]) == hash([a, b])
 
 
 def test_hashes_stay_the_same():
@@ -403,7 +403,7 @@ def test_hashes_are_different_between_c_and_fortran_contiguous_arrays():
     rng = np.random.RandomState(0)
     arr_c = rng.random_sample((10, 10))
     arr_f = np.asfortranarray(arr_c)
-    assert_not_equal(hash(arr_c), hash(arr_f))
+    assert hash(arr_c) != hash(arr_f)
 
 
 @with_numpy
@@ -413,7 +413,7 @@ def test_0d_array():
 
 @with_numpy
 def test_0d_and_1d_array_hashing_is_different():
-    assert_not_equal(hash(np.array(0)), hash(np.array([0])))
+    assert hash(np.array(0)) != hash(np.array([0]))
 
 
 @with_numpy

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -38,11 +38,6 @@ except NameError:
     unicode = lambda s: s
 
 
-def assert_less(a, b):
-    if a > b:
-        raise AssertionError("%r is not lower than %r")
-
-
 ###############################################################################
 # Helper functions for the tests
 def time_func(func, *args):
@@ -227,7 +222,7 @@ def test_hash_numpy_performance():
     md5_hash = lambda x: hashlib.md5(getbuffer(x)).hexdigest()
 
     relative_diff = relative_time(md5_hash, hash, a)
-    assert_less(relative_diff, 0.3)
+    assert relative_diff < 0.3
 
     # Check that hashing an tuple of 3 arrays takes approximately
     # 3 times as much as hashing one array
@@ -235,7 +230,7 @@ def test_hash_numpy_performance():
     time_hash = time_func(hash, (a, a, a))
     relative_diff = 0.5 * (abs(time_hash - time_hashlib)
                            / (time_hash + time_hashlib))
-    assert_less(relative_diff, 0.3)
+    assert relative_diff < 0.3
 
 
 def test_bound_methods_hash():

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -384,10 +384,10 @@ def test_memory_numpy_check_mmap_mode():
     b = twice(a)
     c = twice(a)
 
-    assert_true(isinstance(c, np.memmap))
+    assert isinstance(c, np.memmap)
     assert_equal(c.mode, 'r')
 
-    assert_true(isinstance(b, np.memmap))
+    assert isinstance(b, np.memmap)
     assert_equal(b.mode, 'r')
 
 
@@ -513,7 +513,7 @@ def test_call_and_shelve():
                              MemorizedResult, NotMemorizedResult)):
         assert_equal(func(2), 5)
         result = func.call_and_shelve(2)
-        assert_true(isinstance(result, Result))
+        assert isinstance(result, Result)
         assert_equal(result.get(), 5)
 
         result.clear()
@@ -773,7 +773,7 @@ def test__get_cache_items_to_delete():
     # folder is about 1000 bytes + metadata)
     cache_items_to_delete = _get_cache_items_to_delete(cachedir, '2K')
     nb_hashes = len(expected_hash_cachedirs)
-    assert_true(set.issubset(set(cache_items_to_delete), set(cache_items)))
+    assert set.issubset(set(cache_items_to_delete), set(cache_items))
     assert_equal(len(cache_items_to_delete), nb_hashes - 1)
 
     # Sanity check bytes_limit=2048 is the same as bytes_limit='2K'
@@ -789,7 +789,7 @@ def test__get_cache_items_to_delete():
     bytes_limit_too_small = 500
     cache_items_to_delete_500b = _get_cache_items_to_delete(
         cachedir, bytes_limit_too_small)
-    assert_true(set(cache_items_to_delete_500b), set(cache_items))
+    assert set(cache_items_to_delete_500b), set(cache_items)
 
     # Test LRU property: surviving cache items should all have a more
     # recent last_access that the ones that have been deleted
@@ -823,7 +823,7 @@ def test_memory_reduce_size():
     mem.bytes_limit = '3K'
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
-    assert_true(set.issubset(set(cache_items), set(ref_cache_items)))
+    assert set.issubset(set(cache_items), set(ref_cache_items))
     assert_equal(len(cache_items), 2)
 
     # bytes_limit set so that no cache item is kept

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -796,9 +796,8 @@ def test__get_cache_items_to_delete():
     surviving_cache_items = set(cache_items).difference(
         cache_items_to_delete_6000b)
 
-    assert_true(
-        max(ci.last_access for ci in cache_items_to_delete_6000b) <=
-        min(ci.last_access for ci in surviving_cache_items))
+    assert (max(ci.last_access for ci in cache_items_to_delete_6000b) <=
+            min(ci.last_access for ci in surviving_cache_items))
 
 
 def test_memory_reduce_size():

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -180,7 +180,7 @@ def test_memory_kwarg():
     memory = Memory(cachedir=env['dir'], verbose=0)
     g = memory.cache(g)
     # Smoke test with an explicit keyword argument:
-    assert_equal(g(l=30, m=2), 30)
+    assert g(l=30, m=2) == 30
 
 
 def test_memory_lambda():
@@ -254,13 +254,13 @@ def test_memory_warning_lambda_collisions():
         # inspect.getargspec, see
         # https://github.com/joblib/joblib/issues/247
         warnings.simplefilter("ignore", DeprecationWarning)
-        assert_equal(0, a(0))
-        assert_equal(2, b(1))
-        assert_equal(1, a(1))
+        assert a(0) == 0
+        assert b(1) == 2
+        assert a(1) == 1
 
     # In recent Python versions, we can retrieve the code of lambdas,
     # thus nothing is raised
-    assert_equal(len(w), 4)
+    assert len(w) == 4
 
 
 def test_memory_warning_collision_detection():
@@ -385,10 +385,10 @@ def test_memory_numpy_check_mmap_mode():
     c = twice(a)
 
     assert isinstance(c, np.memmap)
-    assert_equal(c.mode, 'r')
+    assert c.mode == 'r'
 
     assert isinstance(b, np.memmap)
-    assert_equal(b.mode, 'r')
+    assert b.mode == 'r'
 
 
 def test_memory_exception():
@@ -511,10 +511,10 @@ def test_call_and_shelve():
                              ),
                             (MemorizedResult, NotMemorizedResult,
                              MemorizedResult, NotMemorizedResult)):
-        assert_equal(func(2), 5)
+        assert func(2) == 5
         result = func.call_and_shelve(2)
         assert isinstance(result, Result)
-        assert_equal(result.get(), 5)
+        assert result.get() == 5
 
         result.clear()
         assert_raises(KeyError, result.get)
@@ -529,7 +529,7 @@ def test_memorized_pickling():
             pickle.dump(result, fp)
         with open(filename, 'rb') as fp:
             result2 = pickle.load(fp)
-        assert_equal(result2.get(), result.get())
+        assert result2.get() == result.get()
         os.remove(filename)
 
 
@@ -539,8 +539,8 @@ def test_memorized_repr():
 
     func2 = MemorizedFunc(f, env['dir'])
     result2 = func2.call_and_shelve(2)
-    assert_equal(result.get(), result2.get())
-    assert_equal(repr(func), repr(func2))
+    assert result.get() == result2.get()
+    assert repr(func) == repr(func2)
 
     # Smoke test with NotMemorizedFunc
     func = NotMemorizedFunc(f)
@@ -631,7 +631,7 @@ def test_memory_file_modification():
 
     finally:
         sys.stdout = orig_stdout
-    assert_equal(my_stdout.getvalue(), '1\n2\nReloading\nx=1\n')
+    assert my_stdout.getvalue() == '1\n2\nReloading\nx=1\n'
 
 
 def _function_to_cache(a, b):
@@ -653,8 +653,8 @@ def test_memory_in_memory_function_code_change():
     mem = Memory(cachedir=env['dir'], verbose=0)
     f = mem.cache(_function_to_cache)
 
-    assert_equal(f(1, 2), 3)
-    assert_equal(f(1, 2), 3)
+    assert f(1, 2) == 3
+    assert f(1, 2) == 3
 
     with warnings.catch_warnings(record=True):
         # ignore name collision warnings
@@ -663,8 +663,8 @@ def test_memory_in_memory_function_code_change():
         # Check that inline function modification triggers a cache invalidation
 
         _function_to_cache.__code__ = _product.__code__
-        assert_equal(f(1, 2), 2)
-        assert_equal(f(1, 2), 2)
+        assert f(1, 2) == 2
+        assert f(1, 2) == 2
 
 
 def test_clear_memory_with_none_cachedir():
@@ -684,7 +684,7 @@ def func_with_signature(a: int, b: float) -> float:
         mem = Memory(cachedir=env['dir'], verbose=0)
         func_cached = mem.cache(func_with_kwonly_args)
 
-        assert_equal(func_cached(1, 2, kw1=3), (1, 2, 3, 'kw2'))
+        assert func_cached(1, 2, kw1=3) == (1, 2, 3, 'kw2')
 
         # Making sure that providing a keyword-only argument by
         # position raises an exception
@@ -706,15 +706,15 @@ def func_with_signature(a: int, b: float) -> float:
 
         # Test 'ignore' parameter
         func_cached = mem.cache(func_with_kwonly_args, ignore=['kw2'])
-        assert_equal(func_cached(1, 2, kw1=3, kw2=4), (1, 2, 3, 4))
-        assert_equal(func_cached(1, 2, kw1=3, kw2='ignored'), (1, 2, 3, 4))
+        assert func_cached(1, 2, kw1=3, kw2=4) == (1, 2, 3, 4)
+        assert func_cached(1, 2, kw1=3, kw2='ignored') == (1, 2, 3, 4)
 
 
     def test_memory_func_with_signature():
         mem = Memory(cachedir=env['dir'], verbose=0)
         func_cached = mem.cache(func_with_signature)
 
-        assert_equal(func_cached(1, 2.), 3.)
+        assert func_cached(1, 2.) == 3.
 
 
 def _setup_temporary_cache_folder(num_inputs=10):
@@ -743,7 +743,7 @@ def test__get_cache_items():
     cachedir = mem.cachedir
     cache_items = _get_cache_items(cachedir)
     hash_cachedirs = [ci.path for ci in cache_items]
-    assert_equal(set(hash_cachedirs), set(expected_hash_cachedirs))
+    assert set(hash_cachedirs) == set(expected_hash_cachedirs)
 
     def get_files_size(directory):
         full_paths = [os.path.join(directory, fn)
@@ -753,7 +753,7 @@ def test__get_cache_items():
     expected_hash_cache_sizes = [get_files_size(hash_dir)
                                  for hash_dir in hash_cachedirs]
     hash_cache_sizes = [ci.size for ci in cache_items]
-    assert_equal(hash_cache_sizes, expected_hash_cache_sizes)
+    assert hash_cache_sizes == expected_hash_cache_sizes
 
     output_filenames = [os.path.join(hash_dir, 'output.pkl')
                         for hash_dir in hash_cachedirs]
@@ -762,7 +762,7 @@ def test__get_cache_items():
         datetime.datetime.fromtimestamp(os.path.getatime(fn))
         for fn in output_filenames]
     last_accesses = [ci.last_access for ci in cache_items]
-    assert_equal(last_accesses, expected_last_accesses)
+    assert last_accesses == expected_last_accesses
 
 
 def test__get_cache_items_to_delete():
@@ -774,16 +774,15 @@ def test__get_cache_items_to_delete():
     cache_items_to_delete = _get_cache_items_to_delete(cachedir, '2K')
     nb_hashes = len(expected_hash_cachedirs)
     assert set.issubset(set(cache_items_to_delete), set(cache_items))
-    assert_equal(len(cache_items_to_delete), nb_hashes - 1)
+    assert len(cache_items_to_delete) == nb_hashes - 1
 
     # Sanity check bytes_limit=2048 is the same as bytes_limit='2K'
     cache_items_to_delete_2048b = _get_cache_items_to_delete(cachedir, 2048)
-    assert_equal(sorted(cache_items_to_delete),
-                 sorted(cache_items_to_delete_2048b))
+    assert sorted(cache_items_to_delete) == sorted(cache_items_to_delete_2048b)
 
     # bytes_limit greater than the size of the cache
     cache_items_to_delete_empty = _get_cache_items_to_delete(cachedir, '1M')
-    assert_equal(cache_items_to_delete_empty, [])
+    assert cache_items_to_delete_empty == []
 
     # All the cache items need to be deleted
     bytes_limit_too_small = 500
@@ -810,25 +809,25 @@ def test_memory_reduce_size():
     # By default mem.bytes_limit is None and reduce_size is a noop
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
-    assert_equal(sorted(ref_cache_items), sorted(cache_items))
+    assert sorted(ref_cache_items) == sorted(cache_items)
 
     # No cache items deleted if bytes_limit greater than the size of
     # the cache
     mem.bytes_limit = '1M'
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
-    assert_equal(sorted(ref_cache_items), sorted(cache_items))
+    assert sorted(ref_cache_items) == sorted(cache_items)
 
     # bytes_limit is set so that only two cache items are kept
     mem.bytes_limit = '3K'
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
     assert set.issubset(set(cache_items), set(ref_cache_items))
-    assert_equal(len(cache_items), 2)
+    assert len(cache_items) == 2
 
     # bytes_limit set so that no cache item is kept
     bytes_limit_too_small = 500
     mem.bytes_limit = bytes_limit_too_small
     mem.reduce_size()
     cache_items = _get_cache_items(cachedir)
-    assert_equal(cache_items, [])
+    assert cache_items == []

--- a/joblib/test/test_my_exceptions.py
+++ b/joblib/test/test_my_exceptions.py
@@ -2,7 +2,6 @@
 Test my automatically generate exceptions
 """
 from joblib import my_exceptions
-from joblib.testing import assert_true
 
 
 class CustomException(Exception):
@@ -22,24 +21,24 @@ class CustomException2(Exception):
 
 
 def test_inheritance():
-    assert_true(isinstance(my_exceptions.JoblibNameError(), NameError))
-    assert_true(isinstance(my_exceptions.JoblibNameError(),
-                           my_exceptions.JoblibException))
-    assert_true(my_exceptions.JoblibNameError is
-                my_exceptions._mk_exception(NameError)[0])
+    assert isinstance(my_exceptions.JoblibNameError(), NameError)
+    assert isinstance(my_exceptions.JoblibNameError(),
+                      my_exceptions.JoblibException)
+    assert (my_exceptions.JoblibNameError is
+            my_exceptions._mk_exception(NameError)[0])
 
 
 def test_inheritance_special_cases():
     # _mk_exception should transform Exception to JoblibException
-    assert_true(my_exceptions._mk_exception(Exception)[0] is
-                my_exceptions.JoblibException)
+    assert (my_exceptions._mk_exception(Exception[0] is
+            my_exceptions.JoblibException))
 
     # Subclasses of JoblibException should be mapped to
     # JoblibException by _mk_exception
     for exception in [my_exceptions.JoblibException,
                       my_exceptions.TransportableException]:
-        assert_true(my_exceptions._mk_exception(exception)[0] is
-                    my_exceptions.JoblibException)
+        assert (my_exceptions._mk_exception(exception[0] is
+                my_exceptions.JoblibException))
 
     # Non-inheritable exception classes should be mapped to
     # JoblibException by _mk_exception. That can happen with classes
@@ -48,8 +47,8 @@ def test_inheritance_special_cases():
     # example.
     non_inheritable_classes = [type(lambda: None), bool]
     for exception in non_inheritable_classes:
-        assert_true(my_exceptions._mk_exception(exception)[0] is
-                    my_exceptions.JoblibException)
+        assert (my_exceptions._mk_exception(exception[0] is
+                my_exceptions.JoblibException))
 
 
 def test__mk_exception():
@@ -62,7 +61,7 @@ def test__mk_exception():
             'some', 'other', 'args', 'that are not', 'in the repr')
         exc_repr = repr(exc)
 
-        assert_true(isinstance(exc, klass))
-        assert_true(isinstance(exc, my_exceptions.JoblibException))
-        assert_true(exc.__class__.__name__ in exc_repr)
-        assert_true(message in exc_repr)
+        assert isinstance(exc, klass)
+        assert isinstance(exc, my_exceptions.JoblibException)
+        assert exc.__class__.__name__ in exc_repr
+        assert message in exc_repr

--- a/joblib/test/test_my_exceptions.py
+++ b/joblib/test/test_my_exceptions.py
@@ -30,15 +30,15 @@ def test_inheritance():
 
 def test_inheritance_special_cases():
     # _mk_exception should transform Exception to JoblibException
-    assert (my_exceptions._mk_exception(Exception[0] is
-            my_exceptions.JoblibException))
+    assert (my_exceptions._mk_exception(Exception)[0] is
+            my_exceptions.JoblibException)
 
     # Subclasses of JoblibException should be mapped to
     # JoblibException by _mk_exception
     for exception in [my_exceptions.JoblibException,
                       my_exceptions.TransportableException]:
-        assert (my_exceptions._mk_exception(exception[0] is
-                my_exceptions.JoblibException))
+        assert (my_exceptions._mk_exception(exception)[0] is
+                my_exceptions.JoblibException)
 
     # Non-inheritable exception classes should be mapped to
     # JoblibException by _mk_exception. That can happen with classes
@@ -47,8 +47,8 @@ def test_inheritance_special_cases():
     # example.
     non_inheritable_classes = [type(lambda: None), bool]
     for exception in non_inheritable_classes:
-        assert (my_exceptions._mk_exception(exception[0] is
-                my_exceptions.JoblibException))
+        assert (my_exceptions._mk_exception(exception)[0] is
+                my_exceptions.JoblibException)
 
 
 def test__mk_exception():

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -19,8 +19,8 @@ from contextlib import closing
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_memory_profiler, memory_used
-from joblib.testing import (assert_equal, assert_false,
-                            assert_raises, assert_raises_regex, SkipTest)
+from joblib.testing import (assert_equal, assert_raises, assert_raises_regex,
+                            SkipTest)
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.
@@ -184,9 +184,9 @@ def test_numpy_persistence():
                                           compress=compress)
 
             # All is cached in one file
-            assert_equal(len(filenames), 1)
+            assert len(filenames) == 1
             # Check that only one file was created
-            assert_equal(filenames[0], this_filename)
+            assert filenames[0] == this_filename
             # Check that this file does exist
             assert os.path.exists(os.path.join(env['dir'], filenames[0]))
 
@@ -206,7 +206,7 @@ def test_numpy_persistence():
             filenames = numpy_pickle.dump(obj, this_filename,
                                           compress=compress)
             # All is cached in one file
-            assert_equal(len(filenames), 1)
+            assert len(filenames) == 1
 
             obj_ = numpy_pickle.load(this_filename)
             if (type(obj) is not np.memmap and
@@ -221,7 +221,7 @@ def test_numpy_persistence():
         filenames = numpy_pickle.dump(obj, this_filename,
                                       compress=compress)
         # All is cached in one file
-        assert_equal(len(filenames), 1)
+        assert len(filenames) == 1
 
         obj_loaded = numpy_pickle.load(this_filename)
         assert isinstance(obj_loaded, type(obj))
@@ -285,9 +285,9 @@ def test_memmap_persistence():
     # Test w+ mode is caught and the mode has switched to r+
     numpy_pickle.load(filename, mmap_mode='w+')
     assert obj_loaded.array_int.flags.writeable
-    assert_equal(obj_loaded.array_int.mode, 'r+')
+    assert obj_loaded.array_int.mode == 'r+'
     assert obj_loaded.array_float.flags.writeable
-    assert_equal(obj_loaded.array_float.mode, 'r+')
+    assert obj_loaded.array_float.mode == 'r+'
 
 
 @with_numpy
@@ -332,14 +332,14 @@ def test_compress_mmap_mode_warning():
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
         numpy_pickle.load(this_filename, mmap_mode='r+')
-        assert_equal(len(caught_warnings), 1)
+        assert len(caught_warnings) == 1
         for warn in caught_warnings:
-            assert_equal(warn.category, UserWarning)
-            assert_equal(warn.message.args[0],
-                         'mmap_mode "%(mmap_mode)s" is not compatible with '
-                         'compressed file %(filename)s. "%(mmap_mode)s" flag '
-                         'will be ignored.' % {'filename': this_filename,
-                                               'mmap_mode': 'r+'})
+            assert warn.category == UserWarning
+            assert (warn.message.args[0] ==
+                    'mmap_mode "%(mmap_mode)s" is not compatible with '
+                    'compressed file %(filename)s. "%(mmap_mode)s" flag will '
+                    'be ignored.' % {'filename': this_filename,
+                                     'mmap_mode': 'r+'})
 
 
 @with_numpy
@@ -354,14 +354,13 @@ def test_cache_size_warning():
             warnings.simplefilter("always")
             numpy_pickle.dump(a, filename, cache_size=cache_size)
             expected_nb_warnings = 1 if cache_size is not None else 0
-            assert_equal(len(caught_warnings), expected_nb_warnings)
+            assert len(caught_warnings) == expected_nb_warnings
             for warn in caught_warnings:
-                assert_equal(warn.category, DeprecationWarning)
-                assert_equal(warn.message.args[0],
-                             "Please do not set 'cache_size' in joblib.dump, "
-                             "this parameter has no effect and will be "
-                             "removed. You used 'cache_size={0}'".format(
-                             cache_size))
+                assert warn.category == DeprecationWarning
+                assert (warn.message.args[0] ==
+                        "Please do not set 'cache_size' in joblib.dump, this "
+                        "parameter has no effect and will be removed. You "
+                        "used 'cache_size={0}'".format(cache_size))
 
 
 @with_numpy
@@ -415,14 +414,14 @@ def test_compressed_pickle_dump_and_load():
 
     try:
         dumped_filenames = numpy_pickle.dump(expected_list, fname, compress=1)
-        assert_equal(len(dumped_filenames), 1)
+        assert len(dumped_filenames) == 1
         result_list = numpy_pickle.load(fname)
         for result, expected in zip(result_list, expected_list):
             if isinstance(expected, np.ndarray):
-                assert_equal(result.dtype, expected.dtype)
+                assert result.dtype == expected.dtype
                 np.testing.assert_equal(result, expected)
             else:
-                assert_equal(result, expected)
+                assert result == expected
     finally:
         os.remove(fname)
 
@@ -455,19 +454,19 @@ def _check_pickle(filename, expected_list):
                 result_list = numpy_pickle.load(filename)
                 expected_nb_warnings = 1 if ("0.9" in filename or
                                              "0.8.4" in filename) else 0
-                assert_equal(len(caught_warnings), expected_nb_warnings)
+                assert len(caught_warnings) == expected_nb_warnings
             for warn in caught_warnings:
-                assert_equal(warn.category, DeprecationWarning)
-                assert_equal(warn.message.args[0],
-                             "The file '{0}' has been generated with a joblib "
-                             "version less than 0.10. Please regenerate this "
-                             "pickle file.".format(filename))
+                assert warn.category == DeprecationWarning
+                assert (warn.message.args[0] ==
+                        "The file '{0}' has been generated with a joblib "
+                        "version less than 0.10. Please regenerate this "
+                        "pickle file.".format(filename))
             for result, expected in zip(result_list, expected_list):
                 if isinstance(expected, np.ndarray):
-                    assert_equal(result.dtype, expected.dtype)
+                    assert result.dtype == expected.dtype
                     np.testing.assert_equal(result, expected)
                 else:
-                    assert_equal(result, expected)
+                    assert result == expected
         except Exception as exc:
             # When trying to read with python 3 a pickle generated
             # with python 2 we expect a user-friendly error
@@ -537,7 +536,7 @@ def test_compress_tuple_argument():
                           compress=compress)
         # Verify the file contains the right magic number
         with open(filename, 'rb') as f:
-            assert_equal(_detect_compressor(f), compress[0])
+            assert _detect_compressor(f) == compress[0]
 
     # Verify setting a wrong compress tuple raises a ValueError.
     assert_raises_regex(ValueError,
@@ -582,14 +581,14 @@ def test_joblib_compression_formats():
                                       compress=(cmethod, compress))
                     # Verify the file contains the right magic number
                     with open(dump_filename, 'rb') as f:
-                        assert_equal(_detect_compressor(f), cmethod)
+                        assert _detect_compressor(f) == cmethod
                     # Verify the reloaded object is correct
                     obj_reloaded = numpy_pickle.load(dump_filename)
                     assert isinstance(obj_reloaded, type(obj))
                     if isinstance(obj, np.ndarray):
                         np.testing.assert_array_equal(obj_reloaded, obj)
                     else:
-                        assert_equal(obj_reloaded, obj)
+                        assert obj_reloaded == obj
                     os.remove(dump_filename)
 
 
@@ -629,7 +628,7 @@ def test_load_externally_decompressed_files():
         # Test that the uncompressed pickle can be loaded and
         # that the result is correct.
         obj_reloaded = numpy_pickle.load(filename_raw)
-        assert_equal(obj, obj_reloaded)
+        assert obj == obj_reloaded
 
         # Do some cleanup
         os.remove(filename_raw)
@@ -664,11 +663,11 @@ def test_compression_using_file_extension():
             numpy_pickle.dump(obj, dump_fname)
             # Verify the file contains the right magic number
             with open(dump_fname, 'rb') as f:
-                assert_equal(_detect_compressor(f), cmethod)
+                assert _detect_compressor(f) == cmethod
             # Verify the reloaded object is correct
             obj_reloaded = numpy_pickle.load(dump_fname)
             assert isinstance(obj_reloaded, type(obj))
-            assert_equal(obj_reloaded, obj)
+            assert obj_reloaded == obj
             os.remove(dump_fname)
 
 
@@ -704,8 +703,8 @@ def test_file_handle_persistence():
                 np.testing.assert_array_equal(obj_reloaded, obj)
                 np.testing.assert_array_equal(obj_reloaded_2, obj)
             else:
-                assert_equal(obj_reloaded, obj)
-                assert_equal(obj_reloaded_2, obj)
+                assert obj_reloaded == obj
+                assert obj_reloaded_2 == obj
 
             os.remove(filename)
 
@@ -722,7 +721,7 @@ def test_in_memory_persistence():
         if isinstance(obj, np.ndarray):
             np.testing.assert_array_equal(obj_reloaded, obj)
         else:
-            assert_equal(obj_reloaded, obj)
+            assert obj_reloaded == obj
 
 
 @with_numpy
@@ -751,13 +750,13 @@ def test_file_handle_persistence_compressed_mmap():
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter("always")
             numpy_pickle.load(f, mmap_mode='r+')
-            assert_equal(len(caught_warnings), 1)
+            assert len(caught_warnings) == 1
             for warn in caught_warnings:
-                assert_equal(warn.category, UserWarning)
-                assert_equal(warn.message.args[0],
-                             '"%(fileobj)r" is not a raw file, mmap_mode '
-                             '"%(mmap_mode)s" flag will be ignored.'
-                             % {'fileobj': f, 'mmap_mode': 'r+'})
+                assert warn.category == UserWarning
+                assert (warn.message.args[0] ==
+                        '"%(fileobj)r" is not a raw file, mmap_mode '
+                        '"%(mmap_mode)s" flag will be ignored.'
+                        % {'fileobj': f, 'mmap_mode': 'r+'})
 
 
 @with_numpy
@@ -770,13 +769,13 @@ def test_file_handle_persistence_in_memory_mmap():
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
         numpy_pickle.load(buf, mmap_mode='r+')
-        assert_equal(len(caught_warnings), 1)
+        assert len(caught_warnings) == 1
         for warn in caught_warnings:
-            assert_equal(warn.category, UserWarning)
-            assert_equal(warn.message.args[0],
-                         'In memory persistence is not compatible with '
-                         'mmap_mode "%(mmap_mode)s" flag passed. mmap_mode '
-                         'option will be ignored.' % {'mmap_mode': 'r+'})
+            assert warn.category == UserWarning
+            assert (warn.message.args[0] ==
+                    'In memory persistence is not compatible with '
+                    'mmap_mode "%(mmap_mode)s" flag passed. mmap_mode '
+                    'option will be ignored.' % {'mmap_mode': 'r+'})
 
 
 def test_binary_zlibfile():
@@ -806,7 +805,7 @@ def test_binary_zlibfile():
                                     compresslevel=compress_level) as fz:
                     assert fz.writable()
                     fz.write(d)
-                    assert_equal(fz.fileno(), f.fileno())
+                    assert fz.fileno() == f.fileno()
                     assert_raises(io.UnsupportedOperation, fz._check_can_read)
                     assert_raises(io.UnsupportedOperation, fz._check_can_seek)
                 assert fz.closed
@@ -817,8 +816,8 @@ def test_binary_zlibfile():
                     assert fz.readable()
                     if PY3_OR_LATER:
                         assert fz.seekable()
-                    assert_equal(fz.fileno(), f.fileno())
-                    assert_equal(fz.read(), d)
+                    assert fz.fileno() == f.fileno()
+                    assert fz.read() == d
                     assert_raises(io.UnsupportedOperation,
                                   fz._check_can_write)
                     if PY3_OR_LATER:
@@ -826,7 +825,7 @@ def test_binary_zlibfile():
                         # python 2
                         assert fz.seekable()
                         fz.seek(0)
-                        assert_equal(fz.tell(), 0)
+                        assert fz.tell() == 0
                 assert fz.closed
 
             os.remove(filename)
@@ -838,7 +837,7 @@ def test_binary_zlibfile():
                 fz.write(d)
 
             with BinaryZlibFile(filename, 'rb') as fz:
-                assert_equal(fz.read(), d)
+                assert fz.read() == d
                 assert fz.seekable()
 
             # Test without context manager
@@ -848,7 +847,7 @@ def test_binary_zlibfile():
             fz.close()
 
             fz = BinaryZlibFile(filename, 'rb')
-            assert_equal(fz.read(), d)
+            assert fz.read() == d
             fz.close()
 
 
@@ -894,9 +893,9 @@ def test_pathlib():
         filename = env['filename']
         value = 123
         numpy_pickle.dump(value, Path(filename))
-        assert_equal(numpy_pickle.load(filename), value)
+        assert numpy_pickle.load(filename) == value
         numpy_pickle.dump(value, filename)
-        assert_equal(numpy_pickle.load(Path(filename)), value)
+        assert numpy_pickle.load(Path(filename)) == value
 
 
 @with_numpy

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -188,14 +188,13 @@ def test_numpy_persistence():
             # Check that only one file was created
             assert_equal(filenames[0], this_filename)
             # Check that this file does exist
-            assert_true(
-                os.path.exists(os.path.join(env['dir'], filenames[0])))
+            assert os.path.exists(os.path.join(env['dir'], filenames[0]))
 
             # Unpickle the object
             obj_ = numpy_pickle.load(this_filename)
             # Check that the items are indeed arrays
             for item in obj_:
-                assert_true(isinstance(item, np.ndarray))
+                assert isinstance(item, np.ndarray)
             # And finally, check that all the values are equal.
             np.testing.assert_array_equal(np.array(obj), np.array(obj_))
 
@@ -213,7 +212,7 @@ def test_numpy_persistence():
             if (type(obj) is not np.memmap and
                     hasattr(obj, '__array_prepare__')):
                 # We don't reconstruct memmaps
-                assert_true(isinstance(obj_, type(obj)))
+                assert isinstance(obj_, type(obj))
 
             np.testing.assert_array_equal(obj_, obj)
 
@@ -225,7 +224,7 @@ def test_numpy_persistence():
         assert_equal(len(filenames), 1)
 
         obj_loaded = numpy_pickle.load(this_filename)
-        assert_true(isinstance(obj_loaded, type(obj)))
+        assert isinstance(obj_loaded, type(obj))
         np.testing.assert_array_equal(obj_loaded.array_float, obj.array_float)
         np.testing.assert_array_equal(obj_loaded.array_int, obj.array_int)
         np.testing.assert_array_equal(obj_loaded.array_obj, obj.array_obj)
@@ -249,17 +248,17 @@ def test_memmap_persistence():
     numpy_pickle.dump(a, filename)
     b = numpy_pickle.load(filename, mmap_mode='r')
 
-    assert_true(isinstance(b, np.memmap))
+    assert isinstance(b, np.memmap)
 
     # Test with an object containing multiple numpy arrays
     filename = env['filename'] + str(random.randint(0, 1000))
     obj = ComplexTestObject()
     numpy_pickle.dump(obj, filename)
     obj_loaded = numpy_pickle.load(filename, mmap_mode='r')
-    assert_true(isinstance(obj_loaded, type(obj)))
-    assert_true(isinstance(obj_loaded.array_float, np.memmap))
+    assert isinstance(obj_loaded, type(obj))
+    assert isinstance(obj_loaded.array_float, np.memmap)
     assert_false(obj_loaded.array_float.flags.writeable)
-    assert_true(isinstance(obj_loaded.array_int, np.memmap))
+    assert isinstance(obj_loaded.array_int, np.memmap)
     assert_false(obj_loaded.array_int.flags.writeable)
     # Memory map not allowed for numpy object arrays
     assert_false(isinstance(obj_loaded.array_obj, np.memmap))
@@ -272,9 +271,9 @@ def test_memmap_persistence():
 
     # Test we can write in memmaped arrays
     obj_loaded = numpy_pickle.load(filename, mmap_mode='r+')
-    assert_true(obj_loaded.array_float.flags.writeable)
+    assert obj_loaded.array_float.flags.writeable
     obj_loaded.array_float[0:10] = 10.0
-    assert_true(obj_loaded.array_int.flags.writeable)
+    assert obj_loaded.array_int.flags.writeable
     obj_loaded.array_int[0:10] = 10
 
     obj_reloaded = numpy_pickle.load(filename, mmap_mode='r')
@@ -285,9 +284,9 @@ def test_memmap_persistence():
 
     # Test w+ mode is caught and the mode has switched to r+
     numpy_pickle.load(filename, mmap_mode='w+')
-    assert_true(obj_loaded.array_int.flags.writeable)
+    assert obj_loaded.array_int.flags.writeable
     assert_equal(obj_loaded.array_int.mode, 'r+')
-    assert_true(obj_loaded.array_float.flags.writeable)
+    assert obj_loaded.array_float.flags.writeable
     assert_equal(obj_loaded.array_float.mode, 'r+')
 
 
@@ -304,7 +303,7 @@ def test_memmap_persistence_mixed_dtypes():
     a_clone, b_clone = numpy_pickle.load(filename, mmap_mode='r')
 
     # the floating point array has been memory mapped
-    assert_true(isinstance(a_clone, np.memmap))
+    assert isinstance(a_clone, np.memmap)
 
     # the object-dtype array has been loaded in memory
     assert_false(isinstance(b_clone, np.memmap))
@@ -320,7 +319,7 @@ def test_masked_array_persistence():
     filename = env['filename'] + str(random.randint(0, 1000))
     numpy_pickle.dump(a, filename)
     b = numpy_pickle.load(filename, mmap_mode='r')
-    assert_true(isinstance(b, np.ma.masked_array))
+    assert isinstance(b, np.ma.masked_array)
 
 
 @with_numpy
@@ -384,13 +383,13 @@ def test_memory_usage():
             # The memory used to dump the object shouldn't exceed the buffer
             # size used to write array chunks (16MB).
             write_buf_size = _IO_BUFFER_SIZE + 16 * 1024 ** 2 / 1e6
-            assert_true(mem_used <= write_buf_size)
+            assert mem_used <= write_buf_size
 
             mem_used = memory_used(numpy_pickle.load, obj_filename)
             # memory used should be less than array size + buffer size used to
             # read the array chunk by chunk.
             read_buf_size = 32 + _IO_BUFFER_SIZE  # MiB
-            assert_true(mem_used < size + read_buf_size)
+            assert mem_used < size + read_buf_size
 
 
 @with_numpy
@@ -474,10 +473,10 @@ def _check_pickle(filename, expected_list):
             # with python 2 we expect a user-friendly error
             if (py_version_used_for_reading == 3 and
                     py_version_used_for_writing == 2):
-                assert_true(isinstance(exc, ValueError))
+                assert isinstance(exc, ValueError)
                 message = ('You may be trying to read with '
                            'python 3 a joblib pickle generated with python 2.')
-                assert_true(message in str(exc))
+                assert message in str(exc)
             else:
                 raise
     else:
@@ -490,7 +489,7 @@ def _check_pickle(filename, expected_list):
         except ValueError as e:
             message = 'unsupported pickle protocol: {0}'.format(
                 pickle_writing_protocol)
-            assert_true(message in str(e.args))
+            assert message in str(e.args)
 
 
 @with_numpy
@@ -586,7 +585,7 @@ def test_joblib_compression_formats():
                         assert_equal(_detect_compressor(f), cmethod)
                     # Verify the reloaded object is correct
                     obj_reloaded = numpy_pickle.load(dump_filename)
-                    assert_true(isinstance(obj_reloaded, type(obj)))
+                    assert isinstance(obj_reloaded, type(obj))
                     if isinstance(obj, np.ndarray):
                         np.testing.assert_array_equal(obj_reloaded, obj)
                     else:
@@ -668,7 +667,7 @@ def test_compression_using_file_extension():
                 assert_equal(_detect_compressor(f), cmethod)
             # Verify the reloaded object is correct
             obj_reloaded = numpy_pickle.load(dump_fname)
-            assert_true(isinstance(obj_reloaded, type(obj)))
+            assert isinstance(obj_reloaded, type(obj))
             assert_equal(obj_reloaded, obj)
             os.remove(dump_fname)
 
@@ -805,19 +804,19 @@ def test_binary_zlibfile():
             with open(filename, 'wb') as f:
                 with BinaryZlibFile(f, 'wb',
                                     compresslevel=compress_level) as fz:
-                    assert_true(fz.writable())
+                    assert fz.writable()
                     fz.write(d)
                     assert_equal(fz.fileno(), f.fileno())
                     assert_raises(io.UnsupportedOperation, fz._check_can_read)
                     assert_raises(io.UnsupportedOperation, fz._check_can_seek)
-                assert_true(fz.closed)
+                assert fz.closed
                 assert_raises(ValueError, fz._check_not_closed)
 
             with open(filename, 'rb') as f:
                 with BinaryZlibFile(f) as fz:
-                    assert_true(fz.readable())
+                    assert fz.readable()
                     if PY3_OR_LATER:
-                        assert_true(fz.seekable())
+                        assert fz.seekable()
                     assert_equal(fz.fileno(), f.fileno())
                     assert_equal(fz.read(), d)
                     assert_raises(io.UnsupportedOperation,
@@ -825,26 +824,26 @@ def test_binary_zlibfile():
                     if PY3_OR_LATER:
                         # io.BufferedIOBase doesn't have seekable() method in
                         # python 2
-                        assert_true(fz.seekable())
+                        assert fz.seekable()
                         fz.seek(0)
                         assert_equal(fz.tell(), 0)
-                assert_true(fz.closed)
+                assert fz.closed
 
             os.remove(filename)
 
             # Test with a filename as input
             with BinaryZlibFile(filename, 'wb',
                                 compresslevel=compress_level) as fz:
-                assert_true(fz.writable())
+                assert fz.writable()
                 fz.write(d)
 
             with BinaryZlibFile(filename, 'rb') as fz:
                 assert_equal(fz.read(), d)
-                assert_true(fz.seekable())
+                assert fz.seekable()
 
             # Test without context manager
             fz = BinaryZlibFile(filename, 'wb', compresslevel=compress_level)
-            assert_true(fz.writable())
+            assert fz.writable()
             fz.write(d)
             fz.close()
 
@@ -882,7 +881,7 @@ def test_numpy_subclass():
     a = SubArray((10,))
     numpy_pickle.dump(a, filename)
     c = numpy_pickle.load(filename)
-    assert_true(isinstance(c, SubArray))
+    assert isinstance(c, SubArray)
     np.testing.assert_array_equal(c, a)
 
 

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -19,7 +19,7 @@ from contextlib import closing
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_memory_profiler, memory_used
-from joblib.testing import (assert_equal, assert_true, assert_false,
+from joblib.testing import (assert_equal, assert_false,
                             assert_raises, assert_raises_regex, SkipTest)
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
@@ -257,11 +257,11 @@ def test_memmap_persistence():
     obj_loaded = numpy_pickle.load(filename, mmap_mode='r')
     assert isinstance(obj_loaded, type(obj))
     assert isinstance(obj_loaded.array_float, np.memmap)
-    assert_false(obj_loaded.array_float.flags.writeable)
+    assert not obj_loaded.array_float.flags.writeable
     assert isinstance(obj_loaded.array_int, np.memmap)
-    assert_false(obj_loaded.array_int.flags.writeable)
+    assert not obj_loaded.array_int.flags.writeable
     # Memory map not allowed for numpy object arrays
-    assert_false(isinstance(obj_loaded.array_obj, np.memmap))
+    assert not isinstance(obj_loaded.array_obj, np.memmap)
     np.testing.assert_array_equal(obj_loaded.array_float,
                                   obj.array_float)
     np.testing.assert_array_equal(obj_loaded.array_int,
@@ -306,7 +306,7 @@ def test_memmap_persistence_mixed_dtypes():
     assert isinstance(a_clone, np.memmap)
 
     # the object-dtype array has been loaded in memory
-    assert_false(isinstance(b_clone, np.memmap))
+    assert not isinstance(b_clone, np.memmap)
 
 
 @with_numpy
@@ -909,8 +909,8 @@ def test_non_contiguous_array_pickling():
                     np.asfortranarray([[1, 2], [3, 4]])[1:],
                     # Non contiguous array with works fine with nditer
                     np.ones((10, 50, 20), order='F')[:, :1, :]]:
-        assert_false(array.flags.c_contiguous)
-        assert_false(array.flags.f_contiguous)
+        assert not array.flags.c_contiguous
+        assert not array.flags.f_contiguous
         numpy_pickle.dump(array, filename)
         array_reloaded = numpy_pickle.load(filename)
         np.testing.assert_array_equal(array_reloaded, array)

--- a/joblib/test/test_numpy_pickle_compat.py
+++ b/joblib/test/test_numpy_pickle_compat.py
@@ -9,7 +9,7 @@ from tempfile import mkdtemp
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.
 from joblib import numpy_pickle_compat
-from joblib.testing import assert_equal
+
 
 ###############################################################################
 # Test fixtures
@@ -36,4 +36,4 @@ def test_z_file():
         numpy_pickle_compat.write_zfile(f, data)
     with open(filename, 'rb') as f:
         data_read = numpy_pickle_compat.read_zfile(f)
-    assert_equal(data, data_read)
+    assert data == data_read

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -18,8 +18,8 @@ from joblib import parallel
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_multiprocessing
-from joblib.testing import (assert_equal, assert_true, assert_false,
-                            assert_raises, check_subprocess_call, SkipTest)
+from joblib.testing import (assert_equal, assert_raises, check_subprocess_call,
+                            SkipTest)
 from joblib._compat import PY3_OR_LATER
 from multiprocessing import TimeoutError
 from time import sleep
@@ -366,7 +366,7 @@ def test_error_capture():
         Parallel(n_jobs=1)(
             delayed(division)(x, y) for x, y in zip((0, 1), (1, 0)))
     except Exception as ex:
-        assert_false(isinstance(ex, JoblibException))
+        assert not isinstance(ex, JoblibException)
 
 
 class Counter(object):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -214,7 +214,7 @@ def test_mutate_input_with_threads():
     q = Queue(maxsize=5)
     Parallel(n_jobs=2, backend="threading")(
         delayed(q.put, check_pickle=False)(1) for _ in range(5))
-    assert_true(q.full())
+    assert q.full()
 
 
 def test_parallel_kwargs():
@@ -234,8 +234,8 @@ def check_parallel_as_context_manager(backend):
         # via the context manager protocol
         managed_backend = p._backend
         if mp is not None:
-            assert_true(managed_backend is not None)
-            assert_true(managed_backend._pool is not None)
+            assert managed_backend is not None
+            assert managed_backend._pool is not None
 
         # We make call with the managed parallel object several times inside
         # the managed block:
@@ -244,17 +244,17 @@ def check_parallel_as_context_manager(backend):
 
         # Those calls have all used the same pool instance:
         if mp is not None:
-            assert_true(managed_backend._pool is p._backend._pool)
+            assert managed_backend._pool is p._backend._pool
 
     # As soon as we exit the context manager block, the pool is terminated and
     # no longer referenced from the parallel object:
     if mp is not None:
-        assert_true(p._backend._pool is None)
+        assert p._backend._pool is None
 
     # It's still possible to use the parallel instance in non-managed mode:
     assert_equal(expected, p(delayed(f)(x, y=1) for x in lst))
     if mp is not None:
-        assert_true(p._backend._pool is None)
+        assert p._backend._pool is None
 
 
 def test_parallel_context_manager():
@@ -312,7 +312,7 @@ def test_error_capture():
 
         # Try again with the context manager API
         with Parallel(n_jobs=2) as parallel:
-            assert_true(parallel._backend._pool is not None)
+            assert parallel._backend._pool is not None
             original_pool = parallel._backend._pool
 
             assert_raises(JoblibException, parallel,
@@ -321,10 +321,10 @@ def test_error_capture():
 
             # The managed pool should still be available and be in a working
             # state despite the previously raised (and caught) exception
-            assert_true(parallel._backend._pool is not None)
+            assert parallel._backend._pool is not None
 
             # The pool should have been interrupted and restarted:
-            assert_true(parallel._backend._pool is not original_pool)
+            assert parallel._backend._pool is not original_pool
 
             assert_equal([f(x, y=1) for x in range(10)],
                          parallel(delayed(f)(x, y=1) for x in range(10)))
@@ -334,17 +334,17 @@ def test_error_capture():
                           [delayed(interrupt_raiser)(x) for x in (1, 0)])
 
             # The pool should still be available despite the exception
-            assert_true(parallel._backend._pool is not None)
+            assert parallel._backend._pool is not None
 
             # The pool should have been interrupted and restarted:
-            assert_true(parallel._backend._pool is not original_pool)
+            assert parallel._backend._pool is not original_pool
 
             assert_equal([f(x, y=1) for x in range(10)],
                          parallel(delayed(f)(x, y=1) for x in range(10)))
 
         # Check that the inner pool has been terminated when exiting the
         # context manager
-        assert_true(parallel._backend._pool is None)
+        assert parallel._backend._pool is None
     else:
         assert_raises(KeyboardInterrupt, Parallel(n_jobs=2),
                       [delayed(interrupt_raiser)(x) for x in (1, 0)])
@@ -479,7 +479,7 @@ def test_batching_auto_multiprocessing():
         # It should be strictly larger than 1 but as we don't want heisen
         # failures on clogged CI worker environment be safe and only check that
         # it's a strictly positive number.
-        assert_true(p._backend.compute_batch_size() > 0)
+        assert p._backend.compute_batch_size() > 0
 
 
 def test_exception_dispatch():
@@ -541,7 +541,7 @@ def test_invalid_backend():
 def test_register_parallel_backend():
     try:
         register_parallel_backend("test_backend", FakeParallelBackend)
-        assert_true("test_backend" in BACKENDS)
+        assert "test_backend" in BACKENDS
         assert_equal(BACKENDS["test_backend"], FakeParallelBackend)
     finally:
         del BACKENDS["test_backend"]
@@ -627,7 +627,7 @@ def test_parameterized_backend_context_manager():
             assert_equal(active_n_jobs, 3)
             p = Parallel()
             assert_equal(p.n_jobs, 3)
-            assert_true(p._backend is active_backend)
+            assert p._backend is active_backend
             results = p(delayed(sqrt)(i) for i in range(5))
         assert_equal(results, [sqrt(i) for i in range(5)])
 
@@ -649,7 +649,7 @@ def test_direct_parameterized_backend_context_manager():
         assert_equal(active_n_jobs, 5)
         p = Parallel()
         assert_equal(p.n_jobs, 5)
-        assert_true(p._backend is active_backend)
+        assert p._backend is active_backend
         results = p(delayed(sqrt)(i) for i in range(5))
     assert_equal(results, [sqrt(i) for i in range(5)])
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -124,10 +124,9 @@ def test_effective_n_jobs():
 def check_simple_parallel(backend):
     X = range(5)
     for n_jobs in (1, 2, -1, -2):
-        assert_equal(
-            [square(x) for x in X],
-            Parallel(n_jobs=n_jobs, backend=backend)(
-                delayed(square)(x) for x in X))
+        assert ([square(x) for x in X] ==
+                Parallel(n_jobs=n_jobs, backend=backend)(
+                    delayed(square)(x) for x in X))
     try:
         # To smoke-test verbosity, we capture stdout
         orig_stdout = sys.stdout
@@ -171,11 +170,11 @@ def check_main_thread_renamed_no_warning(backend):
         warnings.simplefilter("always")
         results = Parallel(n_jobs=2, backend=backend)(
             delayed(square)(x) for x in range(3))
-        assert_equal(results, [0, 1, 4])
+        assert results == [0, 1, 4]
     # The multiprocessing backend will raise a warning when detecting that is
     # started from the non-main thread. Let's check that there is no false
     # positive because of the name change.
-    assert_equal(caught_warnings, [])
+    assert caught_warnings == []
 
 
 def test_main_thread_renamed_no_warning():
@@ -239,8 +238,8 @@ def check_parallel_as_context_manager(backend):
 
         # We make call with the managed parallel object several times inside
         # the managed block:
-        assert_equal(expected, p(delayed(f)(x, y=1) for x in lst))
-        assert_equal(expected, p(delayed(f)(x, y=1) for x in lst))
+        assert expected == p(delayed(f)(x, y=1) for x in lst)
+        assert expected == p(delayed(f)(x, y=1) for x in lst)
 
         # Those calls have all used the same pool instance:
         if mp is not None:
@@ -252,7 +251,7 @@ def check_parallel_as_context_manager(backend):
         assert p._backend._pool is None
 
     # It's still possible to use the parallel instance in non-managed mode:
-    assert_equal(expected, p(delayed(f)(x, y=1) for x in lst))
+    assert expected == p(delayed(f)(x, y=1) for x in lst)
     if mp is not None:
         assert p._backend._pool is None
 
@@ -284,9 +283,8 @@ def test_parallel_pickling():
 def test_parallel_timeout_success():
     # Check that timeout isn't thrown when function is fast enough
     for backend in ['multiprocessing', 'threading']:
-        assert_equal(10,
-                     len(Parallel(n_jobs=2, backend=backend, timeout=10)
-                         (delayed(sleep)(0.001) for x in range(10))))
+        assert len(Parallel(n_jobs=2, backend=backend, timeout=10)(
+            delayed(sleep)(0.001) for x in range(10))) == 10
 
 
 @with_multiprocessing
@@ -326,8 +324,8 @@ def test_error_capture():
             # The pool should have been interrupted and restarted:
             assert parallel._backend._pool is not original_pool
 
-            assert_equal([f(x, y=1) for x in range(10)],
-                         parallel(delayed(f)(x, y=1) for x in range(10)))
+            assert ([f(x, y=1) for x in range(10)] ==
+                    parallel(delayed(f)(x, y=1) for x in range(10)))
 
             original_pool = parallel._backend._pool
             assert_raises(WorkerInterrupt, parallel,
@@ -339,8 +337,8 @@ def test_error_capture():
             # The pool should have been interrupted and restarted:
             assert parallel._backend._pool is not original_pool
 
-            assert_equal([f(x, y=1) for x in range(10)],
-                         parallel(delayed(f)(x, y=1) for x in range(10)))
+            assert ([f(x, y=1) for x in range(10)] ==
+                    parallel(delayed(f)(x, y=1) for x in range(10)))
 
         # Check that the inner pool has been terminated when exiting the
         # context manager
@@ -376,7 +374,7 @@ class Counter(object):
 
     def __call__(self, i):
         self.list1.append(i)
-        assert_equal(len(self.list1), len(self.list2))
+        assert len(self.list1) == len(self.list2)
 
 
 def consumer(queue, item):
@@ -404,7 +402,7 @@ def check_dispatch_one_job(backend):
         'Produced 4', 'Consumed 4',
         'Produced 5', 'Consumed 5',
     ])
-    assert_equal(len(queue), 12)
+    assert len(queue) == 12
 
     # empty the queue for the next check
     queue[:] = []
@@ -420,7 +418,7 @@ def check_dispatch_one_job(backend):
         # Second batch
         'Produced 4', 'Produced 5', 'Consumed 4', 'Consumed 5',
     ])
-    assert_equal(len(queue), 12)
+    assert len(queue) == 12
 
 
 def test_dispatch_one_job():
@@ -453,7 +451,7 @@ def check_dispatch_multiprocessing(backend):
     first_four.remove('Consumed any')
     assert_equal(first_four,
                  ['Produced 0', 'Produced 1', 'Produced 2'])
-    assert_equal(len(queue), 12)
+    assert len(queue) == 12
 
 
 def test_dispatch_multiprocessing():
@@ -469,7 +467,7 @@ def test_batching_auto_threading():
 
     with Parallel(n_jobs=2, batch_size='auto', backend='threading') as p:
         p(delayed(id)(i) for i in range(5000))  # many very fast tasks
-        assert_equal(p._backend.compute_batch_size(), 1)
+        assert p._backend.compute_batch_size() == 1
 
 
 def test_batching_auto_multiprocessing():
@@ -542,39 +540,39 @@ def test_register_parallel_backend():
     try:
         register_parallel_backend("test_backend", FakeParallelBackend)
         assert "test_backend" in BACKENDS
-        assert_equal(BACKENDS["test_backend"], FakeParallelBackend)
+        assert BACKENDS["test_backend"] == FakeParallelBackend
     finally:
         del BACKENDS["test_backend"]
 
 
 def test_overwrite_default_backend():
-    assert_equal(_active_backend_type(), MultiprocessingBackend)
+    assert _active_backend_type() == MultiprocessingBackend
     try:
         register_parallel_backend("threading", BACKENDS["threading"],
                                   make_default=True)
-        assert_equal(_active_backend_type(), ThreadingBackend)
+        assert _active_backend_type() == ThreadingBackend
     finally:
         # Restore the global default manually
         parallel.DEFAULT_BACKEND = 'multiprocessing'
-    assert_equal(_active_backend_type(), MultiprocessingBackend)
+    assert _active_backend_type() == MultiprocessingBackend
 
 
 def check_backend_context_manager(backend_name):
     with parallel_backend(backend_name, n_jobs=3):
         active_backend, active_n_jobs = parallel.get_active_backend()
-        assert_equal(active_n_jobs, 3)
-        assert_equal(effective_n_jobs(3), 3)
+        assert active_n_jobs == 3
+        assert effective_n_jobs(3) == 3
         p = Parallel()
-        assert_equal(p.n_jobs, 3)
+        assert p.n_jobs == 3
         if backend_name == 'multiprocessing':
-            assert_equal(type(active_backend), MultiprocessingBackend)
-            assert_equal(type(p._backend), MultiprocessingBackend)
+            assert type(active_backend) == MultiprocessingBackend
+            assert type(p._backend) == MultiprocessingBackend
         elif backend_name == 'threading':
-            assert_equal(type(active_backend), ThreadingBackend)
-            assert_equal(type(p._backend), ThreadingBackend)
+            assert type(active_backend) == ThreadingBackend
+            assert type(p._backend) == ThreadingBackend
         elif backend_name.startswith('test_'):
-            assert_equal(type(active_backend), FakeParallelBackend)
-            assert_equal(type(p._backend), FakeParallelBackend)
+            assert type(active_backend) == FakeParallelBackend
+            assert type(p._backend) == FakeParallelBackend
 
 
 @with_multiprocessing
@@ -585,13 +583,13 @@ def test_backend_context_manager():
     all_backends = ['multiprocessing', 'threading'] + all_test_backends
 
     try:
-        assert_equal(_active_backend_type(), MultiprocessingBackend)
+        assert _active_backend_type() == MultiprocessingBackend
         # check that this possible to switch parallel backends sequentially
         for test_backend in all_backends:
             yield check_backend_context_manager, test_backend
 
         # The default backend is retored
-        assert_equal(_active_backend_type(), MultiprocessingBackend)
+        assert _active_backend_type() == MultiprocessingBackend
 
         # Check that context manager switching is thread safe:
         Parallel(n_jobs=2, backend='threading')(
@@ -599,7 +597,7 @@ def test_backend_context_manager():
             for b in all_backends if not b)
 
         # The default backend is again retored
-        assert_equal(_active_backend_type(), MultiprocessingBackend)
+        assert _active_backend_type() == MultiprocessingBackend
     finally:
         for backend_name in list(BACKENDS.keys()):
             if backend_name.startswith('test_'):
@@ -618,43 +616,43 @@ class ParameterizedParallelBackend(SequentialBackend):
 def test_parameterized_backend_context_manager():
     register_parallel_backend('param_backend', ParameterizedParallelBackend)
     try:
-        assert_equal(_active_backend_type(), MultiprocessingBackend)
+        assert _active_backend_type() == MultiprocessingBackend
 
         with parallel_backend('param_backend', param=42, n_jobs=3):
             active_backend, active_n_jobs = parallel.get_active_backend()
-            assert_equal(type(active_backend), ParameterizedParallelBackend)
-            assert_equal(active_backend.param, 42)
-            assert_equal(active_n_jobs, 3)
+            assert type(active_backend) == ParameterizedParallelBackend
+            assert active_backend.param == 42
+            assert active_n_jobs == 3
             p = Parallel()
-            assert_equal(p.n_jobs, 3)
+            assert p.n_jobs == 3
             assert p._backend is active_backend
             results = p(delayed(sqrt)(i) for i in range(5))
-        assert_equal(results, [sqrt(i) for i in range(5)])
+        assert results == [sqrt(i) for i in range(5)]
 
         # The default backend is again retored
-        assert_equal(_active_backend_type(), MultiprocessingBackend)
+        assert _active_backend_type() == MultiprocessingBackend
     finally:
         del BACKENDS['param_backend']
 
 
 def test_direct_parameterized_backend_context_manager():
-    assert_equal(_active_backend_type(), MultiprocessingBackend)
+    assert _active_backend_type() == MultiprocessingBackend
 
     # Check that it's possible to pass a backend instance directly,
     # without registration
     with parallel_backend(ParameterizedParallelBackend(param=43), n_jobs=5):
         active_backend, active_n_jobs = parallel.get_active_backend()
-        assert_equal(type(active_backend), ParameterizedParallelBackend)
-        assert_equal(active_backend.param, 43)
-        assert_equal(active_n_jobs, 5)
+        assert type(active_backend) == ParameterizedParallelBackend
+        assert active_backend.param == 43
+        assert active_n_jobs == 5
         p = Parallel()
-        assert_equal(p.n_jobs, 5)
+        assert p.n_jobs == 5
         assert p._backend is active_backend
         results = p(delayed(sqrt)(i) for i in range(5))
-    assert_equal(results, [sqrt(i) for i in range(5)])
+    assert results == [sqrt(i) for i in range(5)]
 
     # The default backend is again retored
-    assert_equal(_active_backend_type(), MultiprocessingBackend)
+    assert _active_backend_type() == MultiprocessingBackend
 
 
 ###############################################################################
@@ -683,7 +681,7 @@ def check_same_results(params):
     n_tasks = params.pop('n_tasks')
     expected = [square(i) for i in range(n_tasks)]
     results = Parallel(**params)(delayed(square)(i) for i in range(n_tasks))
-    assert_equal(results, expected)
+    assert results == expected
 
 
 def test_dispatch_race_condition():
@@ -717,13 +715,13 @@ def test_default_mp_context():
         if env_method is None:
             # Check the default behavior
             if sys.platform == 'win32':
-                assert_equal(start_method, 'spawn')
+                assert start_method == 'spawn'
             else:
-                assert_equal(start_method, 'fork')
+                assert start_method == 'fork'
         else:
-            assert_equal(start_method, env_method)
+            assert start_method == env_method
     else:
-        assert_equal(context, None)
+        assert context is None
 
 
 @with_multiprocessing
@@ -770,7 +768,7 @@ def test_parallel_with_interactively_defined_functions():
 
 def test_parallel_with_exhausted_iterator():
     exhausted_iterator = iter([])
-    assert_equal(Parallel(n_jobs=2)(exhausted_iterator), [])
+    assert Parallel(n_jobs=2)(exhausted_iterator) == []
 
 
 def check_memmap(a):

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -433,7 +433,7 @@ def test_memmaping_pool_for_large_arrays_in_return():
 
 def _worker_multiply(a, n_times):
     """Multiplication function to be executed by subprocess"""
-    assert_true(has_shareable_memory(a))
+    assert has_shareable_memory(a)
     return a * n_times
 
 

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -7,7 +7,7 @@ from joblib.test.common import setup_autokill
 from joblib.test.common import teardown_autokill
 from joblib.test.common import with_multiprocessing
 from joblib.test.common import with_dev_shm
-from joblib.testing import (assert_raises, with_setup)
+from joblib.testing import assert_raises, with_setup
 
 
 from joblib._multiprocessing_helpers import mp

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -7,7 +7,7 @@ from joblib.test.common import setup_autokill
 from joblib.test.common import teardown_autokill
 from joblib.test.common import with_multiprocessing
 from joblib.test.common import with_dev_shm
-from joblib.testing import (assert_equal, assert_true, assert_false,
+from joblib.testing import (assert_equal, assert_true,
                             assert_raises, with_setup)
 
 from joblib._multiprocessing_helpers import mp
@@ -114,42 +114,42 @@ def test_memmap_based_array_reducing():
 
     # Reconstruct original memmap
     a_reconstructed = reconstruct_memmap(a)
-    assert_true(has_shareable_memory(a_reconstructed))
-    assert_true(isinstance(a_reconstructed, np.memmap))
+    assert has_shareable_memory(a_reconstructed)
+    assert isinstance(a_reconstructed, np.memmap)
     assert_array_equal(a_reconstructed, a)
 
     # Reconstruct strided memmap view
     b_reconstructed = reconstruct_memmap(b)
-    assert_true(has_shareable_memory(b_reconstructed))
+    assert has_shareable_memory(b_reconstructed)
     assert_array_equal(b_reconstructed, b)
 
     # Reconstruct arrays views on memmap base
     c_reconstructed = reconstruct_array(c)
-    assert_false(isinstance(c_reconstructed, np.memmap))
-    assert_true(has_shareable_memory(c_reconstructed))
+    assert not isinstance(c_reconstructed, np.memmap)
+    assert has_shareable_memory(c_reconstructed)
     assert_array_equal(c_reconstructed, c)
 
     d_reconstructed = reconstruct_array(d)
-    assert_false(isinstance(d_reconstructed, np.memmap))
-    assert_true(has_shareable_memory(d_reconstructed))
+    assert not isinstance(d_reconstructed, np.memmap)
+    assert has_shareable_memory(d_reconstructed)
     assert_array_equal(d_reconstructed, d)
 
     # Test graceful degradation on fake memmap instances with in-memory
     # buffers
     a3 = a * 3
-    assert_false(has_shareable_memory(a3))
+    assert not has_shareable_memory(a3)
     a3_reconstructed = reconstruct_memmap(a3)
-    assert_false(has_shareable_memory(a3_reconstructed))
-    assert_false(isinstance(a3_reconstructed, np.memmap))
+    assert not has_shareable_memory(a3_reconstructed)
+    assert not isinstance(a3_reconstructed, np.memmap)
     assert_array_equal(a3_reconstructed, a * 3)
 
     # Test graceful degradation on arrays derived from fake memmap instances
     b3 = np.asarray(a3)
-    assert_false(has_shareable_memory(b3))
+    assert not has_shareable_memory(b3)
 
     b3_reconstructed = reconstruct_array(b3)
-    assert_true(isinstance(b3_reconstructed, np.ndarray))
-    assert_false(has_shareable_memory(b3_reconstructed))
+    assert isinstance(b3_reconstructed, np.ndarray)
+    assert not has_shareable_memory(b3_reconstructed)
     assert_array_equal(b3_reconstructed, b3)
 
 
@@ -178,24 +178,24 @@ def test_high_dimension_memmap_array_reducing():
         return res
 
     a_reconstructed = reconstruct_memmap(a)
-    assert_true(has_shareable_memory(a_reconstructed))
-    assert_true(isinstance(a_reconstructed, np.memmap))
+    assert has_shareable_memory(a_reconstructed)
+    assert isinstance(a_reconstructed, np.memmap)
     assert_array_equal(a_reconstructed, a)
 
     b_reconstructed = reconstruct_memmap(b)
-    assert_true(has_shareable_memory(b_reconstructed))
+    assert has_shareable_memory(b_reconstructed)
     assert_array_equal(b_reconstructed, b)
 
     c_reconstructed = reconstruct_memmap(c)
-    assert_true(has_shareable_memory(c_reconstructed))
+    assert has_shareable_memory(c_reconstructed)
     assert_array_equal(c_reconstructed, c)
 
     d_reconstructed = reconstruct_memmap(d)
-    assert_true(has_shareable_memory(d_reconstructed))
+    assert has_shareable_memory(d_reconstructed)
     assert_array_equal(d_reconstructed, d)
 
     e_reconstructed = reconstruct_memmap(e)
-    assert_true(has_shareable_memory(e_reconstructed))
+    assert has_shareable_memory(e_reconstructed)
     assert_array_equal(e_reconstructed, e)
 
 
@@ -272,8 +272,8 @@ def test_pool_with_memmap_array_view():
 
         # Create an ndarray view on the memmap instance
         a_view = np.asarray(a)
-        assert_false(isinstance(a_view, np.memmap))
-        assert_true(has_shareable_memory(a_view))
+        assert not isinstance(a_view, np.memmap)
+        assert has_shareable_memory(a_view)
 
         p.map(inplace_double, [(a_view, (i, j), 1.0)
                                for i in range(a.shape[0])
@@ -307,7 +307,7 @@ def test_memmaping_pool_for_large_arrays():
     try:
         # The tempory folder for the pool is not provisioned in advance
         assert_equal(os.listdir(TEMP_FOLDER), [])
-        assert_false(os.path.exists(p._temp_folder))
+        assert not os.path.exists(p._temp_folder)
 
         small = np.ones(5, dtype=np.float32)
         assert_equal(small.nbytes, 20)
@@ -323,7 +323,7 @@ def test_memmaping_pool_for_large_arrays():
 
         # The data has been dumped in a temp folder for subprocess to share it
         # without per-child memory copies
-        assert_true(os.path.isdir(p._temp_folder))
+        assert os.path.isdir(p._temp_folder)
         dumped_filenames = os.listdir(p._temp_folder)
         assert_equal(len(dumped_filenames), 1)
 
@@ -331,12 +331,12 @@ def test_memmaping_pool_for_large_arrays():
         # dtype='object'
         objects = np.array(['abc'] * 100, dtype='object')
         results = p.map(has_shareable_memory, [objects])
-        assert_false(results[0])
+        assert not results[0]
 
     finally:
         # check FS garbage upon pool termination
         p.terminate()
-        assert_false(os.path.exists(p._temp_folder))
+        assert not os.path.exists(p._temp_folder)
         del p
 
 
@@ -377,8 +377,8 @@ def test_memmaping_on_dev_shm():
         # shared memory filesystem.
         pool_temp_folder = p._temp_folder
         folder_prefix = '/dev/shm/joblib_memmaping_pool_'
-        assert_true(pool_temp_folder.startswith(folder_prefix))
-        assert_true(os.path.exists(pool_temp_folder))
+        assert pool_temp_folder.startswith(folder_prefix)
+        assert os.path.exists(pool_temp_folder)
 
         # Try with a file larger than the memmap threshold of 10 bytes
         a = np.ones(100, dtype=np.float64)
@@ -403,7 +403,7 @@ def test_memmaping_on_dev_shm():
         del p
 
     # The temp folder is cleaned up upon pool termination
-    assert_false(os.path.exists(pool_temp_folder))
+    assert not os.path.exists(pool_temp_folder)
 
 
 @with_numpy
@@ -424,7 +424,7 @@ def test_memmaping_pool_for_large_arrays_in_return():
     try:
         res = p.apply_async(np.ones, args=(1000,))
         large = res.get()
-        assert_false(has_shareable_memory(large))
+        assert not has_shareable_memory(large)
         assert_array_equal(large, np.ones(1000))
     finally:
         p.terminate()
@@ -458,7 +458,7 @@ def test_workaround_against_bad_memmap_with_copied_buffers():
         # Call a non-inplace multiply operation on the worker and memmap and
         # send it back to the parent.
         b = p.apply_async(_worker_multiply, args=(a, 3)).get()
-        assert_false(has_shareable_memory(b))
+        assert not has_shareable_memory(b)
         assert_array_equal(b, 3 * a)
     finally:
         p.terminate()


### PR DESCRIPTION
#### Second Phase PR on #411 ( Succeeding PR #422 )

Native Python ships `exceptions` module which has an implementation of `AssertionError`. This exception is raised when any statement using `assert` keyword is incorrect. When the tests are run with `py.test`, this is overriden by `_pytest.assertion.reinterpret.AssertionError`.  
Hence instead of using `assert_true`, `assert_false`, `assert_equal ` and `assert_not_equal` methods, using `assert` keyword statements provides a helpful error log for debugging upon failing tests using `py.test` command.  

Besides this, the replacement can be welcoming because:
```python
assert_true(a == b)
assert_equal(a, b)
assert_false(a != b)

# ... all these have same meaning hence can disturb uniformity, whereas
assert a == b 
# looks clearer and more pythonic
```

Execution with py.test causes three tests to fail, which will be taken up just after this PR.