### PR TITLE
[WIP] Refactor test_memory.py as per pytest design. 

### DIFF
--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -22,7 +22,8 @@ from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
 from joblib.testing import (assert_equal, assert_true, assert_raises,
-                            assert_raises_regex, parametrize)
+                            pytest_assert_raises, assert_raises_regex,
+                            parametrize)
 from joblib._compat import PY3_OR_LATER
 
 
@@ -384,7 +385,7 @@ def test_memory_exception():
 
     for _ in range(3):
         # Call 3 times, to be sure that the Exception is always raised
-        yield assert_raises, MyException, h, 1
+        pytest_assert_raises(MyException, h, 1)
 
 
 def test_memory_ignore():

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -21,8 +21,8 @@ from joblib.memory import MemorizedResult, NotMemorizedResult, _FUNCTION_HASHES
 from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
-from joblib.testing import (assert_equal, assert_true,
-                            assert_raises, assert_raises_regex)
+from joblib.testing import (assert_equal, assert_true, assert_raises,
+                            assert_raises_regex, parametrize)
 from joblib._compat import PY3_OR_LATER
 
 
@@ -406,22 +406,20 @@ def test_memory_ignore():
     assert len(accumulator) == 1
 
 
-def test_partial_decoration():
+@parametrize('ignore, verbose, mmap_mode',
+             [(['x'], 100, 'r'),
+              ([], 10, None)])
+def test_partial_decoration(ignore, verbose, mmap_mode):
     "Check cache may be called with kwargs before decorating"
     memory = Memory(cachedir=env['dir'], verbose=0)
 
-    test_values = [
-        (['x'], 100, 'r'),
-        ([], 10, None),
-    ]
-    for ignore, verbose, mmap_mode in test_values:
-        @memory.cache(ignore=ignore, verbose=verbose, mmap_mode=mmap_mode)
-        def z(x):
-            pass
+    @memory.cache(ignore=ignore, verbose=verbose, mmap_mode=mmap_mode)
+    def z(x):
+        pass
 
-        yield assert_equal, z.ignore, ignore
-        yield assert_equal, z._verbose, verbose
-        yield assert_equal, z.mmap_mode, mmap_mode
+    assert z.ignore == ignore
+    assert z._verbose == verbose
+    assert z.mmap_mode == mmap_mode
 
 
 def test_func_dir():

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -21,7 +21,7 @@ from joblib.memory import MemorizedResult, NotMemorizedResult, _FUNCTION_HASHES
 from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
-from joblib.testing import (assert_equal, assert_true, assert_false,
+from joblib.testing import (assert_equal, assert_true,
                             assert_raises, assert_raises_regex)
 from joblib._compat import PY3_OR_LATER
 
@@ -121,10 +121,10 @@ def test_memory_integration():
             current_accumulator = len(accumulator)
             out = g(1)
 
-        yield assert_equal, len(accumulator), current_accumulator + 1
+        assert len(accumulator) == current_accumulator + 1
         # Also, check that Memory.eval works similarly
-        yield assert_equal, memory.eval(f, 1), out
-        yield assert_equal, len(accumulator), current_accumulator + 1
+        assert memory.eval(f, 1) == out
+        assert len(accumulator) == current_accumulator + 1
 
     # Now do a smoke test with a function defined in __main__, as the name
     # mangling rules are more complex
@@ -292,7 +292,7 @@ def test_memory_eval():
     m = eval('lambda x: x')
     mm = memory.cache(m)
 
-    yield assert_equal, 1, mm(1)
+    assert mm(1) == 1
 
 
 def count_and_append(x=[]):
@@ -396,14 +396,14 @@ def test_memory_ignore():
     def z(x, y=1):
         accumulator.append(1)
 
-    yield assert_equal, z.ignore, ['y']
+    assert z.ignore == ['y']
 
     z(0, y=1)
-    yield assert_equal, len(accumulator), 1
+    assert len(accumulator) == 1
     z(0, y=1)
-    yield assert_equal, len(accumulator), 1
+    assert len(accumulator) == 1
     z(0, y=2)
-    yield assert_equal, len(accumulator), 1
+    assert len(accumulator) == 1
 
 
 def test_partial_decoration():
@@ -434,23 +434,23 @@ def test_func_dir():
 
     g = memory.cache(f)
     # Test that the function directory is created on demand
-    yield assert_equal, g._get_func_dir(), path
-    yield assert_true, os.path.exists(path)
+    assert g._get_func_dir() == path
+    assert os.path.exists(path)
 
     # Test that the code is stored.
     # For the following test to be robust to previous execution, we clear
     # the in-memory store
     _FUNCTION_HASHES.clear()
-    yield assert_false, g._check_previous_func_code()
-    yield assert_true, os.path.exists(os.path.join(path, 'func_code.py'))
-    yield assert_true, g._check_previous_func_code()
+    assert not g._check_previous_func_code()
+    assert os.path.exists(os.path.join(path, 'func_code.py'))
+    assert g._check_previous_func_code()
 
     # Test the robustness to failure of loading previous results.
     dir, _ = g.get_output_dir(1)
     a = g(1)
-    yield assert_true, os.path.exists(dir)
+    assert os.path.exists(dir)
     os.remove(os.path.join(dir, 'output.pkl'))
-    yield assert_equal, a, g(1)
+    assert a == g(1)
 
 
 def test_persistence():
@@ -463,9 +463,9 @@ def test_persistence():
 
     output_dir, _ = h.get_output_dir(1)
     func_name = _get_func_fullname(f)
-    yield assert_equal, output, _load_output(output_dir, func_name)
+    assert output == _load_output(output_dir, func_name)
     memory2 = pickle.loads(pickle.dumps(memory))
-    yield assert_equal, memory.cachedir, memory2.cachedir
+    assert memory.cachedir == memory2.cachedir
 
     # Smoke test that pickling a memory with cachedir=None works
     memory = Memory(cachedir=None, verbose=0)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -84,8 +84,8 @@ def check_identity_lazy(func, accumulator):
     func = memory.cache(func)
     for i in range(3):
         for _ in range(2):
-            yield assert_equal, func(i), i
-            yield assert_equal, len(accumulator), i + 1
+            assert func(i) == i
+            assert len(accumulator) == i + 1
 
 
 ###############################################################################
@@ -102,8 +102,7 @@ def test_memory_integration():
         accumulator.append(1)
         return l
 
-    for test in check_identity_lazy(f, accumulator):
-        yield test
+    check_identity_lazy(f, accumulator)
 
     # Now test clearing
     for compress in (False, True):
@@ -158,8 +157,7 @@ def test_memory_kwarg():
         accumulator.append(1)
         return l
 
-    for test in check_identity_lazy(g, accumulator):
-        yield test
+    check_identity_lazy(g, accumulator)
 
     memory = Memory(cachedir=env['dir'], verbose=0)
     g = memory.cache(g)
@@ -179,8 +177,7 @@ def test_memory_lambda():
 
     l = lambda x: helper(x)
 
-    for test in check_identity_lazy(l, accumulator):
-        yield test
+    check_identity_lazy(l, accumulator)
 
 
 def test_memory_name_collision():
@@ -282,8 +279,7 @@ def test_memory_partial():
     import functools
     function = functools.partial(func, 1)
 
-    for test in check_identity_lazy(function, accumulator):
-        yield test
+    check_identity_lazy(function, accumulator)
 
 
 def test_memory_eval():


### PR DESCRIPTION
#### Third Phase PR on #411 (Succeeding PR #458)

This PR deals with refactor of tests in **test_memory.py** to adopt the pytest flavor.

* Yield based tests have been handled in this manner, proposed by @lesteve: ( https://github.com/joblib/joblib/issues/411#issuecomment-266738128 )
    * `yield` which are not inside a for loop can be replaced by assert
    * `yield` inside a for loop could be replaced by using `parametrize`. If that is not super straightforward to do, I would be in favour of replacing by assert.

* Regex checking of exception messages is carried out by `pytest_assert_raises`.