### PR TITLE
[MRG] ENH Don't print very long args/kwargs

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -530,9 +530,9 @@ class MemorizedFunc(Logger):
                 # XXX: Should use an exception logger
                 _, func_name = get_func_name(self.func)
                 args_kwargs = 'args=%s, kwargs=%s' % (args, kwargs)
-                if len(args_kwargs) > 100 and verbose < 50:
+                if len(args_kwargs) > 100 and self._verbose < 50:
                     # Truncate huge args_kwargs list
-                    args_kwargs = args_kwargs[:100] + '...'
+                    args_kwargs = args_kwargs[: 100] + '...'
                 self.warn('Exception while loading results for '
                           '%s (%s)\n %s' %
                           (func_name, args_kwargs, traceback.format_exc()))

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -531,8 +531,8 @@ class MemorizedFunc(Logger):
                 _, func_name = get_func_name(self.func)
                 args_kwargs = 'args=%s, kwargs=%s' % (args, kwargs)
                 if len(args_kwargs) > 100:
-                    args_kwargs = ('...(args, kwargs too long; '
-                                   'suppressed for brevity)...')
+                    # Truncate huge args_kwargs list
+                    args_kwargs = args_kwargs[:100] + '...'
                 self.warn('Exception while loading results for '
                           '%s (%s)\n %s' %
                           (func_name, args_kwargs, traceback.format_exc()))

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -530,7 +530,7 @@ class MemorizedFunc(Logger):
                 # XXX: Should use an exception logger
                 _, func_name = get_func_name(self.func)
                 args_kwargs = 'args=%s, kwargs=%s' % (args, kwargs)
-                if len(args_kwargs) > 100:
+                if len(args_kwargs) > 100 and verbose < 50:
                     # Truncate huge args_kwargs list
                     args_kwargs = args_kwargs[:100] + '...'
                 self.warn('Exception while loading results for '

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -528,10 +528,14 @@ class MemorizedFunc(Logger):
                     print(max(0, (80 - len(msg))) * '_' + msg)
             except Exception:
                 # XXX: Should use an exception logger
+                _, func_name = get_func_name(self.func)
+                args_kwargs = 'args=%s, kwargs=%s' % (args, kwargs)
+                if len(args_kwargs) > 100:
+                    args_kwargs = ('...(args, kwargs too long; '
+                                   'suppressed for brevity)...')
                 self.warn('Exception while loading results for '
-                          '(args=%s, kwargs=%s)\n %s' %
-                          (args, kwargs, traceback.format_exc()))
-
+                          '%s (%s)\n %s' %
+                          (func_name, args_kwargs, traceback.format_exc()))
                 out, metadata = self.call(*args, **kwargs)
                 argument_hash = None
         return (out, argument_hash, metadata)


### PR DESCRIPTION
This avoids very long warning messages like what you get here at https://github.com/scikit-learn/scikit-learn/pull/7990#issuecomment-276998684

@ogrisel @lesteve 