### PR TITLE
[MRG] Refactor test_func_inspect.py as per pytest design.

### DIFF
--- a/joblib/test/common.py
+++ b/joblib/test/common.py
@@ -15,11 +15,21 @@ from joblib.testing import SkipTest, skipif
 # A decorator to run tests only when numpy is available
 try:
     import numpy as np
+
+    def with_numpy(func):
+        """A decorator to skip tests requiring numpy."""
+        return func
+
 except ImportError:
+    def with_numpy(func):
+        """A decorator to skip tests requiring numpy."""
+        def my_func():
+            raise SkipTest('Test requires numpy')
+        return my_func
     np = None
 
-with_numpy = skipif(not np, reason='Test requires numpy.')
-
+# TODO: Turn this back on after refactoring yield based tests in test_hashing
+# with_numpy = skipif(not np, reason='Test requires numpy.')
 
 # we use memory_profiler library for memory consumption checks
 try:

--- a/joblib/test/common.py
+++ b/joblib/test/common.py
@@ -15,18 +15,10 @@ from joblib.testing import SkipTest, skipif
 # A decorator to run tests only when numpy is available
 try:
     import numpy as np
-
-    def with_numpy(func):
-        """A decorator to skip tests requiring numpy."""
-        return func
-
 except ImportError:
-    def with_numpy(func):
-        """A decorator to skip tests requiring numpy."""
-        def my_func():
-            raise SkipTest('Test requires numpy')
-        return my_func
     np = None
+
+with_numpy = skipif(not np, reason='Test requires numpy.')
 
 
 # we use memory_profiler library for memory consumption checks

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -200,14 +200,13 @@ def test_clean_win_chars():
         assert char not in mangled_string
 
 
-def test_format_signature(funcs):
+@parametrize(['funcname', 'args', 'kwargs', 'sgn_expected'],
+             [('g', [list(range(5))], dict(), 'g([0, 1, 2, 3, 4])'),
+              ('k', [1, 2, (3, 4)], {'y': True}, 'k(1, 2, (3, 4), y=True)')])
+def test_format_signature(funcs, funcname, args, kwargs, sgn_expected):
     # Test signature formatting.
-    path, sgn = format_signature(funcs['g'], list(range(10)))
-    assert sgn == 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])'
-    path, sgn = format_signature(funcs['g'], list(range(10)),
-                                 y=list(range(10)))
-    assert sgn == 'g([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],' \
-                  ' y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])'
+    path, sgn_result = format_signature(funcs[funcname], *args, **kwargs)
+    assert sgn_result == sgn_expected
 
 
 @with_numpy

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -12,7 +12,7 @@ from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import (fixture, parametrize, pytest_assert_raises)
+from joblib.testing import fixture, parametrize, pytest_assert_raises
 from joblib._compat import PY3_OR_LATER
 
 
@@ -44,10 +44,6 @@ def k(*args, **kwargs):
 
 @fixture(scope='module')
 def f2(tmpdir_factory):
-    """
-    This fixture returns a dict of functions which are used as test cases
-    by tests written in this module.
-    """
     # Create a Memory object to test decorated functions.
     # We should be careful not to call the decorated functions, so that
     # cache directories are not created in the temp dir.
@@ -75,11 +71,11 @@ class Klass(object):
              [(f, [[], (1, )], {'x': 1, 'y': 0}),
               (f, [['x'], (1, )], {'y': 0}),
               (f, [['y'], (0, )], {'x': 0}),
-              (f, [['y'], (0, ), dict(y=1)], {'x': 0}),
+              (f, [['y'], (0, ), {'y': 1}], {'x': 0}),
               (f, [['x', 'y'], (0, )], {}),
-              (f, [[], (0,), dict(y=1)], {'x': 0, 'y': 1}),
-              (f, [['y'], (), dict(x=2, y=1)], {'x': 2}),
-              (g, [[], (), dict(x=1)], {'x': 1}),
+              (f, [[], (0,), {'y': 1}], {'x': 0, 'y': 1}),
+              (f, [['y'], (), {'x': 2, 'y': 1}], {'x': 2}),
+              (g, [[], (), {'x': 1}], {'x': 1}),
               (i, [[], (2, )], {'x': 2})])
 def test_filter_args(func, args, filtered_args):
     assert filter_args(func, *args) == filtered_args
@@ -95,16 +91,16 @@ def test_filter_args_method():
                {'x': 1, 'y': 0, '*': [], '**': {}}),
               (h, [[], (1, 2, 3, 4)],
                {'x': 1, 'y': 2, '*': [3, 4], '**': {}}),
-              (h, [[], (1, 25), dict(ee=2)],
+              (h, [[], (1, 25), {'ee': 2}],
                {'x': 1, 'y': 25, '*': [], '**': {'ee': 2}}),
-              (h, [['*'], (1, 2, 25), dict(ee=2)],
+              (h, [['*'], (1, 2, 25), {'ee': 2}],
                {'x': 1, 'y': 2, '**': {'ee': 2}})])
 def test_filter_varargs(func, args, filtered_args):
     assert filter_args(func, *args) == filtered_args
 
 
 @parametrize(['func', 'args', 'filtered_args'],
-             [(k, [[], (1, 2), dict(ee=2)],
+             [(k, [[], (1, 2), {'ee': 2}],
                {'*': [1, 2], '**': {'ee': 2}}),
               (k, [[], (3, 4)],
                {'*': [3, 4], '**': {}})])
@@ -113,7 +109,7 @@ def test_filter_kwargs(func, args, filtered_args):
 
 
 def test_filter_args_2():
-    assert (filter_args(j, [], (1, 2), dict(ee=2)) ==
+    assert (filter_args(j, [], (1, 2), {'ee': 2}) ==
             {'x': 1, 'y': 2, '**': {'ee': 2}})
 
     ff = functools.partial(f, 1)
@@ -218,7 +214,7 @@ def test_clean_win_chars():
 
 
 @parametrize(['func', 'args', 'kwargs', 'sgn_expected'],
-             [(g, [list(range(5))], dict(), 'g([0, 1, 2, 3, 4])'),
+             [(g, [list(range(5))], {}, 'g([0, 1, 2, 3, 4])'),
               (k, [1, 2, (3, 4)], {'y': True}, 'k(1, 2, (3, 4), y=True)')])
 def test_format_signature(func, args, kwargs, sgn_expected):
     # Test signature formatting.

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -197,9 +197,8 @@ def test_bound_methods():
                h, [[]])
               ])
 def test_filter_args_error_msg(exception, regex, func, args):
-    """
-    Make sure that filter_args returns decent error messages, for the sake
-    of the user.
+    """ Make sure that filter_args returns decent error messages, for the
+        sake of the user.
     """
     with pytest_assert_raises(exception) as excinfo:
         filter_args(func, *args)

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -43,7 +43,7 @@ def k(*args, **kwargs):
 
 
 @fixture(scope='module')
-def f2(tmpdir_factory):
+def cached_func(tmpdir_factory):
     # Create a Memory object to test decorated functions.
     # We should be careful not to call the decorated functions, so that
     # cache directories are not created in the temp dir.
@@ -51,10 +51,10 @@ def f2(tmpdir_factory):
     mem = Memory(cachedir.strpath)
 
     @mem.cache
-    def f2_inner(x):
+    def cached_func_inner(x):
         return x
 
-    return f2_inner
+    return cached_func_inner
 
 
 class Klass(object):
@@ -118,17 +118,19 @@ def test_filter_args_2():
     assert filter_args(ff, ['y'], (1, )) == {'*': [1], '**': {}}
 
 
-@parametrize(['func', 'funcname'], [(f, 'f'), (g, 'g'), (f2, 'f2')])
+@parametrize(['func', 'funcname'], [(f, 'f'), (g, 'g'),
+                                    (cached_func, 'cached_func')])
 def test_func_name(func, funcname):
     # Check that we are not confused by decoration
-    # here testcase 'f2' is the function itself
+    # here testcase 'cached_func' is the function itself
     assert get_func_name(func)[1] == funcname
 
 
-def test_func_name_on_inner_func(f2):
+def test_func_name_on_inner_func(cached_func):
     # Check that we are not confused by decoration
-    # here testcase 'f2' is the 'f2_inner' function returned by 'f2' fixture
-    assert get_func_name(f2)[1] == 'f2_inner'
+    # here testcase 'cached_func' is the 'cached_func_inner' function
+    # returned by 'cached_func' fixture
+    assert get_func_name(cached_func)[1] == 'cached_func_inner'
 
 
 def test_func_inspect_errors():

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -122,9 +122,17 @@ def test_filter_args_2():
     assert filter_args(ff, ['y'], (1, )) == {'*': [1], '**': {}}
 
 
-# @parametrize(['func', 'funcname'], [f, g, f2], ['f', 'g', 'f2'])
-# def test_func_name(func, funcname):
-#     assert get_func_name(func)[1] == funcname
+@parametrize(['func', 'funcname'], [(f, 'f'), (g, 'g'), (f2, 'f2')])
+def test_func_name(func, funcname):
+    # Check that we are not confused by decoration
+    # here testcase 'f2' is the function itself
+    assert get_func_name(func)[1] == funcname
+
+
+def test_func_name_on_inner_func(f2):
+    # Check that we are not confused by decoration
+    # here testcase 'f2' is the 'f2_inner' function returned by 'f2' fixture
+    assert get_func_name(f2)[1] == 'f2_inner'
 
 
 def test_func_inspect_errors():

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -12,7 +12,7 @@ from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import (fixture, parametrize, assert_raises_regex)
+from joblib.testing import (fixture, parametrize, pytest_assert_raises)
 from joblib._compat import PY3_OR_LATER
 
 
@@ -154,11 +154,10 @@ def func_with_signature(a: int, b: int) -> None: pass
 
         # filter_args doesn't care about keyword-only arguments so you
         # can pass 'kw1' into *args without any problem
-        assert_raises_regex(
-            ValueError,
-            "Keyword-only parameter 'kw1' was passed as positional parameter",
-            filter_args,
-            func_with_kwonly_args, [], (1, 2, 3), {'kw2': 2})
+        with pytest_assert_raises(ValueError) as excinfo:
+            filter_args(func_with_kwonly_args, [], (1, 2, 3), {'kw2': 2})
+        excinfo.match("Keyword-only parameter 'kw1' was passed as positional "
+                      "parameter")
 
         assert (
             filter_args(func_with_kwonly_args, ['b', 'kw2'], (1, 2),
@@ -190,7 +189,9 @@ def test_filter_args_error_msg(funcs, exception, regex, funcname, args):
     Make sure that filter_args returns decent error messages, for the sake
     of the user.
     """
-    assert_raises_regex(exception, regex, filter_args, funcs[funcname], *args)
+    with pytest_assert_raises(exception) as excinfo:
+        filter_args(funcs[funcname], *args)
+    excinfo.match(regex)
 
 
 def test_clean_win_chars():

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -126,18 +126,18 @@ def test_hash_numpy():
     arr3 = arr2.copy()
     arr3[0] += 1
     obj_list = (arr1, arr2, arr3)
-    # for obj1 in obj_list:
-    #     for obj2 in obj_list:
-    #         yield assert_equal, hash(obj1) == hash(obj2), np.all(obj1 == obj2)
-    #
-    # d1 = {1: arr1, 2: arr1}
-    # d2 = {1: arr2, 2: arr2}
-    # yield assert_equal, hash(d1), hash(d2)
-    #
-    # d3 = {1: arr2, 2: arr3}
-    # yield assert_not_equal, hash(d1), hash(d3)
-    #
-    # yield assert_not_equal, hash(arr1), hash(arr1.T)
+    for obj1 in obj_list:
+        for obj2 in obj_list:
+            yield assert_equal, hash(obj1) == hash(obj2), np.all(obj1 == obj2)
+
+    d1 = {1: arr1, 2: arr1}
+    d2 = {1: arr2, 2: arr2}
+    yield assert_equal, hash(d1), hash(d2)
+
+    d3 = {1: arr2, 2: arr3}
+    yield assert_not_equal, hash(d1), hash(d3)
+
+    yield assert_not_equal, hash(arr1), hash(arr1.T)
 
 
 @with_numpy

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -126,18 +126,18 @@ def test_hash_numpy():
     arr3 = arr2.copy()
     arr3[0] += 1
     obj_list = (arr1, arr2, arr3)
-    for obj1 in obj_list:
-        for obj2 in obj_list:
-            yield assert_equal, hash(obj1) == hash(obj2), np.all(obj1 == obj2)
-
-    d1 = {1: arr1, 2: arr1}
-    d2 = {1: arr2, 2: arr2}
-    yield assert_equal, hash(d1), hash(d2)
-
-    d3 = {1: arr2, 2: arr3}
-    yield assert_not_equal, hash(d1), hash(d3)
-
-    yield assert_not_equal, hash(arr1), hash(arr1.T)
+    # for obj1 in obj_list:
+    #     for obj2 in obj_list:
+    #         yield assert_equal, hash(obj1) == hash(obj2), np.all(obj1 == obj2)
+    #
+    # d1 = {1: arr1, 2: arr1}
+    # d2 = {1: arr2, 2: arr2}
+    # yield assert_equal, hash(d1), hash(d2)
+    #
+    # d3 = {1: arr2, 2: arr3}
+    # yield assert_not_equal, hash(d1), hash(d3)
+    #
+    # yield assert_not_equal, hash(arr1), hash(arr1.T)
 
 
 @with_numpy


### PR DESCRIPTION
#### Third Phase PR on #411 (Succeeding PR #446)

This PR deals with refactor of tests in **test_func_inspect.py** to adopt the pytest flavor.

* Prior to this PR, each method had several `yield` based statements where the test cases comprised of a set of functions with args and kwargs as well. I have proposed a `fixture` which returns a dictionary of functions to make `parametrization` easier.

* `with_numpy` decorator is now a `pytest.skipif` marker [Commented for now, will be uncommented after **test_hashing.py** is pytestified. Because this skipif marker does not work well with `yield` based tests.]

* The function names `g` and `f2` have been interchanged. Earlier `g` was decorated with `@mem.cache` earlier, and it was the only one function. All other functions - `f`, `f2`, `h`, `i`, `j`, `k` were normal undecorated ones. This name interchanging is simply a cosmetic change.