### PR TITLE
FIX: for function created in main, replicate the directory structure in cache

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -83,7 +83,7 @@ def _clean_win_chars(string):
         # In Python 3, quote is elsewhere
         import urllib.parse
         quote = urllib.parse.quote
-    for char in ('<', '>', '!', ':', '\\'):
+    for char in ('<', '>', '!', ':'):
         string = string.replace(char, quote(char))
     return string
 
@@ -128,6 +128,9 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
                 # will change with every new kernel instance. This hack
                 # always returns the same filename
                 parts[-1] = '__ipython-input__'
+            if os.name == 'nt':
+                # Remove ':' from drive letter
+                parts[0] = parts[0][:-1]
             filename = os.path.join(*parts)
             if filename.endswith('.py'):
                 filename = filename[:-3]

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -128,10 +128,10 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
                 # will change with every new kernel instance. This hack
                 # always returns the same filename
                 parts[-1] = '__ipython-input__'
-            filename = '-'.join(parts)
+            filename = os.path.join(*parts)
             if filename.endswith('.py'):
                 filename = filename[:-3]
-            module = module + '-' + filename
+            module = os.path.join(module, filename)
     module = module.split('.')
     if hasattr(func, 'func_name'):
         name = func.func_name

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -745,17 +745,18 @@ class MemorizedFunc(Logger):
         return output, metadata
 
     # Make public
-    def _persist_output(self, output, dir):
+    def _persist_output(self, output, output_dir):
         """ Persist the given output tuple in the directory.
         """
         try:
-            mkdirp(dir)
-            filename = os.path.join(dir, 'output.pkl')
+            mkdirp(output_dir)
+            filename = os.path.join(output_dir, 'output.pkl')
             numpy_pickle.dump(output, filename, compress=self.compress)
             if self._verbose > 10:
-                print('Persisting in %s' % dir)
-        except OSError:
-            " Race condition in the creation of the directory "
+                print('Persisting in %s' % output_dir)
+        except OSError as e:
+            " Race condition in the creation of the directory, "
+            "{}".format(e)
 
     def _persist_input(self, output_dir, duration, args, kwargs,
                        this_duration_limit=0.5):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -757,4 +757,4 @@ def test_memory_with_function_defined_in_main(tmpdir, subdirs):
     func_code_filename.write(code, ensure=True)
 
     check_subprocess_call([sys.executable, func_code_filename.strpath],
-                          stdout_regex='^executing myfunc$')
+                          stdout_regex='^executing myfunc\s$')

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -739,8 +739,8 @@ def test_memory_with_function_defined_in_main(tmpdir, subdirs):
     func_code_filename = tmpdir.join(*subdirs).join('test.py')
 
     if len(func_code_filename.strpath) > 260 and posix is None:
-        # Test is akward on Windows because of the 260 characters limit for
-        # the full pathname
+        # Test is awkward on Windows because of the 260 characters
+        # limit for the full pathname
         raise SkipTest('Skipping on Windows')
 
     code = '\n\n'.join([


### PR DESCRIPTION
Should fix #482 

The idea is to replicate the directory structure of a function called in __main__ in the cache instead of building a single directory from the full path. For deep directories tree, the previous strategy could create a long path name.