### PR TITLE
Remove py26 bis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ master
 
 Alexandre Abadie
 
+    Remove support for python 2.6
+
+Alexandre Abadie
+
     Remove deprecated `format_signature`, `format_call` and `load_output`
     functions from Memory API.
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ from any directory or
 from the source directory.
 
 Joblib has no other mandatory dependency than Python (supported
-versions are 2.6+ and 3.3+). Numpy (at least version 1.6.1) is an
+versions are 2.7+ and 3.3+). Numpy (at least version 1.6.1) is an
 optional dependency for array manipulation.
 
 Workflow to contribute

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -279,7 +279,7 @@ class CustomizablePickler(Pickler):
     """
 
     # We override the pure Python pickler as its the only way to be able to
-    # customize the dispatch table without side effects in Python 2.6
+    # customize the dispatch table without side effects in Python 2.7
     # to 3.2. For Python 3.3+ leverage the new dispatch_table
     # feature from http://bugs.python.org/issue14166 that makes it possible
     # to use the C implementation of the Pickler which is faster.

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -43,12 +43,7 @@ except AttributeError:
             raise AssertionError("Should have raised %r" %
                                  expected_exception(expected_regexp))
 
-try:
-    SkipTest = unittest.case.SkipTest
-except AttributeError:
-    # Python <= 2.6, we still need nose here
-    SkipTest = nose.SkipTest
-
+SkipTest = unittest.case.SkipTest
 with_setup = nose.tools.with_setup
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ Lightweight pipelining: using Python functions as pipeline jobs.
               'Intended Audience :: Education',
               'License :: OSI Approved :: BSD License',
               'Operating System :: OS Independent',
-              'Programming Language :: Python :: 2.6',
               'Programming Language :: Python :: 2.7',
               'Programming Language :: Python :: 3',
               'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
follow up of #437.

For the record, there were remaining occurrences of python 2.6:
```
README.rst:versions are 2.6+ and 3.3+). Numpy (at least version 1.6.1) is an
joblib/func_inspect.py:    once we drop support for Python 2.6. We went for a simpler
joblib/func_inspect.py:    which is not available in Python 2.6.
joblib/numpy_pickle_utils.py:    Required as e.g. ZipExtFile in python 2.6 can return less data than
joblib/pool.py:    # customize the dispatch table without side effects in Python 2.6
joblib/testing.py:    # Python <= 2.6, we still need nose here
setup.py:              'Programming Language :: Python :: 2.6',
```

2 side notes:
* the `func_inspect.py` change should deserve a dedicated PR (see [comment](https://github.com/joblib/joblib/pull/437#issuecomment-264476963) )
* the `numpy_pickle_utils.py` remaining reference is because this function is coming from numpy. I'm not sure if I should change it as well.