### PR TITLE
[MRG] add make option for computing coverage locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,7 @@ test:
 
 test-no-multiprocessing:
 	export JOBLIB_MULTIPROCESSING=0 && py.test joblib
+
+test-coverage:
+	py.test --cov-config .coveragerc --cov-report \
+		term-missing --cov=joblib joblib


### PR DESCRIPTION
Add helper Makefile `test-coverage` option for computing and displaying code coverage locally. The `--cov` option is provided by the pytest extension which has to be installed separately, for example using:
```
pip install pytest-cov
```
More information on [their website](http://pytest-cov.readthedocs.io/en/latest/readme.html)
