### PR TITLE
MAINT: ignore .cache directory generated by py.test when a test failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ doc/CHANGES.rst
 doc/README.rst
 # Coverage report
 .coverage
+
+# py.test cache on failure
+.cache


### PR DESCRIPTION
When a test failed, py.test generates a .cache folder. This add it to .gitignore.