### PR TITLE
[MRG] Perform parametrization on certain tests of test_parallel.py

### DIFF
--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -169,15 +169,11 @@ def nested_loop(backend):
         delayed(square)(.01) for _ in range(2))
 
 
-def check_nested_loop(parent_backend, child_backend):
+@parametrize('parent_backend', BACKENDS)
+@parametrize('child_backend', BACKENDS)
+def test_nested_loop(parent_backend, child_backend):
     Parallel(n_jobs=2, backend=parent_backend)(
         delayed(nested_loop)(child_backend) for _ in range(2))
-
-
-def test_nested_loop():
-    for parent_backend in BACKENDS:
-        for child_backend in BACKENDS:
-            check_nested_loop(parent_backend, child_backend)
 
 
 def test_mutate_input_with_threads():
@@ -188,12 +184,12 @@ def test_mutate_input_with_threads():
     assert q.full()
 
 
-def test_parallel_kwargs():
+@parametrize('n_jobs', [1, 2, 3])
+def test_parallel_kwargs(n_jobs):
     """Check the keyword argument processing of pmap."""
     lst = range(10)
-    for n_jobs in (1, 4):
-        assert ([f(x, y=1) for x in lst] ==
-                Parallel(n_jobs=n_jobs)(delayed(f)(x, y=1) for x in lst))
+    assert ([f(x, y=1) for x in lst] ==
+            Parallel(n_jobs=n_jobs)(delayed(f)(x, y=1) for x in lst))
 
 
 def check_parallel_as_context_manager(backend):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -128,18 +128,12 @@ def test_effective_n_jobs():
 
 @parametrize('backend', ALL_VALID_BACKENDS)
 @parametrize('n_jobs', [1, 2, -1, -2])
-def test_simple_parallel(backend, n_jobs):
-    assert ([square(x) for x in range(5)] ==
-            Parallel(n_jobs=n_jobs, backend=backend)(
-                delayed(square)(x) for x in range(5)))
-
-
-@parametrize('backend', ALL_VALID_BACKENDS)
-@parametrize('n_jobs', [-1, 1, 2, 2])
 @parametrize('verbose', [2, 11, 100])
-def test_simple_parallel_verbose(n_jobs, verbose, backend):
-    Parallel(n_jobs=n_jobs, verbose=verbose, backend=backend)(
-        delayed(square)(x) for x in range(5))
+def test_simple_parallel(backend, n_jobs, verbose):
+    assert ([square(x) for x in range(5)] ==
+            Parallel(n_jobs=n_jobs, backend=backend,
+                     verbose=verbose)(
+                delayed(square)(x) for x in range(5)))
 
 
 @parametrize('backend', ALL_VALID_BACKENDS)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -145,7 +145,8 @@ def check_main_thread_renamed_no_warning(backend):
     assert len(warninfo) == 0
 
 
-def test_main_thread_renamed_no_warning():
+@parametrize('backend', ALL_VALID_BACKENDS)
+def test_main_thread_renamed_no_warning(backend):
     # Check that no default backend relies on the name of the main thread:
     # https://github.com/joblib/joblib/issues/180#issuecomment-253266247
     # Some programs use a different name for the main thread. This is the case
@@ -154,8 +155,14 @@ def test_main_thread_renamed_no_warning():
     original_name = main_thread.name
     try:
         main_thread.name = "some_new_name_for_the_main_thread"
-        for backend in ALL_VALID_BACKENDS:
-            check_main_thread_renamed_no_warning(backend)
+        with warns(None) as record:
+            results = Parallel(n_jobs=2, backend=backend)(
+                delayed(square)(x) for x in range(3))
+            assert results == [0, 1, 4]
+        # The multiprocessing backend will raise a warning when detecting that is
+        # started from the non-main thread. Let's check that there is no false
+        # positive because of the name change.
+        assert len(record) == 0
     finally:
         main_thread.name = original_name
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -192,7 +192,8 @@ def test_parallel_kwargs(n_jobs):
             Parallel(n_jobs=n_jobs)(delayed(f)(x, y=1) for x in lst))
 
 
-def check_parallel_as_context_manager(backend):
+@parametrize('backend', ['multiprocessing', 'threading'])
+def test_parallel_as_context_manager(backend):
     lst = range(10)
     expected = [f(x, y=1) for x in lst]
     with Parallel(n_jobs=4, backend=backend) as p:
@@ -223,11 +224,6 @@ def check_parallel_as_context_manager(backend):
         assert p._backend._pool is None
 
 
-def test_parallel_context_manager():
-    for backend in ['multiprocessing', 'threading']:
-        check_parallel_as_context_manager(backend)
-
-
 def test_parallel_pickling():
     """ Check that pmap captures the errors when it is passed an object
         that cannot be pickled.
@@ -247,20 +243,20 @@ def test_parallel_pickling():
         Parallel()(delayed(g)(x) for x in range(10))
 
 
-def test_parallel_timeout_success():
+@parametrize('backend', ['multiprocessing', 'threading'])
+def test_parallel_timeout_success(backend):
     # Check that timeout isn't thrown when function is fast enough
-    for backend in ['multiprocessing', 'threading']:
-        assert len(Parallel(n_jobs=2, backend=backend, timeout=10)(
-            delayed(sleep)(0.001) for x in range(10))) == 10
+    assert len(Parallel(n_jobs=2, backend=backend, timeout=10)(
+        delayed(sleep)(0.001) for x in range(10))) == 10
 
 
 @with_multiprocessing
-def test_parallel_timeout_fail():
+@parametrize('backend', ['multiprocessing', 'threading'])
+def test_parallel_timeout_fail(backend):
     # Check that timeout properly fails when function is too slow
-    for backend in ['multiprocessing', 'threading']:
-        with raises(TimeoutError):
-            Parallel(n_jobs=2, backend=backend, timeout=0.01)(
-                delayed(sleep)(10) for x in range(10))
+    with raises(TimeoutError):
+        Parallel(n_jobs=2, backend=backend, timeout=0.01)(
+            delayed(sleep)(10) for x in range(10))
 
 
 def test_error_capture():

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -18,7 +18,8 @@ from joblib import parallel
 
 from joblib.test.common import np, with_numpy
 from joblib.test.common import with_multiprocessing
-from joblib.testing import raises, check_subprocess_call, SkipTest, warns
+from joblib.testing import (parametrize, raises, check_subprocess_call,
+                            SkipTest, warns)
 from joblib._compat import PY3_OR_LATER
 
 try:
@@ -124,27 +125,13 @@ def test_effective_n_jobs():
 
 ###############################################################################
 # Test parallel
-def check_simple_parallel(backend):
-    X = range(5)
-    for n_jobs in (1, 2, -1, -2):
-        assert ([square(x) for x in X] ==
-                Parallel(n_jobs=n_jobs, backend=backend)(
-                    delayed(square)(x) for x in X))
-    for verbose in (2, 11, 100):
-        Parallel(n_jobs=-1, verbose=verbose, backend=backend)(
-            delayed(square)(x) for x in X)
-        Parallel(n_jobs=1, verbose=verbose, backend=backend)(
-            delayed(square)(x) for x in X)
-        Parallel(n_jobs=2, verbose=verbose, pre_dispatch=2,
-                 backend=backend)(
-            delayed(square)(x) for x in X)
-        Parallel(n_jobs=2, verbose=verbose, backend=backend)(
-            delayed(square)(x) for x in X)
 
-
-def test_simple_parallel():
-    for backend in ALL_VALID_BACKENDS:
-        check_simple_parallel(backend)
+@parametrize('backend', ALL_VALID_BACKENDS)
+@parametrize('n_jobs', [1, 2, -1, -2])
+def test_simple_parallel(backend, n_jobs):
+    assert ([square(x) for x in range(5)] ==
+            Parallel(n_jobs=n_jobs, backend=backend)(
+                delayed(square)(x) for x in range(5)))
 
 
 def check_main_thread_renamed_no_warning(backend):


### PR DESCRIPTION
#### Third Phase (Extended) PR on #411 ( Succeeding PR #466 )

A set of tests have been parametrized in a simple fashion. Certain tests used `try - final` blocks to register new backend and remove it later. But the test may misbehave if `register_parallel_backend` itself is broken. Also, there's a test for `register_parallel_backend` where this method itself is tested, while in some other tests, it is just a part of test setup.

Temporary changes like this (commonly known as **monkeypatching**) are undertaken through pytest's standard `monkeypatch` fixture. using it clearly states that the line written in test is just a part of setup for that particular test.

#### Reference: http://doc.pytest.org/en/latest/monkeypatch.html