### PR TITLE
[MRG] Remove nose dependency completely from project.

### DIFF
--- a/appveyor/requirements.txt
+++ b/appveyor/requirements.txt
@@ -2,6 +2,5 @@
 # force numpy version to use the wheel hosted on rackspace instead of
 # tarball from PyPI
 numpy==1.9.2
-nose
 wheel
 pytest

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -12,7 +12,7 @@ set -e
 
 print_conda_requirements() {
     # Echo a conda requirement string for example
-    # "pip python='2.7.3 scikit-learn=*". It has a hardcoded
+    # "pip python=2.7.3 scikit-learn=*". It has a hardcoded
     # list of possible packages to install and looks at _VERSION
     # environment variables to know whether to install a given package and
     # if yes which version to install. For example:

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -12,13 +12,13 @@ set -e
 
 print_conda_requirements() {
     # Echo a conda requirement string for example
-    # "pip nose python='.7.3 scikit-learn=*". It has a hardcoded
+    # "pip python='.7.3 scikit-learn=*". It has a hardcoded
     # list of possible packages to install and looks at _VERSION
     # environment variables to know whether to install a given package and
     # if yes which version to install. For example:
     #   - for numpy, NUMPY_VERSION is used
     #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
-    TO_INSTALL_ALWAYS="pip nose pytest"
+    TO_INSTALL_ALWAYS="pip pytest"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
     TO_INSTALL_MAYBE="python numpy flake8"
     for PACKAGE in $TO_INSTALL_MAYBE; do

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -12,7 +12,7 @@ set -e
 
 print_conda_requirements() {
     # Echo a conda requirement string for example
-    # "pip python='.7.3 scikit-learn=*". It has a hardcoded
+    # "pip python='2.7.3 scikit-learn=*". It has a hardcoded
     # list of possible packages to install and looks at _VERSION
     # environment variables to know whether to install a given package and
     # if yes which version to install. For example:

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -117,7 +117,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
 def setup(app, get_doc_object_=get_doc_object):
     if not hasattr(app, 'add_config_value'):
-        return # probably called by nose, better bail out
+        return  # probably called by nose, better bail out
 
     global get_doc_object
     get_doc_object = get_doc_object_

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -117,7 +117,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
 def setup(app, get_doc_object_=get_doc_object):
     if not hasattr(app, 'add_config_value'):
-        return
+        return # probably called by nose, better bail out
 
     global get_doc_object
     get_doc_object = get_doc_object_

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -117,7 +117,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
 def setup(app, get_doc_object_=get_doc_object):
     if not hasattr(app, 'add_config_value'):
-        return  # probably called by nose, better bail out
+        return
 
     global get_doc_object
     get_doc_object = get_doc_object_

--- a/joblib/test/common.py
+++ b/joblib/test/common.py
@@ -9,7 +9,7 @@ import sys
 import gc
 
 from joblib._multiprocessing_helpers import mp
-from joblib.testing import SkipTest, with_setup
+from joblib.testing import SkipTest, skipif
 
 
 # A decorator to run tests only when numpy is available
@@ -94,17 +94,9 @@ def teardown_autokill(module_name):
         killer.cancel()
 
 
-def check_multiprocessing():
-    if mp is None:
-        raise SkipTest('Need multiprocessing to run')
+with_multiprocessing = skipif(
+    mp is None, reason='Needs multiprocessing to run.')
 
-
-with_multiprocessing = with_setup(check_multiprocessing)
-
-
-def setup_if_has_dev_shm():
-    if not os.path.exists('/dev/shm'):
-        raise SkipTest("This test requires the /dev/shm shared memory fs.")
-
-
-with_dev_shm = with_setup(setup_if_has_dev_shm)
+with_dev_shm = skipif(
+    not os.path.exists('/dev/shm'),
+    reason='This test requires the /dev/shm shared memory fs.')

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -72,8 +72,8 @@ class Klass(object):
 
 class KlassWithCachedMethod(object):
 
-    def __init__(self, tmpdir_path):
-        mem = Memory(cachedir=tmpdir_path)
+    def __init__(self, cachedir):
+        mem = Memory(cachedir=cachedir)
         self.f = mem.cache(self.f)
 
     def f(self, x):

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -10,7 +10,6 @@ import subprocess
 import threading
 import unittest
 
-import nose
 import pytest
 import _pytest
 
@@ -46,7 +45,6 @@ except AttributeError:
 
 SkipTest = _pytest.runner.Skipped
 skipif = pytest.mark.skipif
-with_setup = nose.tools.with_setup
 fixture = pytest.fixture
 
 


### PR DESCRIPTION
#### Checkpoint PR on #411 ( Succeeds PR #433 )

With this PR **joblib** finally drops `nose` as its own dependency.

```shell
kd@dragonstone:~/Documents/joblib$ git grep nose
CHANGES.rst:    py.test is used to run the tests instead of nosetests.
CHANGES.rst:    ``python setup.py test`` or ``python setup.py nosetests`` do not work
```

- [x] Replaced `with_setup` mechanism of `nosetests` with equivalent `skipif` markers of pytest.
- [x] I removed the examples of nose in some block comments too. (It is a small nitpick though let me know if I should rollback / modify it.)

_NOTE_: I have changed the mechanism of conditional setup of tests (based on availability of multiprocessing / shared memory) in **test_hashing.py** - that is, through a fixture mechanism. It is the "pytest design technique" and although one needs to specify same argument (as I have specified `tmpdir_path`) to many tests, looking at a specific method signature one can easily know that this test "requires" something prior its execution...

* Similar thing can be exercised in other modules, but for this PR only the bare minimum changes needed to drop nose are included.

#### Further Roadmap: 

* Following this PR would be a few more, where each test module will be dealt with - `yield` based methods will be parametrized and overall revamping would be performed one by one to migrate from nose and adopt pytest's flavor.