### PR TITLE
[MRG] Use commit range for diff in flake8_diff.sh

### DIFF
--- a/continuous_integration/flake8_diff.sh
+++ b/continuous_integration/flake8_diff.sh
@@ -60,8 +60,6 @@ if [[ "$TRAVIS" == "true" ]]; then
             COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
         fi
     else
-        # We need to unshallow here too ...
-        git fetch --unshallow || echo "Unshallowing the git checkout failed"
         # We want to fetch the code as it is in the PR branch and not
         # the result of the merge into master. This way line numbers
         # reported by Travis will match with the local code.


### PR DESCRIPTION
instead of finding the common ancestor with git merge-base. As per the
git diff documentation:
"git diff A...B" is equivalent to "git diff $(git-merge-base A B) B"