### PR TITLE
[MRG] Refactor test_logger.py as per pytest design.

### DIFF
--- a/joblib/test/test_logger.py
+++ b/joblib/test/test_logger.py
@@ -6,11 +6,8 @@ Test the logger module.
 # Copyright (c) 2009 Gael Varoquaux
 # License: BSD Style, 3 clauses.
 
-import shutil
-import os
 import sys
 import io
-from tempfile import mkdtemp
 import re
 
 from joblib.logger import PrintTime
@@ -21,41 +18,20 @@ try:
 except NameError:
     unicode = lambda s: s
 
-###############################################################################
-# Test fixtures
-env = dict()
 
-
-def setup():
-    """ Test setup.
-    """
-    cachedir = mkdtemp()
-    if os.path.exists(cachedir):
-        shutil.rmtree(cachedir)
-    env['dir'] = cachedir
-
-
-def teardown():
-    """ Test teardown.
-    """
-    #return True
-    shutil.rmtree(env['dir'])
-
-
-###############################################################################
-# Tests
-def test_print_time():
+def test_print_time(tmpdir):
     # A simple smoke test for PrintTime.
+    logfile = tmpdir.join('test.log').strpath
     try:
         orig_stderr = sys.stderr
         sys.stderr = io.StringIO()
-        print_time = PrintTime(logfile=os.path.join(env['dir'], 'test.log'))
+        print_time = PrintTime(logfile=logfile)
         print_time(unicode('Foo'))
         # Create a second time, to smoke test log rotation.
-        print_time = PrintTime(logfile=os.path.join(env['dir'], 'test.log'))
+        print_time = PrintTime(logfile=logfile)
         print_time(unicode('Foo'))
         # And a third time
-        print_time = PrintTime(logfile=os.path.join(env['dir'], 'test.log'))
+        print_time = PrintTime(logfile=logfile)
         print_time(unicode('Foo'))
         printed_text = sys.stderr.getvalue()
         # Use regexps to be robust to time variations


### PR DESCRIPTION
#### Third Phase PR on #411 (Succeeding PR #450)

This PR deals with refactor of tests in **test_logger.py** to adopt the pytest flavor.

There is one only test method, which used a temporary file to log output. The setup and teardown for the same, using `tempfile` module has been removed, and instead, pytest's own `tmpdir` fixture is specified as function parameter.

Instead of raising an AssertionError based on condition, direct usage of `assert` keyword is used.