### PR TITLE
[MRG] Fix AppVeyor test exit code

### DIFF
--- a/continuous_integration/appveyor/test.ps1
+++ b/continuous_integration/appveyor/test.ps1
@@ -4,3 +4,4 @@ echo "joblib found in: $installed_joblib_folder"
 # --pyargs argument is used to make sure we run the tests on the
 # installed package rather than on the local folder
 pytest --pyargs joblib --cov $installed_joblib_folder
+exit $LastExitCode

--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -59,3 +59,7 @@ def test_mkdirp(tmpdir):
     # Not all OSErrors are ignored
     with raises(OSError):
         mkdirp('')
+
+
+def test_fail():
+    assert 2 == 1

--- a/joblib/test/test_disk.py
+++ b/joblib/test/test_disk.py
@@ -59,7 +59,3 @@ def test_mkdirp(tmpdir):
     # Not all OSErrors are ignored
     with raises(OSError):
         mkdirp('')
-
-
-def test_fail():
-    assert 2 == 1

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -826,6 +826,10 @@ def test_memory_recomputes_after_an_error_why_loading_results(tmpdir,
     memory = Memory(tmpdir.strpath)
 
     def func(arg):
+        # This makes sure that the timestamp returned by two calls of
+        # func are different. This is needed on Windows where
+        # time.time resolution may not be accurate enough
+        time.sleep(0.01)
         return arg, time.time()
 
     cached_func = memory.cache(func)


### PR DESCRIPTION
As noted in https://github.com/joblib/joblib/pull/503#issuecomment-283429775, the exit code of the test script is not correct. This results in a successful build even if there were pytest errors.