### PR TITLE
[MRG] Cache: add extra folder level based on func code hash

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -72,11 +72,6 @@ def extract_first_line(func_code):
     return func_code, first_line
 
 
-class JobLibCollisionWarning(UserWarning):
-    """ Warn that there might be a collision between names of functions.
-    """
-
-
 def _get_func_fullname(func):
     """Compute the part of part associated with a function.
 
@@ -675,43 +670,8 @@ class MemorizedFunc(Logger):
         # We have differing code, is this because we are referring to
         # different functions, or because the function we are referring to has
         # changed?
-
         _, func_name = get_func_name(self.func, resolv_alias=False,
                                      win_characters=False)
-        if old_first_line == first_line == -1 or func_name == '<lambda>':
-            if not first_line == -1:
-                func_description = '%s (%s:%i)' % (func_name,
-                                                source_file, first_line)
-            else:
-                func_description = func_name
-            warnings.warn(JobLibCollisionWarning(
-                "Cannot detect name collisions for function '%s'"
-                        % func_description), stacklevel=stacklevel)
-
-        # Fetch the code at the old location and compare it. If it is the
-        # same than the code store, we have a collision: the code in the
-        # file has not changed, but the name we have is pointing to a new
-        # code block.
-        if not old_first_line == first_line and source_file is not None:
-            possible_collision = False
-            if os.path.exists(source_file):
-                _, func_name = get_func_name(self.func, resolv_alias=False)
-                num_lines = len(func_code.split('\n'))
-                with open_py_source(source_file) as f:
-                    on_disk_func_code = f.readlines()[
-                        old_first_line - 1:old_first_line - 1 + num_lines - 1]
-                on_disk_func_code = ''.join(on_disk_func_code)
-                possible_collision = (on_disk_func_code.rstrip()
-                                      == old_func_code.rstrip())
-            else:
-                possible_collision = source_file.startswith('<doctest ')
-            if possible_collision:
-                warnings.warn(JobLibCollisionWarning(
-                        'Possible name collisions between functions '
-                        "'%s' (%s:%i) and '%s' (%s:%i)" %
-                        (func_name, source_file, old_first_line,
-                        func_name, source_file, first_line)),
-                                stacklevel=stacklevel)
 
         # The function has changed, wipe the cache directory.
         # XXX: Should be using warnings, and giving stacklevel

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -549,13 +549,11 @@ def test_memory_in_memory_function_code_change(tmpdir):
     assert f(1, 2) == 3
     assert f(1, 2) == 3
 
-    with warns(None) as warninfo:
+    with warns(None):
         # Check that inline function modification triggers a cache invalidation
         _function_to_cache.__code__ = _product.__code__
         assert f(1, 2) == 2
         assert f(1, 2) == 2
-
-    assert len(warninfo) == 0
 
 
 def test_clear_memory_with_none_cachedir():


### PR DESCRIPTION
This is a first attempt to add another directory level in the cache using a hash of the function code. The location of the result output now follows that pattern:
```
<cache_dir>/joblib/<func_full_name>/<func_code_hash>/<func_parameters_hash>/output.pkl
```

This PR is still WIP as the cache invalidation is not fully completed: we want to remove all cache for a given function name for any code change. With the actual implementation, any result cached for a given 2-uple {func_code, parameters} is kept (in separate locations) and that would lead to large cache size increase for any code change.