### PR TITLE
[MRG] Use 'with pytest.warns' blocks to assert warnings.

### DIFF
--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -20,7 +20,7 @@ from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.memory import JobLibCollisionWarning
 from joblib.test.common import with_numpy, np
-from joblib.testing import raises
+from joblib.testing import raises, warns
 from joblib._compat import PY3_OR_LATER
 
 
@@ -142,7 +142,7 @@ def test_memory_lambda(tmpdir):
     check_identity_lazy(l, accumulator, tmpdir.strpath)
 
 
-def test_memory_name_collision(tmpdir, recwarn):
+def test_memory_name_collision(tmpdir):
     " Check that name collisions with functions will raise warnings"
     memory = Memory(cachedir=tmpdir.strpath, verbose=0)
 
@@ -162,52 +162,52 @@ def test_memory_name_collision(tmpdir, recwarn):
 
     b = name_collision
 
-    a(1)
-    b(1)
-    assert len(recwarn) == 1
-    w = recwarn.pop(JobLibCollisionWarning)
-    assert "collision" in str(w.message)
+    with warns(JobLibCollisionWarning) as warninfo:
+        a(1)
+        b(1)
+
+    assert len(warninfo) == 1
+    assert "collision" in str(warninfo[-1].message)
 
 
-def test_memory_warning_lambda_collisions(tmpdir, recwarn):
+def test_memory_warning_lambda_collisions(tmpdir):
     # Check that multiple use of lambda will raise collisions
     memory = Memory(cachedir=tmpdir.strpath, verbose=0)
     # For isolation with other tests
-    memory.clear(warn=False)
-
+    memory.clear()
     a = lambda x: x
     a = memory.cache(a)
     b = lambda x: x + 1
     b = memory.cache(b)
 
-    assert a(0) == 0
-    assert b(1) == 2
-    assert a(1) == 1
+    with warns(JobLibCollisionWarning) as warninfo:
+        assert a(0) == 0
+        assert b(1) == 2
+        assert a(1) == 1
 
     # In recent Python versions, we can retrieve the code of lambdas,
     # thus nothing is raised
-    assert len(recwarn) == 4
+    assert len(warninfo) == 4
 
 
-def test_memory_warning_collision_detection(tmpdir, recwarn):
+def test_memory_warning_collision_detection(tmpdir):
     # Check that collisions impossible to detect will raise appropriate
     # warnings.
     memory = Memory(cachedir=tmpdir.strpath, verbose=0)
     # For isolation with other tests
-    memory.clear(warn=False)
-
+    memory.clear()
     a1 = eval('lambda x: x')
     a1 = memory.cache(a1)
     b1 = eval('lambda x: x+1')
     b1 = memory.cache(b1)
 
-    a1(1)
-    b1(1)
-    a1(0)
+    with warns(JobLibCollisionWarning) as warninfo:
+        a1(1)
+        b1(1)
+        a1(0)
 
-    assert len(recwarn) == 2
-    w = recwarn.pop(JobLibCollisionWarning)
-    assert "cannot detect" in str(w.message).lower()
+    assert len(warninfo) == 2
+    assert "cannot detect" in str(warninfo[-1].message).lower()
 
 
 def test_memory_partial(tmpdir):
@@ -561,11 +561,11 @@ def test_memory_in_memory_function_code_change(tmpdir):
     assert f(1, 2) == 3
     assert f(1, 2) == 3
 
-    # Check that inline function modification triggers a cache invalidation
-
-    _function_to_cache.__code__ = _product.__code__
-    assert f(1, 2) == 2
-    assert f(1, 2) == 2
+    with warns(JobLibCollisionWarning):
+        # Check that inline function modification triggers a cache invalidation
+        _function_to_cache.__code__ = _product.__code__
+        assert f(1, 2) == 2
+        assert f(1, 2) == 2
 
 
 def test_clear_memory_with_none_cachedir():

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -162,12 +162,12 @@ def test_memory_name_collision(tmpdir):
 
     b = name_collision
 
-    with warns(JobLibCollisionWarning) as warninfo:
+    with warns(JobLibCollisionWarning) as record:
         a(1)
         b(1)
 
-    assert len(warninfo) == 1
-    assert "collision" in str(warninfo[-1].message)
+    assert len(record) == 1
+    assert "collision" in str(record[0].message)
 
 
 def test_memory_warning_lambda_collisions(tmpdir):
@@ -180,14 +180,14 @@ def test_memory_warning_lambda_collisions(tmpdir):
     b = lambda x: x + 1
     b = memory.cache(b)
 
-    with warns(JobLibCollisionWarning) as warninfo:
+    with warns(JobLibCollisionWarning) as record:
         assert a(0) == 0
         assert b(1) == 2
         assert a(1) == 1
 
     # In recent Python versions, we can retrieve the code of lambdas,
     # thus nothing is raised
-    assert len(warninfo) == 4
+    assert len(record) == 4
 
 
 def test_memory_warning_collision_detection(tmpdir):
@@ -201,13 +201,13 @@ def test_memory_warning_collision_detection(tmpdir):
     b1 = eval('lambda x: x+1')
     b1 = memory.cache(b1)
 
-    with warns(JobLibCollisionWarning) as warninfo:
+    with warns(JobLibCollisionWarning) as record:
         a1(1)
         b1(1)
         a1(0)
 
-    assert len(warninfo) == 2
-    assert "cannot detect" in str(warninfo[-1].message).lower()
+    assert len(record) == 2
+    assert "cannot detect" in str(record[0].message).lower()
 
 
 def test_memory_partial(tmpdir):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -173,12 +173,12 @@ def test_memory_warning_lambda_collisions(tmpdir, recwarn):
     # Check that multiple use of lambda will raise collisions
     memory = Memory(cachedir=tmpdir.strpath, verbose=0)
     # For isolation with other tests
-    memory.clear()
+    memory.clear(warn=False)
+
     a = lambda x: x
     a = memory.cache(a)
     b = lambda x: x + 1
     b = memory.cache(b)
-
 
     assert a(0) == 0
     assert b(1) == 2
@@ -194,7 +194,8 @@ def test_memory_warning_collision_detection(tmpdir, recwarn):
     # warnings.
     memory = Memory(cachedir=tmpdir.strpath, verbose=0)
     # For isolation with other tests
-    memory.clear()
+    memory.clear(warn=False)
+
     a1 = eval('lambda x: x')
     a1 = memory.cache(a1)
     b1 = eval('lambda x: x+1')

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -162,12 +162,12 @@ def test_memory_name_collision(tmpdir):
 
     b = name_collision
 
-    with warns(JobLibCollisionWarning) as record:
+    with warns(JobLibCollisionWarning) as warninfo:
         a(1)
         b(1)
 
-    assert len(record) == 1
-    assert "collision" in str(record[0].message)
+    assert len(warninfo) == 1
+    assert "collision" in str(warninfo[0].message)
 
 
 def test_memory_warning_lambda_collisions(tmpdir):
@@ -180,14 +180,14 @@ def test_memory_warning_lambda_collisions(tmpdir):
     b = lambda x: x + 1
     b = memory.cache(b)
 
-    with warns(JobLibCollisionWarning) as record:
+    with warns(JobLibCollisionWarning) as warninfo:
         assert a(0) == 0
         assert b(1) == 2
         assert a(1) == 1
 
     # In recent Python versions, we can retrieve the code of lambdas,
     # thus nothing is raised
-    assert len(record) == 4
+    assert len(warninfo) == 4
 
 
 def test_memory_warning_collision_detection(tmpdir):
@@ -201,13 +201,13 @@ def test_memory_warning_collision_detection(tmpdir):
     b1 = eval('lambda x: x+1')
     b1 = memory.cache(b1)
 
-    with warns(JobLibCollisionWarning) as record:
+    with warns(JobLibCollisionWarning) as warninfo:
         a1(1)
         b1(1)
         a1(0)
 
-    assert len(record) == 2
-    assert "cannot detect" in str(record[0].message).lower()
+    assert len(warninfo) == 2
+    assert "cannot detect" in str(warninfo[0].message).lower()
 
 
 def test_memory_partial(tmpdir):

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -290,10 +290,10 @@ def test_compress_mmap_mode_warning(tmpdir):
     a = rnd.random_sample(10)
     this_filename = tmpdir.join('test.pkl').strpath
     numpy_pickle.dump(a, this_filename, compress=1)
-    with warns(UserWarning) as record:
+    with warns(UserWarning) as warninfo:
         numpy_pickle.load(this_filename, mmap_mode='r+')
-    assert len(record) == 1
-    assert (str(record[0].message) ==
+    assert len(warninfo) == 1
+    assert (str(warninfo[0].message) ==
             'mmap_mode "%(mmap_mode)s" is not compatible with compressed '
             'file %(filename)s. "%(mmap_mode)s" flag will be ignored.' %
             {'filename': this_filename, 'mmap_mode': 'r+'})
@@ -308,11 +308,11 @@ def test_cache_size_warning(tmpdir):
 
     for cache_size in (None, 0, 10):
         warnings.simplefilter("always")
-        with warns(None) as record:
+        with warns(None) as warninfo:
             numpy_pickle.dump(a, filename, cache_size=cache_size)
         expected_nb_warnings = 1 if cache_size is not None else 0
-        assert len(record) == expected_nb_warnings
-        for w in record:
+        assert len(warninfo) == expected_nb_warnings
+        for w in warninfo:
             assert w.category == DeprecationWarning
             assert (str(w.message) ==
                     "Please do not set 'cache_size' in joblib.dump, this "
@@ -403,7 +403,7 @@ def _check_pickle(filename, expected_list):
         py_version_used_for_writing, 4)
     if pickle_reading_protocol >= pickle_writing_protocol:
         try:
-            with warns(None) as record:
+            with warns(None) as warninfo:
                 warnings.simplefilter('always')
                 warnings.filterwarnings(
                     'ignore', module='numpy',
@@ -412,8 +412,8 @@ def _check_pickle(filename, expected_list):
             filename_base = os.path.basename(filename)
             expected_nb_warnings = 1 if ("_0.9" in filename_base or
                                          "_0.8.4" in filename_base) else 0
-            assert len(record) == expected_nb_warnings
-            for w in record:
+            assert len(warninfo) == expected_nb_warnings
+            for w in warninfo:
                 assert w.category == DeprecationWarning
                 assert (str(w.message) ==
                         "The file '{0}' has been generated with a joblib "
@@ -692,10 +692,10 @@ def test_file_handle_persistence_compressed_mmap(tmpdir):
         numpy_pickle.dump(obj, f, compress=('gzip', 3))
 
     with closing(gzip.GzipFile(filename, 'rb')) as f:
-        with warns(UserWarning) as record:
+        with warns(UserWarning) as warninfo:
             numpy_pickle.load(f, mmap_mode='r+')
-        assert len(record) == 1
-        assert (str(record[0].message) ==
+        assert len(warninfo) == 1
+        assert (str(warninfo[0].message) ==
                 '"%(fileobj)r" is not a raw file, mmap_mode "%(mmap_mode)s" '
                 'flag will be ignored.' % {'fileobj': f, 'mmap_mode': 'r+'})
 
@@ -707,10 +707,10 @@ def test_file_handle_persistence_in_memory_mmap():
 
     numpy_pickle.dump(obj, buf)
 
-    with warns(UserWarning) as record:
+    with warns(UserWarning) as warninfo:
         numpy_pickle.load(buf, mmap_mode='r+')
-    assert len(record) == 1
-    assert (str(record[0].message) ==
+    assert len(warninfo) == 1
+    assert (str(warninfo[0].message) ==
             'In memory persistence is not compatible with mmap_mode '
             '"%(mmap_mode)s" flag passed. mmap_mode option will be '
             'ignored.' % {'mmap_mode': 'r+'})

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -290,10 +290,10 @@ def test_compress_mmap_mode_warning(tmpdir):
     a = rnd.random_sample(10)
     this_filename = tmpdir.join('test.pkl').strpath
     numpy_pickle.dump(a, this_filename, compress=1)
-    with warns(UserWarning) as warninfo:
+    with warns(UserWarning) as record:
         numpy_pickle.load(this_filename, mmap_mode='r+')
-    assert len(warninfo) == 1
-    assert (str(warninfo[-1].message) ==
+    assert len(record) == 1
+    assert (str(record[0].message) ==
             'mmap_mode "%(mmap_mode)s" is not compatible with compressed '
             'file %(filename)s. "%(mmap_mode)s" flag will be ignored.' %
             {'filename': this_filename, 'mmap_mode': 'r+'})
@@ -308,11 +308,11 @@ def test_cache_size_warning(tmpdir):
 
     for cache_size in (None, 0, 10):
         warnings.simplefilter("always")
-        with warns(None) as warninfo:
+        with warns(None) as record:
             numpy_pickle.dump(a, filename, cache_size=cache_size)
         expected_nb_warnings = 1 if cache_size is not None else 0
-        assert len(warninfo) == expected_nb_warnings
-        for w in warninfo:
+        assert len(record) == expected_nb_warnings
+        for w in record:
             assert w.category == DeprecationWarning
             assert (str(w.message) ==
                     "Please do not set 'cache_size' in joblib.dump, this "
@@ -403,17 +403,17 @@ def _check_pickle(filename, expected_list):
         py_version_used_for_writing, 4)
     if pickle_reading_protocol >= pickle_writing_protocol:
         try:
-            warnings.simplefilter('always')
-            warnings.filterwarnings(
-                'ignore', module='numpy',
-                message='The compiler package is deprecated')
-            with warns(None) as warninfo:
+            with warns(None) as record:
+                warnings.simplefilter('always')
+                warnings.filterwarnings(
+                    'ignore', module='numpy',
+                    message='The compiler package is deprecated')
                 result_list = numpy_pickle.load(filename)
-                filename_base = os.path.basename(filename)
+            filename_base = os.path.basename(filename)
             expected_nb_warnings = 1 if ("_0.9" in filename_base or
                                          "_0.8.4" in filename_base) else 0
-            assert len(warninfo) == expected_nb_warnings
-            for w in warninfo:
+            assert len(record) == expected_nb_warnings
+            for w in record:
                 assert w.category == DeprecationWarning
                 assert (str(w.message) ==
                         "The file '{0}' has been generated with a joblib "
@@ -692,10 +692,10 @@ def test_file_handle_persistence_compressed_mmap(tmpdir):
         numpy_pickle.dump(obj, f, compress=('gzip', 3))
 
     with closing(gzip.GzipFile(filename, 'rb')) as f:
-        with warns(UserWarning) as warninfo:
+        with warns(UserWarning) as record:
             numpy_pickle.load(f, mmap_mode='r+')
-        assert len(warninfo) == 1
-        assert (str(warninfo[-1].message) ==
+        assert len(record) == 1
+        assert (str(record[0].message) ==
                 '"%(fileobj)r" is not a raw file, mmap_mode "%(mmap_mode)s" '
                 'flag will be ignored.' % {'fileobj': f, 'mmap_mode': 'r+'})
 
@@ -707,10 +707,10 @@ def test_file_handle_persistence_in_memory_mmap():
 
     numpy_pickle.dump(obj, buf)
 
-    with warns(UserWarning) as warninfo:
+    with warns(UserWarning) as record:
         numpy_pickle.load(buf, mmap_mode='r+')
-    assert len(warninfo) == 1
-    assert (str(warninfo[-1].message) ==
+    assert len(record) == 1
+    assert (str(record[0].message) ==
             'In memory persistence is not compatible with mmap_mode '
             '"%(mmap_mode)s" flag passed. mmap_mode option will be '
             'ignored.' % {'mmap_mode': 'r+'})

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -148,14 +148,14 @@ def test_simple_parallel():
 
 
 def check_main_thread_renamed_no_warning(backend):
-    with warns(None) as record:
+    with warns(None) as warninfo:
         results = Parallel(n_jobs=2, backend=backend)(
             delayed(square)(x) for x in range(3))
         assert results == [0, 1, 4]
     # The multiprocessing backend will raise a warning when detecting that is
     # started from the non-main thread. Let's check that there is no false
     # positive because of the name change.
-    assert len(record) == 0
+    assert len(warninfo) == 0
 
 
 def test_main_thread_renamed_no_warning():

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -148,14 +148,14 @@ def test_simple_parallel():
 
 
 def check_main_thread_renamed_no_warning(backend):
-    with warns(None) as warninfo:
+    with warns(None) as record:
         results = Parallel(n_jobs=2, backend=backend)(
             delayed(square)(x) for x in range(3))
         assert results == [0, 1, 4]
     # The multiprocessing backend will raise a warning when detecting that is
     # started from the non-main thread. Let's check that there is no false
     # positive because of the name change.
-    assert len(warninfo) == 0
+    assert len(record) == 0
 
 
 def test_main_thread_renamed_no_warning():

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -18,7 +18,7 @@ from joblib import parallel
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_multiprocessing
-from joblib.testing import raises, check_subprocess_call, SkipTest
+from joblib.testing import raises, check_subprocess_call, SkipTest, warns
 from joblib._compat import PY3_OR_LATER
 
 try:
@@ -147,17 +147,18 @@ def test_simple_parallel():
         check_simple_parallel(backend)
 
 
-def check_main_thread_renamed_no_warning(backend, recwarn):
-    results = Parallel(n_jobs=2, backend=backend)(
-        delayed(square)(x) for x in range(3))
-    assert results == [0, 1, 4]
+def check_main_thread_renamed_no_warning(backend):
+    with warns(None) as warninfo:
+        results = Parallel(n_jobs=2, backend=backend)(
+            delayed(square)(x) for x in range(3))
+        assert results == [0, 1, 4]
     # The multiprocessing backend will raise a warning when detecting that is
     # started from the non-main thread. Let's check that there is no false
     # positive because of the name change.
-    assert len(recwarn) == 0
+    assert len(warninfo) == 0
 
 
-def test_main_thread_renamed_no_warning(recwarn):
+def test_main_thread_renamed_no_warning():
     # Check that no default backend relies on the name of the main thread:
     # https://github.com/joblib/joblib/issues/180#issuecomment-253266247
     # Some programs use a different name for the main thread. This is the case
@@ -167,7 +168,7 @@ def test_main_thread_renamed_no_warning(recwarn):
     try:
         main_thread.name = "some_new_name_for_the_main_thread"
         for backend in ALL_VALID_BACKENDS:
-            check_main_thread_renamed_no_warning(backend, recwarn)
+            check_main_thread_renamed_no_warning(backend)
     finally:
         main_thread.name = original_name
 

--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -16,6 +16,7 @@ from joblib._compat import PY3_OR_LATER
 
 
 raises = pytest.raises
+warns = pytest.warns
 SkipTest = _pytest.runner.Skipped
 skipif = pytest.mark.skipif
 fixture = pytest.fixture


### PR DESCRIPTION
#### Fourth Phase PR on #411 ( Succeeding PR #464 )

This PR uses `with pytest.warns` blocks (initially planned `recwarn` fixture of pytest) to record raised warnings in a particular test and assert warning messages, instead of `with warning.catch_warnings` blocks.

#### Reference: http://doc.pytest.org/en/latest/recwarn.html