### PR TITLE
[MRG+1] Expose logging function in joblib.logger

### DIFF
--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -181,7 +181,7 @@ class AutoBatchingMixin(object):
             batch_size = max(2 * ideal_batch_size, 1)
             self._effective_batch_size = batch_size
             if self.parallel.verbose >= 10:
-                self.parallel._print(
+                self.parallel._log(
                     "Batch computation too fast (%.4fs.) "
                     "Setting batch_size=%d.", (batch_duration, batch_size))
         elif (batch_duration > self.MAX_IDEAL_BATCH_DURATION and
@@ -194,7 +194,7 @@ class AutoBatchingMixin(object):
             batch_size = old_batch_size // 2
             self._effective_batch_size = batch_size
             if self.parallel.verbose >= 10:
-                self.parallel._print(
+                self.parallel._log(
                     "Batch computation too slow (%.4fs.) "
                     "Setting batch_size=%d.", (batch_duration, batch_size))
         else:

--- a/joblib/format_stack.py
+++ b/joblib/format_stack.py
@@ -29,6 +29,8 @@ import time
 import tokenize
 import traceback
 
+from . import logger
+
 try:                           # Python 2
     generate_tokens = tokenize.generate_tokens
 except AttributeError:         # Python 3
@@ -212,7 +214,7 @@ def format_records(records):   # , print_globals=False):
                 # inspect messes up resolving the argument list of view()
                 # and barfs out. At some point I should dig into this one
                 # and file a bug report about it.
-                print("\nJoblib's exception reporting continues...\n")
+                logger.log("\nJoblib's exception reporting continues...\n")
                 call = 'in %s(***failed resolving arguments***)' % func
 
         # Initialize a list of names on the current line, which the
@@ -277,7 +279,7 @@ def format_records(records):   # , print_globals=False):
             _m = ("An unexpected error occurred while tokenizing input file %s\n"
                   "The following traceback may be corrupted or invalid\n"
                   "The error message is: %s\n" % (file, msg))
-            print(_m)
+            logger.log(_m)
 
         # prune names list of duplicates, but keep the right order
         unique_names = uniq_stable(names)

--- a/joblib/logger.py
+++ b/joblib/logger.py
@@ -14,10 +14,16 @@ import time
 import sys
 import os
 import shutil
-import logging
 import pprint
 
 from .disk import mkdirp
+
+
+def log(message, file=None):
+    # Late default settings to play nice with doctests
+    if file is None:
+        file = sys.stdout
+    print(message, file=file)
 
 
 def _squeeze_time(t):
@@ -73,18 +79,13 @@ class Logger(object):
         """
         self.depth = depth
 
-    def warn(self, msg):
-        logging.warn("[%s]: %s" % (self, msg))
-
-    def debug(self, msg):
-        # XXX: This conflicts with the debug flag used in children class
-        logging.debug("[%s]: %s" % (self, msg))
-
     def format(self, obj, indent=0):
         """ Return the formated representation of the object.
         """
         return pformat(obj, indent=indent, depth=self.depth)
 
+    def warn(self, msg):
+        log("WARNING [%s]: %s" % (self, msg))
 
 ###############################################################################
 # class `PrintTime`
@@ -142,11 +143,11 @@ class PrintTime(object):
             time_lapse = time.time() - self.start_time
             full_msg = "%s: %.2fs, %.1f min" % (msg, time_lapse,
                                                 time_lapse / 60)
-        print(full_msg, file=sys.stderr)
+        log(full_msg, file=sys.stderr)
         if self.logfile is not None:
             try:
                 with open(self.logfile, 'a') as f:
-                    print(full_msg, file=f)
+                    log(full_msg, file=f)
             except:
                 """ Multiprocessing writing to files can create race
                     conditions. Rather fail silently than crash the

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -62,6 +62,8 @@ from .numpy_pickle import load
 from .numpy_pickle import dump
 from .hashing import hash
 from .backports import make_memmap
+from . import logger
+
 # Some system have a ramdisk mounted by default, we can use it instead of /tmp
 # as the default folder to dump big arrays to share with subprocesses
 SYSTEM_SHARED_MEM_FS = '/dev/shm'
@@ -235,8 +237,9 @@ class ArrayMemmapReducer(object):
             # done processing this data.
             if not os.path.exists(filename):
                 if self.verbose > 0:
-                    print("Memmaping (shape=%r, dtype=%s) to new file %s" % (
-                        a.shape, a.dtype, filename))
+                    logger.log(
+                        "Memmaping (shape=%r, dtype=%s) to new file %s" % (
+                            a.shape, a.dtype, filename))
                 for dumped_filename in dump(a, filename):
                     os.chmod(dumped_filename, FILE_PERMISSIONS)
 
@@ -245,7 +248,7 @@ class ArrayMemmapReducer(object):
                     # multiple children processes
                     load(filename, mmap_mode=self._mmap_mode).max()
             elif self.verbose > 1:
-                print("Memmaping (shape=%s, dtype=%s) to old file %s" % (
+                logger.log("Memmaping (shape=%s, dtype=%s) to old file %s" % (
                     a.shape, a.dtype, filename))
 
             # The worker process will use joblib.load to memmap the data
@@ -254,7 +257,7 @@ class ArrayMemmapReducer(object):
             # do not convert a into memmap, let pickler do its usual copy with
             # the default system pickler
             if self.verbose > 1:
-                print("Pickling array (shape=%r, dtype=%s)." % (
+                logger.log("Pickling array (shape=%r, dtype=%s)." % (
                     a.shape, a.dtype))
             return (loads, (dumps(a, protocol=HIGHEST_PROTOCOL),))
 

--- a/joblib/test/common.py
+++ b/joblib/test/common.py
@@ -10,7 +10,7 @@ import gc
 
 from joblib._multiprocessing_helpers import mp
 from joblib.testing import SkipTest, skipif
-
+from joblib import logger
 
 # A decorator to run tests only when numpy is available
 try:
@@ -77,12 +77,12 @@ def setup_autokill(module_name, timeout=30):
 
     def autokill():
         pid = os.getpid()
-        print("Timeout exceeded: terminating stalled process: %d" % pid)
+        logger.log("Timeout exceeded: terminating stalled process: %d" % pid)
         os.kill(pid, signal.SIGTERM)
 
         # If were are still there ask the OS to kill ourself for real
         time.sleep(0.5)
-        print("Timeout exceeded: killing stalled process: %d" % pid)
+        logger.log("Timeout exceeded: killing stalled process: %d" % pid)
         os.kill(pid, signal.SIGKILL)
 
     _KILLER_THREADS[module_name] = t = threading.Timer(timeout, autokill)


### PR DESCRIPTION
This way it can be overriden globally via monkey patching.

The use case I am facing would be to replace printing to stdout by writing to a log file.