### PR TITLE
[MRG] turn warnings into error in the doc generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     # NUMPY_VERSION not set means numpy is not installed
     - PYTHON_VERSION="3.4" COVERAGE="true"
     - PYTHON_VERSION="3.5" NUMPY_VERSION="1.10"
-    - PYTHON_VERSION="3.6" NUMPY_VERSION="1.11" COVERAGE="true"
+    - PYTHON_VERSION="3.6" NUMPY_VERSION="1.11" COVERAGE="true" BUILD_DOC="true"
     # multiprocesssing disabled via the JOBLIB_MULTIPROCESSING environment variable
     - PYTHON_VERSION="3.6" NUMPY_VERSION="1.11" JOBLIB_MULTIPROCESSING=0 COVERAGE="true"
     # flake8 linting on diff wrt common ancestor with upstream/master

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -84,4 +84,8 @@ if [[ "$COVERAGE" == "true" ]]; then
     pip install pytest-cov codecov
 fi
 
+if [[ "$BUILD_DOC" == "true" ]]; then
+    python setup.py build_sphinx
+fi
+
 python setup.py install

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -237,3 +237,5 @@ except IOError:
     # directory
 
 numpydoc_show_class_members = False
+
+suppress_warnings = ['image.nonlocal_uri']

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,6 @@ ignore=E402
 
 [metadata]
 license_file = LICENSE.txt
+
+[build_sphinx]
+warning-is-error = 1


### PR DESCRIPTION
* ignore "nonlocal image URI found"
* add doc generation in one of the Travis build

I had to fix a few warnings before the release and it would be great to do this incrementally on each PR instead.