### PR TITLE
[MRG] Perform parametrization on numpy pickle tests.

### DIFF
--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -33,7 +33,7 @@ def test_disk_used(tmpdir):
     assert disk_used(cachedir) < target_size + 12
 
 
-@parametrize('text, value',
+@parametrize('text,value',
              [('80G', 80 * 1024 ** 3),
               ('1.4M', int(1.4 * 1024 ** 2)),
               ('120M', 120 * 1024 ** 2),
@@ -42,7 +42,7 @@ def test_memstr_to_bytes(text, value):
     assert memstr_to_bytes(text) == value
 
 
-@parametrize('text, exception, regex',
+@parametrize('text,exception,regex',
              [('fooG', ValueError, r'Invalid literal for size.*fooG.*'),
               ('1.4N', ValueError, r'Invalid literal for size.*1.4N.*')])
 def test_memstr_to_bytes_exception(text, exception, regex):

--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -33,7 +33,7 @@ def test_disk_used(tmpdir):
     assert disk_used(cachedir) < target_size + 12
 
 
-@parametrize(['text', 'value'],
+@parametrize('text, value',
              [('80G', 80 * 1024 ** 3),
               ('1.4M', int(1.4 * 1024 ** 2)),
               ('120M', 120 * 1024 ** 2),
@@ -42,7 +42,7 @@ def test_memstr_to_bytes(text, value):
     assert memstr_to_bytes(text) == value
 
 
-@parametrize(['text', 'exception', 'regex'],
+@parametrize('text, exception, regex',
              [('fooG', ValueError, r'Invalid literal for size.*fooG.*'),
               ('1.4N', ValueError, r'Invalid literal for size.*1.4N.*')])
 def test_memstr_to_bytes_exception(text, exception, regex):

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -119,7 +119,7 @@ def test_filter_args_2():
 
 
 @parametrize('func,funcname', [(f, 'f'), (g, 'g'),
-                                (cached_func, 'cached_func')])
+                               (cached_func, 'cached_func')])
 def test_func_name(func, funcname):
     # Check that we are not confused by decoration
     # here testcase 'cached_func' is the function itself

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -67,7 +67,7 @@ class Klass(object):
 # Tests
 
 
-@parametrize('func, args, filtered_args',
+@parametrize('func,args,filtered_args',
              [(f, [[], (1, )], {'x': 1, 'y': 0}),
               (f, [['x'], (1, )], {'y': 0}),
               (f, [['y'], (0, )], {'x': 0}),
@@ -86,7 +86,7 @@ def test_filter_args_method():
     assert filter_args(obj.f, [], (1, )) == {'x': 1, 'self': obj}
 
 
-@parametrize('func, args, filtered_args',
+@parametrize('func,args,filtered_args',
              [(h, [[], (1, )],
                {'x': 1, 'y': 0, '*': [], '**': {}}),
               (h, [[], (1, 2, 3, 4)],
@@ -99,7 +99,7 @@ def test_filter_varargs(func, args, filtered_args):
     assert filter_args(func, *args) == filtered_args
 
 
-@parametrize('func, args, filtered_args',
+@parametrize('func,args,filtered_args',
              [(k, [[], (1, 2), {'ee': 2}],
                {'*': [1, 2], '**': {'ee': 2}}),
               (k, [[], (3, 4)],
@@ -118,7 +118,7 @@ def test_filter_args_2():
     assert filter_args(ff, ['y'], (1, )) == {'*': [1], '**': {}}
 
 
-@parametrize('func, funcname', [(f, 'f'), (g, 'g'),
+@parametrize('func,funcname', [(f, 'f'), (g, 'g'),
                                 (cached_func, 'cached_func')])
 def test_func_name(func, funcname):
     # Check that we are not confused by decoration
@@ -190,7 +190,7 @@ def test_bound_methods():
     assert filter_args(a.f, [], (1, )) != filter_args(b.f, [], (1, ))
 
 
-@parametrize('exception, regex, func, args',
+@parametrize('exception,regex,func,args',
              [(ValueError, 'ignore_lst must be a list of parameters to ignore',
                f, ['bar', (None, )]),
               (ValueError, 'Ignore list: argument \'(.*)\' is not defined',
@@ -213,7 +213,7 @@ def test_clean_win_chars():
         assert char not in mangled_string
 
 
-@parametrize('func, args, kwargs, sgn_expected',
+@parametrize('func,args,kwargs,sgn_expected',
              [(g, [list(range(5))], {}, 'g([0, 1, 2, 3, 4])'),
               (k, [1, 2, (3, 4)], {'y': True}, 'k(1, 2, (3, 4), y=True)')])
 def test_format_signature(func, args, kwargs, sgn_expected):

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -67,7 +67,7 @@ class Klass(object):
 # Tests
 
 
-@parametrize(['func', 'args', 'filtered_args'],
+@parametrize('func, args, filtered_args',
              [(f, [[], (1, )], {'x': 1, 'y': 0}),
               (f, [['x'], (1, )], {'y': 0}),
               (f, [['y'], (0, )], {'x': 0}),
@@ -86,7 +86,7 @@ def test_filter_args_method():
     assert filter_args(obj.f, [], (1, )) == {'x': 1, 'self': obj}
 
 
-@parametrize(['func', 'args', 'filtered_args'],
+@parametrize('func, args, filtered_args',
              [(h, [[], (1, )],
                {'x': 1, 'y': 0, '*': [], '**': {}}),
               (h, [[], (1, 2, 3, 4)],
@@ -99,7 +99,7 @@ def test_filter_varargs(func, args, filtered_args):
     assert filter_args(func, *args) == filtered_args
 
 
-@parametrize(['func', 'args', 'filtered_args'],
+@parametrize('func, args, filtered_args',
              [(k, [[], (1, 2), {'ee': 2}],
                {'*': [1, 2], '**': {'ee': 2}}),
               (k, [[], (3, 4)],
@@ -118,8 +118,8 @@ def test_filter_args_2():
     assert filter_args(ff, ['y'], (1, )) == {'*': [1], '**': {}}
 
 
-@parametrize(['func', 'funcname'], [(f, 'f'), (g, 'g'),
-                                    (cached_func, 'cached_func')])
+@parametrize('func, funcname', [(f, 'f'), (g, 'g'),
+                                (cached_func, 'cached_func')])
 def test_func_name(func, funcname):
     # Check that we are not confused by decoration
     # here testcase 'cached_func' is the function itself
@@ -190,14 +190,13 @@ def test_bound_methods():
     assert filter_args(a.f, [], (1, )) != filter_args(b.f, [], (1, ))
 
 
-@parametrize(['exception', 'regex', 'func', 'args'],
+@parametrize('exception, regex, func, args',
              [(ValueError, 'ignore_lst must be a list of parameters to ignore',
                f, ['bar', (None, )]),
               (ValueError, 'Ignore list: argument \'(.*)\' is not defined',
                g, [['bar'], (None, )]),
               (ValueError, 'Wrong number of arguments',
-               h, [[]])
-              ])
+               h, [[]])])
 def test_filter_args_error_msg(exception, regex, func, args):
     """ Make sure that filter_args returns decent error messages, for the
         sake of the user.
@@ -214,7 +213,7 @@ def test_clean_win_chars():
         assert char not in mangled_string
 
 
-@parametrize(['func', 'args', 'kwargs', 'sgn_expected'],
+@parametrize('func, args, kwargs, sgn_expected',
              [(g, [list(range(5))], {}, 'g([0, 1, 2, 3, 4])'),
               (k, [1, 2, (3, 4)], {'y': True}, 'k(1, 2, (3, 4), y=True)')])
 def test_format_signature(func, args, kwargs, sgn_expected):

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -342,7 +342,7 @@ def test_dtype():
     assert hash([a, c]) == hash([a, b])
 
 
-@parametrize('to_hash, expected',
+@parametrize('to_hash,expected',
              [('This is a string to hash',
                  {'py2': '80436ada343b0d79a99bfd8883a96e45',
                   'py3': '71b3f47df22cb19431d85d92d0b230b2'}),

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -777,7 +777,8 @@ def test_binary_zlibfile_bad_compression_levels(tmpdir, bad_value):
     filename = tmpdir.join('test.pkl').strpath
     with raises(ValueError) as excinfo:
         BinaryZlibFile(filename, 'wb', compresslevel=bad_value)
-    excinfo.match("compresslevel must be between an integer between 1 and 9")
+    excinfo.match("'compresslevel' must be an integer between 1 and 9. "
+                  "You provided 'compress_level={}'".format(bad_value))
 
 
 @parametrize('bad_mode', ['a', 'x', 'r', 'w', 1, 2])

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -495,7 +495,7 @@ def test_compress_tuple_argument(tmpdir, compress_tuple):
         assert _detect_compressor(f) == compress_tuple[0]
 
 
-@parametrize('compress_tuple, message',
+@parametrize('compress_tuple,message',
              [(('zlib', 3, 'extra'),        # wrong compress tuple
                'Compress argument tuple should contain exactly 2 elements'),
               (('wrong', 3),                # wrong compress method
@@ -561,7 +561,7 @@ def _zlib_file_decompress(source_filename, target_filename):
         fo.write(buf)
 
 
-@parametrize('extension, decompress',
+@parametrize('extension,decompress',
              [('.z', _zlib_file_decompress),
               ('.gz', _gzip_file_decompress)])
 def test_load_externally_decompressed_files(tmpdir, extension, decompress):
@@ -582,7 +582,7 @@ def test_load_externally_decompressed_files(tmpdir, extension, decompress):
     assert obj == obj_reloaded
 
 
-@parametrize('extension, cmethod',
+@parametrize('extension,cmethod',
              # valid compressor extensions
              [('.z', 'zlib'),
               ('.gz', 'gzip'),

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -785,7 +785,7 @@ def test_binary_zlibfile_invalid_modes(tmpdir, bad_mode):
     filename = tmpdir.join('test.pkl').strpath
     with raises(ValueError) as excinfo:
         BinaryZlibFile(filename, bad_mode)
-    excinfo.match("Invalid mode: {}".format(bad_mode))
+    excinfo.match("Invalid mode")
 
 
 @parametrize('bad_file', [1, (), {}])

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -777,8 +777,9 @@ def test_binary_zlibfile_bad_compression_levels(tmpdir, bad_value):
     filename = tmpdir.join('test.pkl').strpath
     with raises(ValueError) as excinfo:
         BinaryZlibFile(filename, 'wb', compresslevel=bad_value)
-    excinfo.match("'compresslevel' must be an integer between 1 and 9. "
-                  "You provided 'compress_level={}'".format(bad_value))
+    pattern = re.escape("'compresslevel' must be an integer between 1 and 9. "
+                        "You provided 'compresslevel={}'".format(bad_value))
+    excinfo.match(pattern)
 
 
 @parametrize('bad_mode', ['a', 'x', 'r', 'w', 1, 2])

--- a/joblib/test/test_numpy_pickle_utils.py
+++ b/joblib/test/test_numpy_pickle_utils.py
@@ -1,16 +1,11 @@
 from joblib import numpy_pickle_utils
+from joblib.testing import parametrize
 
 
-def test_binary_zlib_file(tmpdir):
+@parametrize('filename', ['test', u'test'])  # testing str and unicode names
+def test_binary_zlib_file(tmpdir, filename):
     """Testing creation of files depending on the type of the filenames."""
-    # Testing str filename.
     binary_file = numpy_pickle_utils.BinaryZlibFile(
-        tmpdir.join('test').strpath,
-        mode='wb')
-    binary_file.close()
-
-    # Testing unicode filename.
-    binary_file = numpy_pickle_utils.BinaryZlibFile(
-        tmpdir.join(u'test').strpath,
+        tmpdir.join(filename).strpath,
         mode='wb')
     binary_file.close()


### PR DESCRIPTION
#### Final PR on #411 ( Succeeding PR #469 )
#### Fixes #455 

This PR parametrizes tests from **test_numpy_pickle.py** and **test_numpy_pickle_utils.py**. Also, cosmetic changes in `@parametrization` decorators of **test_disk.py** and **test_func_inspect.py** have been included.

