### PR TITLE
[MRG] Remove pytest warnings due to yield based tests.

### DIFF
--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -19,8 +19,7 @@ from contextlib import closing
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_memory_profiler, memory_used
-from joblib.testing import (assert_equal, assert_raises, assert_raises_regex,
-                            SkipTest)
+from joblib.testing import assert_raises, assert_raises_regex, SkipTest
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.
@@ -151,7 +150,7 @@ def test_standard_types():
             # We compare the pickled instance to the reloaded one only if it
             # can be compared to a copied one
             if member == copy.deepcopy(member):
-                yield assert_equal, member, _member
+                assert member == _member
 
 
 def test_value_error():

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -17,10 +17,7 @@ from joblib._compat import PY3_OR_LATER
 
 
 _dummy = unittest.TestCase('__init__')
-assert_true = _dummy.assertTrue
-assert_false = _dummy.assertFalse
-assert_equal = _dummy.assertEqual
-assert_not_equal = _dummy.assertNotEqual
+
 assert_raises = _dummy.assertRaises
 pytest_assert_raises = pytest.raises
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ universal=1
 
 [tool:pytest]
 addopts =
-    --disable-pytest-warnings
     --doctest-glob="doc/*.rst"
     --doctest-modules
 testpaths = joblib


### PR DESCRIPTION
#### Fourth Phase PR on #411 

This PR targets on completely removing all the pytest warnings existing in all the tests at this stage. On `master`, at the base of this PR, there are **189** pytest warnings - mostly because pytest >= 3 has deprecated support of `yield` based tests. 

* Statements `yield`ing a simple function (callable) have been removed and a normal function call is included there.

* Statements `yield`ing `assert_*` methods have been replaced with simple `assert` keywords as of now.

* Finally `--disable-pytest-warnings` has been removed.

The goal of this PR is to eliminate all pytest warnings existing already.