### PR TITLE
[MRG] Use Python 3.5 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
 install:
@@ -19,7 +19,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   # Install the build and runtime dependencies of the project.
-  - "pip install --trusted-host 28daf2247a33ed269873-7b1aad3fab3cc330e1fd9d109892382a.r6.cf2.rackcdn.com -r appveyor/requirements.txt"
+  - "pip install -r appveyor/requirements.txt"
   - "python setup.py bdist_wheel"
   - ps: "ls dist"
 

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -96,7 +96,7 @@ function InstallPip ($python_home) {
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -eq "3.4") {
+    if ($python_version -eq "3.5") {
         $filename = "Miniconda3-3.5.5-Windows-" + $platform_suffix + ".exe"
     } else {
         $filename = "Miniconda-3.5.5-Windows-" + $platform_suffix + ".exe"

--- a/appveyor/requirements.txt
+++ b/appveyor/requirements.txt
@@ -1,6 +1,3 @@
---find-links http://28daf2247a33ed269873-7b1aad3fab3cc330e1fd9d109892382a.r6.cf2.rackcdn.com/
-# force numpy version to use the wheel hosted on rackspace instead of
-# tarball from PyPI
-numpy==1.9.2
+numpy
 wheel
 pytest


### PR DESCRIPTION
Also use the wheels on PyPI rather than on rackspace.