### PR TITLE
[MRG] Refactor test_hashing.py as per pytest design.

### DIFF
--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -76,7 +76,7 @@ class KlassWithCachedMethod(object):
 ###############################################################################
 # Tests
 
-@parametrize(['obj1', 'obj2'], list(itertools.product(
+@parametrize('obj1, obj2', list(itertools.product(
     [1, 2, 1., 2., 1 + 1j, 2. + 1j,
      'a', 'b',
      (1,), (1, 1,), [1, ], [1, 1, ],
@@ -344,7 +344,7 @@ def test_dtype():
     assert hash([a, c]) == hash([a, b])
 
 
-@parametrize(['to_hash', 'expected'],
+@parametrize('to_hash, expected',
              [('This is a string to hash',
                  {'py2': '80436ada343b0d79a99bfd8883a96e45',
                   'py3': '71b3f47df22cb19431d85d92d0b230b2'}),

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -93,8 +93,8 @@ class KlassWithCachedMethod(object):
 def test_trival_hash(obj1, obj2):
     """Smoke test hash on various types."""
     # Check that 2 objects have the same hash only if they are the same.
-    is_hash_equal = (hash(obj1) == hash(obj2))
-    assert is_hash_equal == (obj1 is obj2)
+    is_hash_equal = hash(obj1) == hash(obj2)
+    assert is_hash_equal == obj1 is obj2
 
 
 def test_hash_methods():

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -115,28 +115,42 @@ def test_hash_methods():
     assert hash(a1.extend) != hash(a2.extend)
 
 
+@fixture(scope='function')
 @with_numpy
-def test_hash_numpy():
-    """ Test hashing with numpy arrays.
+def three_np_arrays():
+    """
+    Returns three numpy arrays where first two are same and third is a bit
+    different. These arrays will be used by few tests below.
     """
     rnd = np.random.RandomState(0)
     arr1 = rnd.random_sample((10, 10))
     arr2 = arr1.copy()
     arr3 = arr2.copy()
     arr3[0] += 1
-    obj_list = (arr1, arr2, arr3)
-    for obj1 in obj_list:
-        for obj2 in obj_list:
-            yield assert_equal, hash(obj1) == hash(obj2), np.all(obj1 == obj2)
+    return arr1, arr2, arr3
 
-    d1 = {1: arr1, 2: arr1}
-    d2 = {1: arr2, 2: arr2}
-    yield assert_equal, hash(d1), hash(d2)
 
+def test_hash_numpy_arrays(three_np_arrays):
+    """Test hashing with numpy arrays."""
+    arr1, arr2, arr3 = three_np_arrays
+
+    # Only same arrays will have same hash
+    assert hash(arr1) == hash(arr2)
+    assert hash(arr1) != hash(arr3)
+    assert hash(arr1) != hash(arr1.T)
+
+
+def test_hash_numpy_dict_of_arrays(three_np_arrays):
+    """Test hashing with dicts made of numpy arrays."""
+    arr1, arr2, arr3 = three_np_arrays
+
+    d1 = {1: arr1, 2: arr2}
+    d2 = {1: arr2, 2: arr1}
     d3 = {1: arr2, 2: arr3}
-    yield assert_not_equal, hash(d1), hash(d3)
 
-    yield assert_not_equal, hash(arr1), hash(arr1.T)
+    # Two dicts will have same hash if they have exact same key value pairs
+    assert hash(d1) == hash(d2)
+    assert hash(d1) != hash(d3)
 
 
 @with_numpy

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -20,7 +20,7 @@ import time
 from joblib.hashing import hash
 from joblib.func_inspect import filter_args
 from joblib.memory import Memory
-from joblib.testing import assert_raises_regex, skipif, fixture, parametrize
+from joblib.testing import pytest_assert_raises, skipif, fixture, parametrize
 from joblib.test.common import np, with_numpy
 from joblib.my_exceptions import TransportableException
 from joblib._compat import PY3_OR_LATER
@@ -465,6 +465,6 @@ def test_hashing_pickling_error():
     def non_picklable():
         return 42
 
-    assert_raises_regex(pickle.PicklingError,
-                        'PicklingError while hashing',
-                        hash, non_picklable)
+    with pytest_assert_raises(pickle.PicklingError) as excinfo:
+        hash(non_picklable)
+    excinfo.match('PicklingError while hashing')

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -76,20 +76,23 @@ class KlassWithCachedMethod(object):
 ###############################################################################
 # Tests
 
-@parametrize('obj1, obj2', list(itertools.product(
-    [1, 2, 1., 2., 1 + 1j, 2. + 1j,
-     'a', 'b',
-     (1,), (1, 1,), [1, ], [1, 1, ],
-     {1: 1}, {1: 2}, {2: 1},
-     None,
-     gc.collect,
-     [1, ].append,
-     # Next 2 sets have unorderable elements in python 3.
-     set(('a', 1)),
-     set(('a', 1, ('a', 1))),
-     # Next 2 dicts have unorderable type of keys in python 3.
-     {'a': 1, 1: 2},
-     {'a': 1, 1: 2, 'd': {'a': 1}}], repeat=2)))
+input_list = [1, 2, 1., 2., 1 + 1j, 2. + 1j,
+              'a', 'b',
+              (1,), (1, 1,), [1, ], [1, 1, ],
+              {1: 1}, {1: 2}, {2: 1},
+              None,
+              gc.collect,
+              [1, ].append,
+              # Next 2 sets have unorderable elements in python 3.
+              set(('a', 1)),
+              set(('a', 1, ('a', 1))),
+              # Next 2 dicts have unorderable type of keys in python 3.
+              {'a': 1, 1: 2},
+              {'a': 1, 1: 2, 'd': {'a': 1}}]
+
+
+@parametrize('obj1', input_list)
+@parametrize('obj2', input_list)
 def test_trivial_hash(obj1, obj2):
     """Smoke test hash on various types."""
     # Check that 2 objects have the same hash only if they are the same.
@@ -441,8 +444,7 @@ def test_hashes_stay_the_same_with_numpy_objects():
     expected_list = expected_dict[py_version_str]
 
     for to_hash, expected in zip(to_hash_list, expected_list):
-        py_version_str = 'py3' if PY3_OR_LATER else 'py2'
-        assert hash(to_hash) == expected[py_version_str]
+        assert hash(to_hash) == expected
 
 
 def test_hashing_pickling_error():

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -351,40 +351,39 @@ def test_dtype():
     assert hash([a, c]) == hash([a, b])
 
 
-def test_hashes_stay_the_same():
+@parametrize(['to_hash', 'expected'],
+             [('This is a string to hash',
+                 {'py2': '80436ada343b0d79a99bfd8883a96e45',
+                  'py3': '71b3f47df22cb19431d85d92d0b230b2'}),
+
+              (u"C'est l\xe9t\xe9",
+                 {'py2': '2ff3a25200eb6219f468de2640913c2d',
+                  'py3': '2d8d189e9b2b0b2e384d93c868c0e576'}),
+
+              ((123456, 54321, -98765),
+                 {'py2': '50d81c80af05061ac4dcdc2d5edee6d6',
+                  'py3': 'e205227dd82250871fa25aa0ec690aa3'}),
+
+              ([random.Random(42).random() for _ in range(5)],
+                 {'py2': '1a36a691b2e2ba3a9df72de3dccf17ea',
+                  'py3': 'a11ffad81f9682a7d901e6edc3d16c84'}),
+
+              ([3, 'abc', None, TransportableException('foo', ValueError)],
+                 {'py2': 'adb6ba84990ee5e462dc138383f11802',
+                  'py3': '994f663c64ba5e64b2a85ebe75287829'}),
+
+              ({'abcde': 123, 'sadfas': [-9999, 2, 3]},
+                 {'py2': 'fc9314a39ff75b829498380850447047',
+                  'py3': 'aeda150553d4bb5c69f0e69d51b0e2ef'})])
+def test_hashes_stay_the_same(to_hash, expected):
     # We want to make sure that hashes don't change with joblib
     # version. For end users, that would mean that they have to
     # regenerate their cache from scratch, which potentially means
     # lengthy recomputations.
-    rng = random.Random(42)
-    to_hash_list = ['This is a string to hash',
-                    u"C'est l\xe9t\xe9",
-                    (123456, 54321, -98765),
-                    [rng.random() for _ in range(5)],
-                    [3, 'abc', None,
-                     TransportableException('the message', ValueError)],
-                    {'abcde': 123, 'sadfas': [-9999, 2, 3]}]
-
-    # These expected results have been generated with joblib 0.9.2
-    expected_dict = {
-        'py2': ['80436ada343b0d79a99bfd8883a96e45',
-                '2ff3a25200eb6219f468de2640913c2d',
-                '50d81c80af05061ac4dcdc2d5edee6d6',
-                '536af09b66a087ed18b515acc17dc7fc',
-                '123ffc6f13480767167e171a8e1f6f4a',
-                'fc9314a39ff75b829498380850447047'],
-        'py3': ['71b3f47df22cb19431d85d92d0b230b2',
-                '2d8d189e9b2b0b2e384d93c868c0e576',
-                'e205227dd82250871fa25aa0ec690aa3',
-                '9e4e9bf9b91890c9734a6111a35e6633',
-                '6065a3c48e842ea5dee2cfd0d6820ad6',
-                'aeda150553d4bb5c69f0e69d51b0e2ef']}
+    # Expected results have been generated with joblib 0.9.2
 
     py_version_str = 'py3' if PY3_OR_LATER else 'py2'
-    expected_list = expected_dict[py_version_str]
-
-    for to_hash, expected in zip(to_hash_list, expected_list):
-        yield assert_equal, hash(to_hash), expected
+    assert hash(to_hash) == expected[py_version_str]
 
 
 @with_numpy

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -93,8 +93,9 @@ class KlassWithCachedMethod(object):
 def test_trivial_hash(obj1, obj2):
     """Smoke test hash on various types."""
     # Check that 2 objects have the same hash only if they are the same.
-    is_hash_equal = hash(obj1) == hash(obj2)
-    assert is_hash_equal == obj1 is obj2
+    are_hashes_equal = hash(obj1) == hash(obj2)
+    are_objs_identical = obj1 is obj2
+    assert are_hashes_equal == are_objs_identical
 
 
 def test_hash_methods():
@@ -125,9 +126,9 @@ def test_hash_numpy_arrays(three_np_arrays):
 
     # Only same arrays will have same hash
     for obj1, obj2 in itertools.product(three_np_arrays, repeat=2):
-        is_hash_equal = hash(obj1) == hash(obj2)
-        is_array_equal = np.all(obj1 == obj2)
-        assert is_hash_equal == is_array_equal
+        are_hashes_equal = hash(obj1) == hash(obj2)
+        are_arrays_equal = np.all(obj1 == obj2)
+        assert are_hashes_equal == are_arrays_equal
 
     assert hash(arr1) != hash(arr1.T)
 
@@ -173,9 +174,9 @@ def test_hash_memmap(tmpdir, coerce_mmap):
     try:
         m = np.memmap(filename, shape=(10, 10), mode='w+')
         a = np.asarray(m)
-        is_hash_equal = (hash(a, coerce_mmap=coerce_mmap) ==
-                         hash(m, coerce_mmap=coerce_mmap))
-        assert is_hash_equal == coerce_mmap
+        are_hashes_equal = (hash(a, coerce_mmap=coerce_mmap) ==
+                            hash(m, coerce_mmap=coerce_mmap))
+        assert are_hashes_equal == coerce_mmap
     finally:
         if 'm' in locals():
             del m

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -110,9 +110,6 @@ def test_hash_methods():
 @fixture(scope='function')
 @with_numpy
 def three_np_arrays():
-    """Returns three numpy arrays where first two are same and third is a bit
-       different. These arrays will be used by few tests below.
-    """
     rnd = np.random.RandomState(0)
     arr1 = rnd.random_sample((10, 10))
     arr2 = arr1.copy()
@@ -124,7 +121,6 @@ def three_np_arrays():
 def test_hash_numpy_arrays(three_np_arrays):
     arr1, arr2, arr3 = three_np_arrays
 
-    # Only same arrays will have same hash
     for obj1, obj2 in itertools.product(three_np_arrays, repeat=2):
         are_hashes_equal = hash(obj1) == hash(obj2)
         are_arrays_equal = np.all(obj1 == obj2)
@@ -140,7 +136,6 @@ def test_hash_numpy_dict_of_arrays(three_np_arrays):
     d2 = {1: arr2, 2: arr1}
     d3 = {1: arr2, 2: arr3}
 
-    # Two dicts will have same hash if they have exact same key value pairs
     assert hash(d1) == hash(d2)
     assert hash(d1) != hash(d3)
 
@@ -426,21 +421,24 @@ def test_hashes_stay_the_same_with_numpy_objects():
         np.arange(100, dtype='<i8').reshape((10, 10))[:, :2],
     ]
 
-    # Expected results have been generated with joblib 0.9.0
-    expected_list = [{'py2': '80f2387e7752abbda2658aafed49e086',
-                      'py3': '10a6afc379ca2708acfbaef0ab676eab'},
-                     {'py2': '0d700f7f25ea670fd305e4cd93b0e8cd',
-                      'py3': '988a7114f337f381393025911ebc823b'},
-                     {'py2': '83a2bdf843e79e4b3e26521db73088b9',
-                      'py3': 'c6809f4b97e35f2fa0ee8d653cbd025c'},
-                     {'py2': '63e0efd43c0a9ad92a07e8ce04338dd3',
-                      'py3': 'b3ad17348e32728a7eb9cda1e7ede438'},
-                     {'py2': '03fef702946b602c852b8b4e60929914',
-                      'py3': '927b3e6b0b6a037e8e035bda134e0b05'},
-                     {'py2': '07074691e90d7098a85956367045c81e',
-                      'py3': '108f6ee98e7db19ea2006ffd208f4bf1'},
-                     {'py2': 'd264cf79f353aa7bbfa8349e3df72d8f',
-                      'py3': 'bd48ccaaff28e16e6badee81041b7180'}]
+    # These expected results have been generated with joblib 0.9.0
+    expected_dict = {'py2': ['80f2387e7752abbda2658aafed49e086',
+                             '0d700f7f25ea670fd305e4cd93b0e8cd',
+                             '83a2bdf843e79e4b3e26521db73088b9',
+                             '63e0efd43c0a9ad92a07e8ce04338dd3',
+                             '03fef702946b602c852b8b4e60929914',
+                             '07074691e90d7098a85956367045c81e',
+                             'd264cf79f353aa7bbfa8349e3df72d8f'],
+                     'py3': ['10a6afc379ca2708acfbaef0ab676eab',
+                             '988a7114f337f381393025911ebc823b',
+                             'c6809f4b97e35f2fa0ee8d653cbd025c',
+                             'b3ad17348e32728a7eb9cda1e7ede438',
+                             '927b3e6b0b6a037e8e035bda134e0b05',
+                             '108f6ee98e7db19ea2006ffd208f4bf1',
+                             'bd48ccaaff28e16e6badee81041b7180']}
+
+    py_version_str = 'py3' if PY3_OR_LATER else 'py2'
+    expected_list = expected_dict[py_version_str]
 
     for to_hash, expected in zip(to_hash_list, expected_list):
         py_version_str = 'py3' if PY3_OR_LATER else 'py2'

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -121,7 +121,6 @@ def three_np_arrays():
 
 
 def test_hash_numpy_arrays(three_np_arrays):
-    """Test hashing with numpy arrays."""
     arr1, arr2, arr3 = three_np_arrays
 
     # Only same arrays will have same hash
@@ -134,7 +133,6 @@ def test_hash_numpy_arrays(three_np_arrays):
 
 
 def test_hash_numpy_dict_of_arrays(three_np_arrays):
-    """Test hashing with dicts made of numpy arrays."""
     arr1, arr2, arr3 = three_np_arrays
 
     d1 = {1: arr1, 2: arr2}

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -394,9 +394,12 @@ def test_0d_and_1d_array_hashing_is_different():
     assert hash(np.array(0)) != hash(np.array([0]))
 
 
-@fixture(scope='function')
 @with_numpy
-def to_hash_np_objs(request):
+def test_hashes_stay_the_same_with_numpy_objects():
+    # We want to make sure that hashes don't change with joblib
+    # version. For end users, that would mean that they have to
+    # regenerate their cache from scratch, which potentially means
+    # lengthy recomputations.
     rng = np.random.RandomState(42)
     # Being explicit about dtypes in order to avoid
     # architecture-related differences. Also using 'f4' rather than
@@ -423,33 +426,25 @@ def to_hash_np_objs(request):
         np.arange(100, dtype='<i8').reshape((10, 10))[:, :2],
     ]
 
-    # Return member of list requested by parametrize marker in test below
-    return to_hash_list[request.param]
+    # Expected results have been generated with joblib 0.9.0
+    expected_list = [{'py2': '80f2387e7752abbda2658aafed49e086',
+                      'py3': '10a6afc379ca2708acfbaef0ab676eab'},
+                     {'py2': '0d700f7f25ea670fd305e4cd93b0e8cd',
+                      'py3': '988a7114f337f381393025911ebc823b'},
+                     {'py2': '83a2bdf843e79e4b3e26521db73088b9',
+                      'py3': 'c6809f4b97e35f2fa0ee8d653cbd025c'},
+                     {'py2': '63e0efd43c0a9ad92a07e8ce04338dd3',
+                      'py3': 'b3ad17348e32728a7eb9cda1e7ede438'},
+                     {'py2': '03fef702946b602c852b8b4e60929914',
+                      'py3': '927b3e6b0b6a037e8e035bda134e0b05'},
+                     {'py2': '07074691e90d7098a85956367045c81e',
+                      'py3': '108f6ee98e7db19ea2006ffd208f4bf1'},
+                     {'py2': 'd264cf79f353aa7bbfa8349e3df72d8f',
+                      'py3': 'bd48ccaaff28e16e6badee81041b7180'}]
 
-
-@parametrize(['to_hash_np_objs', 'expected'],
-             # Here only an index is specified for 'to_hash_np_objs'
-             # Corresponding element will be fetched from above fixture
-             # of same name due to 'indirect' keyword used here
-             # Expected results have been generated with joblib 0.9.0
-             [(0, {'py2': '80f2387e7752abbda2658aafed49e086',
-                   'py3': '10a6afc379ca2708acfbaef0ab676eab'}),
-              (1, {'py2': '0d700f7f25ea670fd305e4cd93b0e8cd',
-                   'py3': '988a7114f337f381393025911ebc823b'}),
-              (2, {'py2': '83a2bdf843e79e4b3e26521db73088b9',
-                   'py3': 'c6809f4b97e35f2fa0ee8d653cbd025c'}),
-              (3, {'py2': '63e0efd43c0a9ad92a07e8ce04338dd3',
-                   'py3': 'b3ad17348e32728a7eb9cda1e7ede438'}),
-              (4, {'py2': '03fef702946b602c852b8b4e60929914',
-                   'py3': '927b3e6b0b6a037e8e035bda134e0b05'}),
-              (5, {'py2': '07074691e90d7098a85956367045c81e',
-                   'py3': '108f6ee98e7db19ea2006ffd208f4bf1'}),
-              (6, {'py2': 'd264cf79f353aa7bbfa8349e3df72d8f',
-                   'py3': 'bd48ccaaff28e16e6badee81041b7180'})],
-             indirect=['to_hash_np_objs'])
-def test_hashes_stay_the_same_with_numpy_objects(to_hash_np_objs, expected):
-    py_version_str = 'py3' if PY3_OR_LATER else 'py2'
-    assert hash(to_hash_np_objs) == expected[py_version_str]
+    for to_hash, expected in zip(to_hash_list, expected_list):
+        py_version_str = 'py3' if PY3_OR_LATER else 'py2'
+        assert hash(to_hash) == expected[py_version_str]
 
 
 def test_hashing_pickling_error():

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -20,8 +20,7 @@ import time
 from joblib.hashing import hash
 from joblib.func_inspect import filter_args
 from joblib.memory import Memory
-from joblib.testing import (assert_raises_regex, skipif, fixture,
-                            parametrize)
+from joblib.testing import assert_raises_regex, skipif, fixture, parametrize
 from joblib.test.common import np, with_numpy
 from joblib.my_exceptions import TransportableException
 from joblib._compat import PY3_OR_LATER
@@ -146,15 +145,13 @@ def test_hash_numpy_dict_of_arrays(three_np_arrays):
 
 
 @with_numpy
-def test_numpy_datetime_array():
+@parametrize('dtype', ['datetime64[s]', 'timedelta64[D]'])
+def test_numpy_datetime_array(dtype):
     # memoryview is not supported for some dtypes e.g. datetime64
     # see https://github.com/joblib/joblib/issues/188 for more details
-    dtypes = ['datetime64[s]', 'timedelta64[D]']
-
     a_hash = hash(np.arange(10))
-    arrays = (np.arange(0, 10, dtype=dtype) for dtype in dtypes)
-    for array in arrays:
-        assert hash(array) != a_hash
+    array = np.arange(0, 10, dtype=dtype)
+    assert hash(array) != a_hash
 
 
 @with_numpy

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -90,7 +90,7 @@ class KlassWithCachedMethod(object):
      # Next 2 dicts have unorderable type of keys in python 3.
      {'a': 1, 1: 2},
      {'a': 1, 1: 2, 'd': {'a': 1}}], repeat=2)))
-def test_trival_hash(obj1, obj2):
+def test_trivial_hash(obj1, obj2):
     """Smoke test hash on various types."""
     # Check that 2 objects have the same hash only if they are the same.
     is_hash_equal = hash(obj1) == hash(obj2)

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -20,7 +20,7 @@ import time
 from joblib.hashing import hash
 from joblib.func_inspect import filter_args
 from joblib.memory import Memory
-from joblib.testing import (assert_raises_regex, SkipTest, fixture,
+from joblib.testing import (assert_raises_regex, skipif, fixture,
                             parametrize)
 from joblib.test.common import np, with_numpy
 from joblib.my_exceptions import TransportableException
@@ -188,6 +188,8 @@ def test_hash_memmap(tmpdir, coerce_mmap):
 
 
 @with_numpy
+@skipif(sys.platform == 'win32', reason='This test is not stable under windows'
+                                        ' for some reason')
 def test_hash_numpy_performance():
     """ Check the performance of hashing numpy arrays:
 
@@ -205,10 +207,6 @@ def test_hash_numpy_performance():
         In [26]: %timeit hash(a)
         100 loops, best of 3: 20.8 ms per loop
     """
-    # This test is not stable under windows for some reason, skip it.
-    if sys.platform == 'win32':
-        raise SkipTest()
-
     rnd = np.random.RandomState(0)
     a = rnd.random_sample(1000000)
     if hasattr(np, 'getbuffer'):

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -6,23 +6,25 @@ Test the hashing module.
 # Copyright (c) 2009 Gael Varoquaux
 # License: BSD Style, 3 clauses.
 
-import time
-import hashlib
-import tempfile
-import os
-import sys
-import gc
-import io
 import collections
+from decimal import Decimal
+import gc
+import hashlib
+import io
+import itertools
+import os
 import pickle
 import random
-from decimal import Decimal
+import sys
+import tempfile
+import time
 
 from joblib.hashing import hash
 from joblib.func_inspect import filter_args
 from joblib.memory import Memory
 from joblib.testing import (assert_equal, assert_not_equal,
-                            assert_raises_regex, SkipTest, fixture)
+                            assert_raises_regex, SkipTest, fixture,
+                            parametrize)
 from joblib.test.common import np, with_numpy
 from joblib.my_exceptions import TransportableException
 from joblib._compat import PY3_OR_LATER
@@ -83,28 +85,25 @@ class KlassWithCachedMethod(object):
 ###############################################################################
 # Tests
 
-def test_trival_hash():
-    """ Smoke test hash on various types.
-    """
-    obj_list = [1, 2, 1., 2., 1 + 1j, 2. + 1j,
-                'a', 'b',
-                (1, ), (1, 1, ), [1, ], [1, 1, ],
-                {1: 1}, {1: 2}, {2: 1},
-                None,
-                gc.collect,
-                [1, ].append,
-                # Next 2 sets have unorderable elements in python 3.
-                set(('a', 1)),
-                set(('a', 1, ('a', 1))),
-                # Next 2 dicts have unorderable type of keys in python 3.
-                {'a': 1, 1: 2},
-                {'a': 1, 1: 2, 'd': {'a': 1}},
-                ]
-    for obj1 in obj_list:
-        for obj2 in obj_list:
-            # Check that 2 objects have the same hash only if they are
-            # the same.
-            yield assert_equal, hash(obj1) == hash(obj2), obj1 is obj2
+@parametrize(['obj1', 'obj2'], list(itertools.product(
+    [1, 2, 1., 2., 1 + 1j, 2. + 1j,
+     'a', 'b',
+     (1,), (1, 1,), [1, ], [1, 1, ],
+     {1: 1}, {1: 2}, {2: 1},
+     None,
+     gc.collect,
+     [1, ].append,
+     # Next 2 sets have unorderable elements in python 3.
+     set(('a', 1)),
+     set(('a', 1, ('a', 1))),
+     # Next 2 dicts have unorderable type of keys in python 3.
+     {'a': 1, 1: 2},
+     {'a': 1, 1: 2, 'd': {'a': 1}}], repeat=2)))
+def test_trival_hash(obj1, obj2):
+    """Smoke test hash on various types."""
+    # Check that 2 objects have the same hash only if they are the same.
+    if obj1 is obj2:
+        assert hash(obj1) == hash(obj2)
 
 
 def test_hash_methods():


### PR DESCRIPTION
#### Third Phase PR on #411 (Succeeding PR #453)

This PR deals with refactor of tests in **test_hashing.py** to adopt the pytest flavor.

* Parametrization of certain tests have been done by an accompanying fixture to protect numpy specific code using `@with_numpy`. Refer https://github.com/joblib/joblib/issues/411#issuecomment-266444495 for more details.

* Regex checking of tests has been done using pytest now.

* `tmpdir_path` fixture has been removed and pytest's own `tmpdir` is brought back to used to keep uniformity across modules. Some older occurences (if any) will be taken care later.

* Some cosmetic changes like reordering of imports has been included.