### PR TITLE
[MRG] Refactor test_memory.py as per pytest design.

### DIFF
--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -545,6 +545,14 @@ def test_memory_in_memory_function_code_change(memory):
 def test_clear_memory_with_none_cachedir(no_memoize_memory):
     no_memoize_memory.clear()
 
+
+def func_with_kwonly_args(a, b, kw1='kw1', kw2='kw2'):
+    pass
+
+
+def func_with_signature(a, b):
+    pass
+
 if PY3_OR_LATER:
     exec("""
 def func_with_kwonly_args(a, b, *, kw1='kw1', kw2='kw2'):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -516,6 +516,7 @@ def test_memory_file_modification(capsys, tmpdir, monkeypatch):
 
     # Now reload
     sys.stdout.write('Reloading\n')
+    sys.modules.pop('tmp_joblib_')
     import tmp_joblib_ as tmp
     f = memory.cache(tmp.f)
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -562,13 +562,6 @@ def test_clear_memory_with_none_cachedir():
     memory.clear()
 
 
-def func_with_kwonly_args(a, b, kw1='kw1', kw2='kw2'):
-    pass
-
-
-def func_with_signature(a, b):
-    pass
-
 if PY3_OR_LATER:
     exec("""
 def func_with_kwonly_args(a, b, *, kw1='kw1', kw2='kw2'):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -275,11 +275,9 @@ def test_memory_numpy(memory, mmap_mode):
 
 
 @with_numpy
-def test_memory_numpy_check_mmap_mode(tmpdir):
+def test_memory_numpy_check_mmap_mode(memory):
     """Check that mmap_mode is respected even at the first call"""
-
-    memory = Memory(cachedir=tmpdir.strpath, mmap_mode='r', verbose=0)
-    memory.clear(warn=False)
+    memory.mmap_mode = 'r'
 
     @memory.cache()
     def twice(a):
@@ -335,20 +333,17 @@ def test_memory_ignore(memory):
     assert len(accumulator) == 1
 
 
-def test_partial_decoration(memory):
+@parametrize('ignore, verbose, mmap_mode', [(['x'], 100, 'r'),
+                                            ([], 10, None)])
+def test_partial_decoration(memory, ignore, verbose, mmap_mode):
     "Check cache may be called with kwargs before decorating"
-    test_values = [
-        (['x'], 100, 'r'),
-        ([], 10, None),
-    ]
-    for ignore, verbose, mmap_mode in test_values:
-        @memory.cache(ignore=ignore, verbose=verbose, mmap_mode=mmap_mode)
-        def z(x):
-            pass
+    @memory.cache(ignore=ignore, verbose=verbose, mmap_mode=mmap_mode)
+    def z(x):
+        pass
 
-        assert z.ignore == ignore
-        assert z._verbose == verbose
-        assert z.mmap_mode == mmap_mode
+    assert z.ignore == ignore
+    assert z._verbose == verbose
+    assert z.mmap_mode == mmap_mode
 
 
 def test_func_dir(tmpdir, memory):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -613,9 +613,9 @@ def func_with_signature(a: int, b: float) -> float:
 
 
 def _setup_toy_cache(tmpdir, num_inputs=10):
-    mem = Memory(cachedir=tmpdir.strpath, verbose=0)
+    memory = Memory(cachedir=tmpdir.strpath, verbose=0)
 
-    @mem.cache()
+    @memory.cache()
     def get_1000_bytes(arg):
         return 'a' * 1000
 
@@ -627,7 +627,7 @@ def _setup_toy_cache(tmpdir, num_inputs=10):
 
     full_hashdirs = [os.path.join(get_1000_bytes.cachedir, dirname)
                      for dirname in hash_dirnames]
-    return mem, full_hashdirs, get_1000_bytes
+    return memory, full_hashdirs, get_1000_bytes
 
 
 def test__get_cache_items(tmpdir):
@@ -697,7 +697,7 @@ def test_memory_reduce_size(tmpdir):
     cachedir = memory.cachedir
     ref_cache_items = _get_cache_items(cachedir)
 
-    # By default mem.bytes_limit is None and reduce_size is a noop
+    # By default memory.bytes_limit is None and reduce_size is a noop
     memory.reduce_size()
     cache_items = _get_cache_items(cachedir)
     assert sorted(ref_cache_items) == sorted(cache_items)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -20,7 +20,7 @@ from joblib.memory import _get_cache_items, _get_cache_items_to_delete
 from joblib.memory import _load_output, _get_func_fullname
 from joblib.memory import JobLibCollisionWarning
 from joblib.test.common import with_numpy, np
-from joblib.testing import fixture, parametrize, raises, warns
+from joblib.testing import parametrize, raises, warns
 from joblib._compat import PY3_OR_LATER
 
 
@@ -472,7 +472,7 @@ def test_memorized_repr(tmpdir):
     result.get()
 
 
-def test_memory_file_modification(capsys, tmpdir):
+def test_memory_file_modification(capsys, tmpdir, monkeypatch):
     # Test that modifying a Python file after loading it does not lead to
     # Recomputation
     dir_name = tmpdir.mkdir('tmp_import').strpath
@@ -482,7 +482,7 @@ def test_memory_file_modification(capsys, tmpdir):
         module_file.write(content)
 
     # Load the module:
-    sys.path.append(dir_name)
+    monkeypatch.syspath_prepend(dir_name)
     import tmp_joblib_ as tmp
 
     memory = Memory(cachedir=tmpdir.strpath, verbose=0)
@@ -516,7 +516,6 @@ def test_memory_file_modification(capsys, tmpdir):
 
     # Now reload
     sys.stdout.write('Reloading\n')
-    sys.modules.pop('tmp_joblib_')
     import tmp_joblib_ as tmp
     f = memory.cache(tmp.f)
 


### PR DESCRIPTION
#### Third Phase (Extended) PR on #411 ( Replacement of #460 , Succeeding #465 )

This PR deals with refactor of tests in **test_memory.py** to adopt the pytest flavor.

* Create two new fixtures `memory` and `no_memoize_memory` as they are used by almost all of the tests.
* Remove memory clearing calls at certain places, because earlier temporary directory was created / destroyed manually. Now pytest's tmpdir already ensures isolation with other tests.
 * Parametrize tests wherever it seems straightforward.