### PR TITLE
[MRG] Use pytest for asserting exceptions in all test methods.

### DIFF
--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -12,7 +12,7 @@ import array
 import os
 
 from joblib.disk import disk_used, memstr_to_bytes, mkdirp
-from joblib.testing import parametrize, assert_raises, pytest_assert_raises
+from joblib.testing import parametrize, assert_raises
 
 ###############################################################################
 
@@ -46,7 +46,7 @@ def test_memstr_to_bytes(text, value):
              [('fooG', ValueError, r'Invalid literal for size.*fooG.*'),
               ('1.4N', ValueError, r'Invalid literal for size.*1.4N.*')])
 def test_memstr_to_bytes_exception(text, exception, regex):
-    with pytest_assert_raises(exception) as excinfo:
+    with assert_raises(exception) as excinfo:
         memstr_to_bytes(text)
     assert excinfo.match(regex)
 

--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -12,7 +12,7 @@ import array
 import os
 
 from joblib.disk import disk_used, memstr_to_bytes, mkdirp
-from joblib.testing import parametrize, assert_raises
+from joblib.testing import parametrize, raises
 
 ###############################################################################
 
@@ -46,7 +46,7 @@ def test_memstr_to_bytes(text, value):
              [('fooG', ValueError, r'Invalid literal for size.*fooG.*'),
               ('1.4N', ValueError, r'Invalid literal for size.*1.4N.*')])
 def test_memstr_to_bytes_exception(text, exception, regex):
-    with assert_raises(exception) as excinfo:
+    with raises(exception) as excinfo:
         memstr_to_bytes(text)
     assert excinfo.match(regex)
 
@@ -57,4 +57,5 @@ def test_mkdirp(tmpdir):
     mkdirp(os.path.join(tmpdir.strpath, 'spam', 'spam'))
 
     # Not all OSErrors are ignored
-    assert_raises(OSError, mkdirp, '')
+    with raises(OSError):
+        mkdirp('')

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -12,7 +12,7 @@ from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import fixture, parametrize, pytest_assert_raises
+from joblib.testing import fixture, parametrize, assert_raises
 from joblib._compat import PY3_OR_LATER
 
 
@@ -168,7 +168,7 @@ def func_with_signature(a: int, b: int) -> None: pass
 
         # filter_args doesn't care about keyword-only arguments so you
         # can pass 'kw1' into *args without any problem
-        with pytest_assert_raises(ValueError) as excinfo:
+        with assert_raises(ValueError) as excinfo:
             filter_args(func_with_kwonly_args, [], (1, 2, 3), {'kw2': 2})
         excinfo.match("Keyword-only parameter 'kw1' was passed as positional "
                       "parameter")
@@ -202,7 +202,7 @@ def test_filter_args_error_msg(exception, regex, func, args):
     """ Make sure that filter_args returns decent error messages, for the
         sake of the user.
     """
-    with pytest_assert_raises(exception) as excinfo:
+    with assert_raises(exception) as excinfo:
         filter_args(func, *args)
     excinfo.match(regex)
 

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -12,7 +12,7 @@ from joblib.func_inspect import filter_args, get_func_name, get_func_code
 from joblib.func_inspect import _clean_win_chars, format_signature
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import fixture, parametrize, assert_raises
+from joblib.testing import fixture, parametrize, raises
 from joblib._compat import PY3_OR_LATER
 
 
@@ -168,7 +168,7 @@ def func_with_signature(a: int, b: int) -> None: pass
 
         # filter_args doesn't care about keyword-only arguments so you
         # can pass 'kw1' into *args without any problem
-        with assert_raises(ValueError) as excinfo:
+        with raises(ValueError) as excinfo:
             filter_args(func_with_kwonly_args, [], (1, 2, 3), {'kw2': 2})
         excinfo.match("Keyword-only parameter 'kw1' was passed as positional "
                       "parameter")
@@ -202,7 +202,7 @@ def test_filter_args_error_msg(exception, regex, func, args):
     """ Make sure that filter_args returns decent error messages, for the
         sake of the user.
     """
-    with assert_raises(exception) as excinfo:
+    with raises(exception) as excinfo:
         filter_args(func, *args)
     excinfo.match(regex)
 

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -20,7 +20,7 @@ from decimal import Decimal
 from joblib.hashing import hash
 from joblib.func_inspect import filter_args
 from joblib.memory import Memory
-from joblib.testing import pytest_assert_raises, skipif, fixture, parametrize
+from joblib.testing import assert_raises, skipif, fixture, parametrize
 from joblib.test.common import np, with_numpy
 from joblib.my_exceptions import TransportableException
 from joblib._compat import PY3_OR_LATER
@@ -451,6 +451,6 @@ def test_hashing_pickling_error():
     def non_picklable():
         return 42
 
-    with pytest_assert_raises(pickle.PicklingError) as excinfo:
+    with assert_raises(pickle.PicklingError) as excinfo:
         hash(non_picklable)
     excinfo.match('PicklingError while hashing')

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -20,7 +20,7 @@ from decimal import Decimal
 from joblib.hashing import hash
 from joblib.func_inspect import filter_args
 from joblib.memory import Memory
-from joblib.testing import assert_raises, skipif, fixture, parametrize
+from joblib.testing import raises, skipif, fixture, parametrize
 from joblib.test.common import np, with_numpy
 from joblib.my_exceptions import TransportableException
 from joblib._compat import PY3_OR_LATER
@@ -451,6 +451,6 @@ def test_hashing_pickling_error():
     def non_picklable():
         return 42
 
-    with assert_raises(pickle.PicklingError) as excinfo:
+    with raises(pickle.PicklingError) as excinfo:
         hash(non_picklable)
     excinfo.match('PicklingError while hashing')

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -20,7 +20,7 @@ from joblib.memory import MemorizedResult, NotMemorizedResult, _FUNCTION_HASHES
 from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
-from joblib.testing import assert_raises
+from joblib.testing import raises
 from joblib._compat import PY3_OR_LATER
 
 
@@ -343,7 +343,8 @@ def test_memory_exception(tmpdir):
 
     for _ in range(3):
         # Call 3 times, to be sure that the Exception is always raised
-        assert_raises(MyException, h, 1)
+        with raises(MyException):
+            h(1)
 
 
 def test_memory_ignore(tmpdir):
@@ -451,7 +452,8 @@ def test_call_and_shelve(tmpdir):
         assert result.get() == 5
 
         result.clear()
-        assert_raises(KeyError, result.get)
+        with raises(KeyError):
+            result.get()
         result.clear()  # Do nothing if there is no cache.
 
 
@@ -609,7 +611,7 @@ def func_with_signature(a: int, b: float) -> float:
 
         # Making sure that providing a keyword-only argument by
         # position raises an exception
-        with assert_raises(ValueError) as excinfo:
+        with raises(ValueError) as excinfo:
             func_cached(1, 2, 3, kw2=4)
         excinfo.match("Keyword-only parameter 'kw1' was passed as positional "
                       "parameter")
@@ -618,7 +620,7 @@ def func_with_signature(a: int, b: float) -> float:
         # should still raise ValueError
         func_cached(1, 2, kw1=3, kw2=4)
 
-        with assert_raises(ValueError) as excinfo:
+        with raises(ValueError) as excinfo:
             func_cached(1, 2, 3, kw2=4)
         excinfo.match("Keyword-only parameter 'kw1' was passed as positional "
                       "parameter")

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -20,7 +20,7 @@ from joblib.memory import MemorizedResult, NotMemorizedResult, _FUNCTION_HASHES
 from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
-from joblib.testing import assert_raises, pytest_assert_raises
+from joblib.testing import assert_raises
 from joblib._compat import PY3_OR_LATER
 
 
@@ -609,7 +609,7 @@ def func_with_signature(a: int, b: float) -> float:
 
         # Making sure that providing a keyword-only argument by
         # position raises an exception
-        with pytest_assert_raises(ValueError) as excinfo:
+        with assert_raises(ValueError) as excinfo:
             func_cached(1, 2, 3, kw2=4)
         excinfo.match("Keyword-only parameter 'kw1' was passed as positional "
                       "parameter")
@@ -618,7 +618,7 @@ def func_with_signature(a: int, b: float) -> float:
         # should still raise ValueError
         func_cached(1, 2, kw1=3, kw2=4)
 
-        with pytest_assert_raises(ValueError) as excinfo:
+        with assert_raises(ValueError) as excinfo:
             func_cached(1, 2, 3, kw2=4)
         excinfo.match("Keyword-only parameter 'kw1' was passed as positional "
                       "parameter")

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -20,7 +20,7 @@ from joblib.memory import MemorizedResult, NotMemorizedResult, _FUNCTION_HASHES
 from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.test.common import with_numpy, np
-from joblib.testing import assert_raises, assert_raises_regex
+from joblib.testing import assert_raises, pytest_assert_raises
 from joblib._compat import PY3_OR_LATER
 
 
@@ -609,21 +609,19 @@ def func_with_signature(a: int, b: float) -> float:
 
         # Making sure that providing a keyword-only argument by
         # position raises an exception
-        assert_raises_regex(
-            ValueError,
-            "Keyword-only parameter 'kw1' was passed as positional parameter",
-            func_cached,
-            1, 2, 3, {'kw2': 4})
+        with pytest_assert_raises(ValueError) as excinfo:
+            func_cached(1, 2, 3, kw2=4)
+        excinfo.match("Keyword-only parameter 'kw1' was passed as positional "
+                      "parameter")
 
         # Keyword-only parameter passed by position with cached call
         # should still raise ValueError
         func_cached(1, 2, kw1=3, kw2=4)
 
-        assert_raises_regex(
-            ValueError,
-            "Keyword-only parameter 'kw1' was passed as positional parameter",
-            func_cached,
-            1, 2, 3, {'kw2': 4})
+        with pytest_assert_raises(ValueError) as excinfo:
+            func_cached(1, 2, 3, kw2=4)
+        excinfo.match("Keyword-only parameter 'kw1' was passed as positional "
+                      "parameter")
 
         # Test 'ignore' parameter
         func_cached = mem.cache(func_with_kwonly_args, ignore=['kw2'])

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -16,7 +16,7 @@ from contextlib import closing
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_memory_profiler, memory_used
-from joblib.testing import assert_raises, pytest_assert_raises, SkipTest
+from joblib.testing import assert_raises, SkipTest
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.
@@ -131,7 +131,7 @@ def test_compress_level_error():
     wrong_compress = (-1, 10, 'wrong')
     for wrong in wrong_compress:
         exception_msg = 'Non valid compress level given: "{0}"'.format(wrong)
-        with pytest_assert_raises(ValueError) as excinfo:
+        with assert_raises(ValueError) as excinfo:
             numpy_pickle.dump('dummy', 'foo', compress=wrong)
         excinfo.match(exception_msg)
 
@@ -499,17 +499,17 @@ def test_compress_tuple_argument(tmpdir):
             assert _detect_compressor(f) == compress[0]
 
     # Verify setting a wrong compress tuple raises a ValueError.
-    with pytest_assert_raises(ValueError) as excinfo:
+    with assert_raises(ValueError) as excinfo:
         numpy_pickle.dump('dummy', filename, compress=('zlib', 3, 'extra'))
     excinfo.match('Compress argument tuple should contain exactly 2 elements')
 
     # Verify a tuple with a wrong compress method raises a ValueError.
-    with pytest_assert_raises(ValueError) as excinfo:
+    with assert_raises(ValueError) as excinfo:
         numpy_pickle.dump('dummy', filename, compress=('wrong', 3))
     excinfo.match('Non valid compression method given: "{}"'.format('wrong'))
 
     # Verify a tuple with a wrong compress level raises a ValueError.
-    with pytest_assert_raises(ValueError) as excinfo:
+    with assert_raises(ValueError) as excinfo:
         numpy_pickle.dump('dummy', filename, compress=('zlib', 'wrong'))
     excinfo.match('Non valid compress level given: "{}"'.format('wrong'))
 
@@ -529,7 +529,7 @@ def test_joblib_compression_formats(tmpdir):
                 if not PY3_OR_LATER and cmethod in ('xz', 'lzma'):
                     # Lzma module only available for python >= 3.3
                     msg = "{} compression is only available".format(cmethod)
-                    with pytest_assert_raises(NotImplementedError) as excinfo:
+                    with assert_raises(NotImplementedError) as excinfo:
                         numpy_pickle.dump(obj, dump_filename,
                                           compress=(cmethod, compress))
                     excinfo.match(msg)
@@ -608,7 +608,7 @@ def test_compression_using_file_extension(tmpdir):
         if not PY3_OR_LATER and cmethod in ('xz', 'lzma'):
             # Lzma module only available for python >= 3.3
             msg = "{} compression is only available".format(cmethod)
-            with pytest_assert_raises(NotImplementedError) as excinfo:
+            with assert_raises(NotImplementedError) as excinfo:
                 numpy_pickle.dump(obj, dump_fname)
             excinfo.match(msg)
         else:

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -16,7 +16,7 @@ from contextlib import closing
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_memory_profiler, memory_used
-from joblib.testing import assert_raises, SkipTest
+from joblib.testing import raises, SkipTest
 
 # numpy_pickle is not a drop-in replacement of pickle, as it takes
 # filenames instead of open files as arguments.
@@ -123,7 +123,8 @@ def test_standard_types(tmpdir):
 
 def test_value_error():
     # Test inverting the input arguments to dump
-    assert_raises(ValueError, numpy_pickle.dump, 'foo', dict())
+    with raises(ValueError):
+        numpy_pickle.dump('foo', dict())
 
 
 def test_compress_level_error():
@@ -131,7 +132,7 @@ def test_compress_level_error():
     wrong_compress = (-1, 10, 'wrong')
     for wrong in wrong_compress:
         exception_msg = 'Non valid compress level given: "{0}"'.format(wrong)
-        with assert_raises(ValueError) as excinfo:
+        with raises(ValueError) as excinfo:
             numpy_pickle.dump('dummy', 'foo', compress=wrong)
         excinfo.match(exception_msg)
 
@@ -391,7 +392,8 @@ def _check_pickle(filename, expected_list):
     if (not PY3_OR_LATER and (filename.endswith('.xz') or
                               filename.endswith('.lzma'))):
         # lzma is not supported for python versions < 3.3
-        assert_raises(NotImplementedError, numpy_pickle.load, filename)
+        with raises(NotImplementedError):
+            numpy_pickle.load(filename)
         return
 
     version_match = re.match(r'.+py(\d)(\d).+', filename)
@@ -499,17 +501,17 @@ def test_compress_tuple_argument(tmpdir):
             assert _detect_compressor(f) == compress[0]
 
     # Verify setting a wrong compress tuple raises a ValueError.
-    with assert_raises(ValueError) as excinfo:
+    with raises(ValueError) as excinfo:
         numpy_pickle.dump('dummy', filename, compress=('zlib', 3, 'extra'))
     excinfo.match('Compress argument tuple should contain exactly 2 elements')
 
     # Verify a tuple with a wrong compress method raises a ValueError.
-    with assert_raises(ValueError) as excinfo:
+    with raises(ValueError) as excinfo:
         numpy_pickle.dump('dummy', filename, compress=('wrong', 3))
     excinfo.match('Non valid compression method given: "{}"'.format('wrong'))
 
     # Verify a tuple with a wrong compress level raises a ValueError.
-    with assert_raises(ValueError) as excinfo:
+    with raises(ValueError) as excinfo:
         numpy_pickle.dump('dummy', filename, compress=('zlib', 'wrong'))
     excinfo.match('Non valid compress level given: "{}"'.format('wrong'))
 
@@ -529,7 +531,7 @@ def test_joblib_compression_formats(tmpdir):
                 if not PY3_OR_LATER and cmethod in ('xz', 'lzma'):
                     # Lzma module only available for python >= 3.3
                     msg = "{} compression is only available".format(cmethod)
-                    with assert_raises(NotImplementedError) as excinfo:
+                    with raises(NotImplementedError) as excinfo:
                         numpy_pickle.dump(obj, dump_filename,
                                           compress=(cmethod, compress))
                     excinfo.match(msg)
@@ -608,7 +610,7 @@ def test_compression_using_file_extension(tmpdir):
         if not PY3_OR_LATER and cmethod in ('xz', 'lzma'):
             # Lzma module only available for python >= 3.3
             msg = "{} compression is only available".format(cmethod)
-            with assert_raises(NotImplementedError) as excinfo:
+            with raises(NotImplementedError) as excinfo:
                 numpy_pickle.dump(obj, dump_fname)
             excinfo.match(msg)
         else:
@@ -730,16 +732,18 @@ def test_binary_zlibfile(tmpdir):
 
     # Test bad compression levels
     for bad_value in (-1, 10, 15, 'a', (), {}):
-        assert_raises(ValueError, BinaryZlibFile, filename, 'wb',
-                      compresslevel=bad_value)
+        with raises(ValueError):
+            BinaryZlibFile(filename, 'wb', compresslevel=bad_value)
 
     # Test invalid modes
     for bad_mode in ('a', 'x', 'r', 'w', 1, 2):
-        assert_raises(ValueError, BinaryZlibFile, filename, bad_mode)
+        with raises(ValueError):
+            BinaryZlibFile(filename, bad_mode)
 
     # Test wrong filename type (not a string or a file)
     for bad_file in (1, (), {}):
-        assert_raises(TypeError, BinaryZlibFile, bad_file, 'rb')
+        with raises(TypeError):
+            BinaryZlibFile(bad_file, 'rb')
 
     for d in (b'a little data as bytes.',
               # More bytes
@@ -753,10 +757,14 @@ def test_binary_zlibfile(tmpdir):
                     assert fz.writable()
                     fz.write(d)
                     assert fz.fileno() == f.fileno()
-                    assert_raises(io.UnsupportedOperation, fz._check_can_read)
-                    assert_raises(io.UnsupportedOperation, fz._check_can_seek)
+                    with raises(io.UnsupportedOperation):
+                        fz._check_can_read()
+
+                    with raises(io.UnsupportedOperation):
+                        fz._check_can_seek()
                 assert fz.closed
-                assert_raises(ValueError, fz._check_not_closed)
+                with raises(ValueError):
+                    fz._check_not_closed()
 
             with open(filename, 'rb') as f:
                 with BinaryZlibFile(f) as fz:
@@ -765,8 +773,8 @@ def test_binary_zlibfile(tmpdir):
                         assert fz.seekable()
                     assert fz.fileno() == f.fileno()
                     assert fz.read() == d
-                    assert_raises(io.UnsupportedOperation,
-                                  fz._check_can_write)
+                    with raises(io.UnsupportedOperation):
+                        fz._check_can_write()
                     if PY3_OR_LATER:
                         # io.BufferedIOBase doesn't have seekable() method in
                         # python 2

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -466,7 +466,7 @@ def test_exception_dispatch():
     "Make sure that exception raised during dispatch are indeed captured"
     with raises(ValueError):
         Parallel(n_jobs=2, pre_dispatch=16, verbose=0)(
-            (delayed(exception_raiser)(i) for i in range(30)))
+            delayed(exception_raiser)(i) for i in range(30))
 
 
 def test_nested_exception_dispatch():

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -19,8 +19,7 @@ from joblib import parallel
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_multiprocessing
-from joblib.testing import (assert_raises, check_subprocess_call,
-                            SkipTest)
+from joblib.testing import raises, check_subprocess_call, SkipTest
 from joblib._compat import PY3_OR_LATER
 
 try:
@@ -257,8 +256,8 @@ def test_parallel_pickling():
     except Exception as exc:
         exception_class = exc.__class__
 
-    assert_raises(exception_class, Parallel(),
-                  (delayed(g)(x) for x in range(10)))
+    with raises(exception_class):
+        Parallel()(delayed(g)(x) for x in range(10))
 
 
 def test_parallel_timeout_success():
@@ -272,9 +271,9 @@ def test_parallel_timeout_success():
 def test_parallel_timeout_fail():
     # Check that timeout properly fails when function is too slow
     for backend in ['multiprocessing', 'threading']:
-        assert_raises(TimeoutError,
-                      Parallel(n_jobs=2, backend=backend, timeout=0.01),
-                      (delayed(sleep)(10) for x in range(10)))
+        with raises(TimeoutError):
+            Parallel(n_jobs=2, backend=backend, timeout=0.01)(
+                delayed(sleep)(10) for x in range(10))
 
 
 def test_error_capture():
@@ -283,20 +282,22 @@ def test_error_capture():
     if mp is not None:
         # A JoblibException will be raised only if there is indeed
         # multiprocessing
-        assert_raises(JoblibException, Parallel(n_jobs=2),
-                      [delayed(division)(x, y)
-                       for x, y in zip((0, 1), (1, 0))])
-        assert_raises(WorkerInterrupt, Parallel(n_jobs=2),
-                      [delayed(interrupt_raiser)(x) for x in (1, 0)])
+        with raises(JoblibException):
+            Parallel(n_jobs=2)(
+                [delayed(division)(x, y)
+                    for x, y in zip((0, 1), (1, 0))])
+        with raises(WorkerInterrupt):
+            Parallel(n_jobs=2)(
+                [delayed(interrupt_raiser)(x) for x in (1, 0)])
 
         # Try again with the context manager API
         with Parallel(n_jobs=2) as parallel:
             assert parallel._backend._pool is not None
             original_pool = parallel._backend._pool
 
-            assert_raises(JoblibException, parallel,
-                          [delayed(division)(x, y)
-                           for x, y in zip((0, 1), (1, 0))])
+            with raises(JoblibException):
+                parallel([delayed(division)(x, y)
+                          for x, y in zip((0, 1), (1, 0))])
 
             # The managed pool should still be available and be in a working
             # state despite the previously raised (and caught) exception
@@ -309,8 +310,8 @@ def test_error_capture():
                     parallel(delayed(f)(x, y=1) for x in range(10)))
 
             original_pool = parallel._backend._pool
-            assert_raises(WorkerInterrupt, parallel,
-                          [delayed(interrupt_raiser)(x) for x in (1, 0)])
+            with raises(WorkerInterrupt):
+                parallel([delayed(interrupt_raiser)(x) for x in (1, 0)])
 
             # The pool should still be available despite the exception
             assert parallel._backend._pool is not None
@@ -325,19 +326,20 @@ def test_error_capture():
         # context manager
         assert parallel._backend._pool is None
     else:
-        assert_raises(KeyboardInterrupt, Parallel(n_jobs=2),
-                      [delayed(interrupt_raiser)(x) for x in (1, 0)])
+        with raises(KeyboardInterrupt):
+            Parallel(n_jobs=2)(
+                [delayed(interrupt_raiser)(x) for x in (1, 0)])
 
     # wrapped exceptions should inherit from the class of the original
     # exception to make it easy to catch them
-    assert_raises(ZeroDivisionError, Parallel(n_jobs=2),
-                  [delayed(division)(x, y) for x, y in zip((0, 1), (1, 0))])
+    with raises(ZeroDivisionError):
+        Parallel(n_jobs=2)(
+            [delayed(division)(x, y) for x, y in zip((0, 1), (1, 0))])
 
-    assert_raises(
-        MyExceptionWithFinickyInit,
-        Parallel(n_jobs=2, verbose=0),
-        (delayed(exception_raiser)(i, custom_exception=True)
-         for i in range(30)))
+    with raises(MyExceptionWithFinickyInit):
+        Parallel(n_jobs=2, verbose=0)(
+            (delayed(exception_raiser)(i, custom_exception=True)
+             for i in range(30)))
 
     try:
         # JoblibException wrapping is disabled in sequential mode:
@@ -462,19 +464,17 @@ def test_batching_auto_multiprocessing():
 
 def test_exception_dispatch():
     "Make sure that exception raised during dispatch are indeed captured"
-    assert_raises(
-        ValueError,
-        Parallel(n_jobs=2, pre_dispatch=16, verbose=0),
-        (delayed(exception_raiser)(i) for i in range(30)))
+    with raises(ValueError):
+        Parallel(n_jobs=2, pre_dispatch=16, verbose=0)(
+            (delayed(exception_raiser)(i) for i in range(30)))
 
 
 def test_nested_exception_dispatch():
     # Ensure TransportableException objects for nested joblib cases gets
     # propagated.
-    assert_raises(
-        JoblibException,
-        Parallel(n_jobs=2, pre_dispatch=16, verbose=0),
-        (delayed(SafeFunction(exception_raiser))(i) for i in range(30)))
+    with raises(JoblibException):
+        Parallel(n_jobs=2, pre_dispatch=16, verbose=0)(
+            delayed(SafeFunction(exception_raiser))(i) for i in range(30))
 
 
 def _reload_joblib():
@@ -494,8 +494,9 @@ def test_multiple_spawning():
     # systems that do not support fork
     if not int(os.environ.get('JOBLIB_MULTIPROCESSING', 1)):
         raise SkipTest()
-    assert_raises(ImportError, Parallel(n_jobs=2, pre_dispatch='all'),
-                  [delayed(_reload_joblib)() for i in range(10)])
+    with raises(ImportError):
+        Parallel(n_jobs=2, pre_dispatch='all')(
+            [delayed(_reload_joblib)() for i in range(10)])
 
 
 class FakeParallelBackend(SequentialBackend):
@@ -513,7 +514,8 @@ class FakeParallelBackend(SequentialBackend):
 
 
 def test_invalid_backend():
-    assert_raises(ValueError, Parallel, backend='unit-testing')
+    with raises(ValueError):
+        Parallel(backend='unit-testing')
 
 
 def test_register_parallel_backend():
@@ -650,13 +652,17 @@ def test_joblib_exception():
 
 def test_safe_function():
     safe_division = SafeFunction(division)
-    assert_raises(JoblibException, safe_division, 1, 0)
+    with raises(JoblibException):
+        safe_division(1, 0)
 
 
 def test_invalid_batch_size():
-    assert_raises(ValueError, Parallel, batch_size=0)
-    assert_raises(ValueError, Parallel, batch_size=-1)
-    assert_raises(ValueError, Parallel, batch_size=1.42)
+    with raises(ValueError):
+        Parallel(batch_size=0)
+    with raises(ValueError):
+        Parallel(batch_size=-1)
+    with raises(ValueError):
+        Parallel(batch_size=1.42)
 
 
 def check_same_results(params):

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -5,7 +5,7 @@ from joblib.test.common import setup_autokill
 from joblib.test.common import teardown_autokill
 from joblib.test.common import with_multiprocessing
 from joblib.test.common import with_dev_shm
-from joblib.testing import assert_raises, fixture
+from joblib.testing import raises
 
 
 from joblib._multiprocessing_helpers import mp
@@ -216,13 +216,13 @@ def test_pool_with_memmap(tmpdir):
         c = np.memmap(filename, dtype=np.float32, shape=(10,), mode='r',
                       offset=5 * 4)
 
-        assert_raises(AssertionError, p.map, check_array,
-                      [(c, i, 3.0) for i in range(c.shape[0])])
+        with raises(AssertionError):
+            p.map(check_array, [(c, i, 3.0) for i in range(c.shape[0])])
 
         # depending on the version of numpy one can either get a RuntimeError
         # or a ValueError
-        assert_raises((RuntimeError, ValueError), p.map, inplace_double,
-                      [(c, i, 2.0) for i in range(c.shape[0])])
+        with raises((RuntimeError, ValueError)):
+            p.map(inplace_double, [(c, i, 2.0) for i in range(c.shape[0])])
     finally:
         # Clean all filehandlers held by the pool
         p.terminate()

--- a/joblib/test/test_testing.py
+++ b/joblib/test/test_testing.py
@@ -1,7 +1,7 @@
 import sys
 import re
 
-from joblib.testing import assert_raises, check_subprocess_call
+from joblib.testing import raises, check_subprocess_call
 
 
 def test_check_subprocess_call():
@@ -22,7 +22,7 @@ def test_check_subprocess_call_non_matching_regex():
     code = '42'
     non_matching_pattern = '_no_way_this_matches_anything_'
 
-    with assert_raises(ValueError) as excinfo:
+    with raises(ValueError) as excinfo:
         check_subprocess_call([sys.executable, '-c', code],
                               stdout_regex=non_matching_pattern)
     excinfo.match('Unexpected stdout.+{}'.format(non_matching_pattern))
@@ -30,7 +30,8 @@ def test_check_subprocess_call_non_matching_regex():
 
 def test_check_subprocess_call_wrong_command():
     wrong_command = '_a_command_that_does_not_exist_'
-    assert_raises(OSError, check_subprocess_call, [wrong_command])
+    with raises(OSError):
+        check_subprocess_call([wrong_command])
 
 
 def test_check_subprocess_call_non_zero_return_code():
@@ -44,7 +45,7 @@ def test_check_subprocess_call_non_zero_return_code():
                          'Stdout:\nwriting on stdout.+'
                          'Stderr:\nwriting on stderr', re.DOTALL)
 
-    with assert_raises(ValueError) as excinfo:
+    with raises(ValueError) as excinfo:
         check_subprocess_call([sys.executable, '-c', code_with_non_zero_exit])
     excinfo.match(pattern)
 
@@ -66,7 +67,7 @@ def test_check_subprocess_call_timeout():
                          'Stderr:\nbefore sleep on stderr',
                          re.DOTALL)
 
-    with assert_raises(ValueError) as excinfo:
+    with raises(ValueError) as excinfo:
         check_subprocess_call([sys.executable, '-c', code_timing_out],
                               timeout=1)
     excinfo.match(pattern)

--- a/joblib/test/test_testing.py
+++ b/joblib/test/test_testing.py
@@ -1,7 +1,7 @@
 import sys
 import re
 
-from joblib.testing import pytest_assert_raises, check_subprocess_call
+from joblib.testing import assert_raises, check_subprocess_call
 
 
 def test_check_subprocess_call():
@@ -22,7 +22,7 @@ def test_check_subprocess_call_non_matching_regex():
     code = '42'
     non_matching_pattern = '_no_way_this_matches_anything_'
 
-    with pytest_assert_raises(ValueError) as excinfo:
+    with assert_raises(ValueError) as excinfo:
         check_subprocess_call([sys.executable, '-c', code],
                               stdout_regex=non_matching_pattern)
     excinfo.match('Unexpected stdout.+{}'.format(non_matching_pattern))
@@ -30,8 +30,7 @@ def test_check_subprocess_call_non_matching_regex():
 
 def test_check_subprocess_call_wrong_command():
     wrong_command = '_a_command_that_does_not_exist_'
-    with pytest_assert_raises(OSError):
-        check_subprocess_call([wrong_command])
+    assert_raises(OSError, check_subprocess_call, [wrong_command])
 
 
 def test_check_subprocess_call_non_zero_return_code():
@@ -45,7 +44,7 @@ def test_check_subprocess_call_non_zero_return_code():
                          'Stdout:\nwriting on stdout.+'
                          'Stderr:\nwriting on stderr', re.DOTALL)
 
-    with pytest_assert_raises(ValueError) as excinfo:
+    with assert_raises(ValueError) as excinfo:
         check_subprocess_call([sys.executable, '-c', code_with_non_zero_exit])
     excinfo.match(pattern)
 
@@ -67,7 +66,7 @@ def test_check_subprocess_call_timeout():
                          'Stderr:\nbefore sleep on stderr',
                          re.DOTALL)
 
-    with pytest_assert_raises(ValueError) as excinfo:
+    with assert_raises(ValueError) as excinfo:
         check_subprocess_call([sys.executable, '-c', code_timing_out],
                               timeout=1)
     excinfo.match(pattern)

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -15,7 +15,7 @@ import _pytest
 from joblib._compat import PY3_OR_LATER
 
 
-assert_raises = pytest.raises
+raises = pytest.raises
 SkipTest = _pytest.runner.Skipped
 skipif = pytest.mark.skipif
 fixture = pytest.fixture

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -8,7 +8,6 @@ import os.path
 import re
 import subprocess
 import threading
-import unittest
 
 import pytest
 import _pytest
@@ -16,11 +15,7 @@ import _pytest
 from joblib._compat import PY3_OR_LATER
 
 
-_dummy = unittest.TestCase('__init__')
-
-assert_raises = _dummy.assertRaises
-pytest_assert_raises = pytest.raises
-
+assert_raises = pytest.raises
 SkipTest = _pytest.runner.Skipped
 skipif = pytest.mark.skipif
 fixture = pytest.fixture

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -21,12 +21,6 @@ _dummy = unittest.TestCase('__init__')
 assert_raises = _dummy.assertRaises
 pytest_assert_raises = pytest.raises
 
-try:
-    assert_raises_regex = _dummy.assertRaisesRegex
-except AttributeError:
-    # Python 2.7
-    assert_raises_regex = _dummy.assertRaisesRegexp
-
 SkipTest = _pytest.runner.Skipped
 skipif = pytest.mark.skipif
 fixture = pytest.fixture


### PR DESCRIPTION
#### Fourth Phase PR on #411 (Succeeding PR #463 )

`pytest.raises` produces a less noisy error log upon failure. This PR replaces all the `assert_raises` and `assert_raises_regex` calls with `pytest_assert_raises`. Finally the `unittest` 's `assert_raises` is removed from `joblib.testing` and `pytest_assert_raises` has been renamed as `raises`.

* `assert_raises` and `assert_raises_regex` calls have been modified as:
```python
with raises(ExceptionName) as excinfo:   # pytest.raises
    code_that_raises_exception()
    # more code
excinfo.match('exception message regex')
```

* `assert_raises` (old) and `assert_raises_regex` were the last of helpers used from `unittest` module. By this PR, the testing infrastructure no longer directly depends on `unittest`.