### PR TITLE
[MRG] Replace stdout / stderr switching in smoke tests with capsys.

### DIFF
--- a/joblib/test/test_logger.py
+++ b/joblib/test/test_logger.py
@@ -6,8 +6,6 @@ Test the logger module.
 # Copyright (c) 2009 Gael Varoquaux
 # License: BSD Style, 3 clauses.
 
-import sys
-import io
 import re
 
 from joblib.logger import PrintTime
@@ -37,4 +35,4 @@ def test_print_time(tmpdir, capsys):
             r".\..s, 0..min\n"
     if not re.match(match, err_printed_text):
         raise AssertionError('Excepted %s, got %s' %
-                                (match, err_printed_text))
+                             (match, err_printed_text))

--- a/joblib/test/test_logger.py
+++ b/joblib/test/test_logger.py
@@ -19,26 +19,22 @@ except NameError:
     unicode = lambda s: s
 
 
-def test_print_time(tmpdir):
+def test_print_time(tmpdir, capsys):
     # A simple smoke test for PrintTime.
     logfile = tmpdir.join('test.log').strpath
-    try:
-        orig_stderr = sys.stderr
-        sys.stderr = io.StringIO()
-        print_time = PrintTime(logfile=logfile)
-        print_time(unicode('Foo'))
-        # Create a second time, to smoke test log rotation.
-        print_time = PrintTime(logfile=logfile)
-        print_time(unicode('Foo'))
-        # And a third time
-        print_time = PrintTime(logfile=logfile)
-        print_time(unicode('Foo'))
-        printed_text = sys.stderr.getvalue()
-        # Use regexps to be robust to time variations
-        match = r"Foo: 0\..s, 0\..min\nFoo: 0\..s, 0..min\nFoo: " + \
-                r".\..s, 0..min\n"
-        if not re.match(match, printed_text):
-            raise AssertionError('Excepted %s, got %s' %
-                                    (match, printed_text))
-    finally:
-        sys.stderr = orig_stderr
+    print_time = PrintTime(logfile=logfile)
+    print_time(unicode('Foo'))
+    # Create a second time, to smoke test log rotation.
+    print_time = PrintTime(logfile=logfile)
+    print_time(unicode('Foo'))
+    # And a third time
+    print_time = PrintTime(logfile=logfile)
+    print_time(unicode('Foo'))
+
+    out_printed_text, err_printed_text = capsys.readouterr()
+    # Use regexps to be robust to time variations
+    match = r"Foo: 0\..s, 0\..min\nFoo: 0\..s, 0..min\nFoo: " + \
+            r".\..s, 0..min\n"
+    if not re.match(match, err_printed_text):
+        raise AssertionError('Excepted %s, got %s' %
+                                (match, err_printed_text))

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -8,7 +8,6 @@ Test the parallel module.
 
 import time
 import sys
-import io
 import os
 from math import sqrt
 import threading

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -127,37 +127,16 @@ def check_simple_parallel(backend):
         assert ([square(x) for x in X] ==
                 Parallel(n_jobs=n_jobs, backend=backend)(
                     delayed(square)(x) for x in X))
-    try:
-        # To smoke-test verbosity, we capture stdout
-        orig_stdout = sys.stdout
-        orig_stderr = sys.stdout
-        if PY3_OR_LATER:
-            sys.stderr = io.StringIO()
-            sys.stderr = io.StringIO()
-        else:
-            sys.stdout = io.BytesIO()
-            sys.stderr = io.BytesIO()
-        for verbose in (2, 11, 100):
-            Parallel(n_jobs=-1, verbose=verbose, backend=backend)(
-                delayed(square)(x) for x in X)
-            Parallel(n_jobs=1, verbose=verbose, backend=backend)(
-                delayed(square)(x) for x in X)
-            Parallel(n_jobs=2, verbose=verbose, pre_dispatch=2,
-                     backend=backend)(
-                delayed(square)(x) for x in X)
-            Parallel(n_jobs=2, verbose=verbose, backend=backend)(
-                delayed(square)(x) for x in X)
-    except Exception as e:
-        my_stdout = sys.stdout
-        my_stderr = sys.stderr
-        sys.stdout = orig_stdout
-        sys.stderr = orig_stderr
-        print(unicode(my_stdout.getvalue()))
-        print(unicode(my_stderr.getvalue()))
-        raise e
-    finally:
-        sys.stdout = orig_stdout
-        sys.stderr = orig_stderr
+    for verbose in (2, 11, 100):
+        Parallel(n_jobs=-1, verbose=verbose, backend=backend)(
+            delayed(square)(x) for x in X)
+        Parallel(n_jobs=1, verbose=verbose, backend=backend)(
+            delayed(square)(x) for x in X)
+        Parallel(n_jobs=2, verbose=verbose, pre_dispatch=2,
+                 backend=backend)(
+            delayed(square)(x) for x in X)
+        Parallel(n_jobs=2, verbose=verbose, backend=backend)(
+            delayed(square)(x) for x in X)
 
 
 def test_simple_parallel():


### PR DESCRIPTION
#### Fixes #457 

Since joblib now uses pytest instead of nose, one does not need to explicitly capture the output. In many tests, `sys.stdout` and `sys.stderr` were temporarily replaced by a dummy `StringIO` or `tempfile`, which were restored back after test execution completed.

This manual switching is now removed owing to default behaviour of pytest (refer #457 description). Pytest's `capsys` fixture is used to grab the output and perform regex matching.

