### PR TITLE
Move temp_dir path generation to a separate private function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: test
 
 test:
-	pytest -v joblib
+	pytest joblib
 
 test-no-multiprocessing:
 	export JOBLIB_MULTIPROCESSING=0 && pytest joblib

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: test
 
 test:
-	pytest joblib
+	pytest -v joblib
 
 test-no-multiprocessing:
 	export JOBLIB_MULTIPROCESSING=0 && pytest joblib

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -96,11 +96,6 @@ def _get_backing_memmap(a):
 def _get_temp_dir(pool_folder_name, temp_folder=None):
     """Get the full path to a subfolder inside the temporary folder.
 
-    This function is originally used in joblib.pool.MemmapingPool, but
-    it could also be used in combination with joblib.Memory, provided
-    that the produced cache folders are manually cleaned to avoid
-    running out of memory.
-
     Parameters
     ----------
     pool_folder_name : str

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -93,6 +93,63 @@ def _get_backing_memmap(a):
         return _get_backing_memmap(b)
 
 
+def _get_temp_dir(pool_folder_name, temp_folder=None):
+    """Get the full path to a subfolder inside the temporary folder.
+
+    This function is originally used in joblib.pool.MemmapingPool, but
+    it could also be used in combination with joblib.Memory, provided
+    that the produced cache folders are manually cleaned to avoid
+    running out of memory.
+
+    Parameters
+    ----------
+    pool_folder_name : str
+        Sub-folder name used for the serialization of a pool instance.
+
+    temp_folder: str, optional
+        Folder to be used by the pool for memmaping large arrays
+        for sharing memory with worker processes. If None, this will try in
+        order:
+
+        - a folder pointed by the JOBLIB_TEMP_FOLDER environment
+          variable,
+        - /dev/shm if the folder exists and is writable: this is a
+          RAMdisk filesystem available by default on modern Linux
+          distributions,
+        - the default system temporary folder that can be
+          overridden with TMP, TMPDIR or TEMP environment
+          variables, typically /tmp under Unix operating systems.
+
+    Returns
+    -------
+    pool_folder : str
+       full path to the temporary folder
+    use_shared_mem : bool
+       whether the temporary folder is written to tmpfs
+    """
+    use_shared_mem = False
+    if temp_folder is None:
+        temp_folder = os.environ.get('JOBLIB_TEMP_FOLDER', None)
+    if temp_folder is None:
+        if os.path.exists(SYSTEM_SHARED_MEM_FS):
+            try:
+                temp_folder = SYSTEM_SHARED_MEM_FS
+                pool_folder = os.path.join(temp_folder, pool_folder_name)
+                if not os.path.exists(pool_folder):
+                    os.makedirs(pool_folder)
+                use_shared_mem = True
+            except IOError:
+                # Missing rights in the the /dev/shm partition,
+                # fallback to regular temp folder.
+                temp_folder = None
+    if temp_folder is None:
+        # Fallback to the default tmp folder, typically /tmp
+        temp_folder = tempfile.gettempdir()
+    temp_folder = os.path.abspath(os.path.expanduser(temp_folder))
+    pool_folder = os.path.join(temp_folder, pool_folder_name)
+    return pool_folder, use_shared_mem
+
+
 def has_shareable_memory(a):
     """Return True if a is backed by some mmap buffer directly or not."""
     return _get_backing_memmap(a) is not None
@@ -525,28 +582,10 @@ class MemmapingPool(PicklingPool):
         # Prepare a sub-folder name for the serialization of this particular
         # pool instance (do not create in advance to spare FS write access if
         # no array is to be dumped):
-        use_shared_mem = False
         pool_folder_name = "joblib_memmaping_pool_%d_%d" % (
             os.getpid(), id(self))
-        if temp_folder is None:
-            temp_folder = os.environ.get('JOBLIB_TEMP_FOLDER', None)
-        if temp_folder is None:
-            if os.path.exists(SYSTEM_SHARED_MEM_FS):
-                try:
-                    temp_folder = SYSTEM_SHARED_MEM_FS
-                    pool_folder = os.path.join(temp_folder, pool_folder_name)
-                    if not os.path.exists(pool_folder):
-                        os.makedirs(pool_folder)
-                    use_shared_mem = True
-                except IOError:
-                    # Missing rights in the the /dev/shm partition,
-                    # fallback to regular temp folder.
-                    temp_folder = None
-        if temp_folder is None:
-            # Fallback to the default tmp folder, typically /tmp
-            temp_folder = tempfile.gettempdir()
-        temp_folder = os.path.abspath(os.path.expanduser(temp_folder))
-        pool_folder = os.path.join(temp_folder, pool_folder_name)
+        pool_folder, use_shared_mem = _get_temp_dir(pool_folder_name,
+		                                    temp_folder)
         self._temp_folder = pool_folder
 
         # Register the garbage collector at program exit in case caller forgets

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -585,7 +585,7 @@ class MemmapingPool(PicklingPool):
         pool_folder_name = "joblib_memmaping_pool_%d_%d" % (
             os.getpid(), id(self))
         pool_folder, use_shared_mem = _get_temp_dir(pool_folder_name,
-		                                    temp_folder)
+                                                    temp_folder)
         self._temp_folder = pool_folder
 
         # Register the garbage collector at program exit in case caller forgets

--- a/joblib/test/test_pool.py
+++ b/joblib/test/test_pool.py
@@ -1,5 +1,6 @@
 import os
 import mmap
+import sys
 
 from joblib.test.common import with_numpy, np
 from joblib.test.common import setup_autokill
@@ -15,6 +16,7 @@ from joblib.pool import ArrayMemmapReducer
 from joblib.pool import reduce_memmap
 from joblib.pool import _strided_from_memmap
 from joblib.pool import _get_backing_memmap
+from joblib.pool import _get_temp_dir
 
 
 def setup_module():
@@ -478,3 +480,15 @@ def test_pool_memmap_with_big_offset(tmpdir):
     assert isinstance(result, np.memmap)
     assert result.offset == offset
     np.testing.assert_array_equal(obj, result)
+
+
+def test_pool_get_temp_dir(tmpdir):
+    pool_folder_name = 'test.tmpdir'
+    pool_folder, shared_mem = _get_temp_dir(pool_folder_name, tmpdir.strpath)
+    assert shared_mem is False
+    assert pool_folder == tmpdir.join('test.tmpdir').strpath
+
+    pool_folder, shared_mem = _get_temp_dir(pool_folder_name, temp_folder=None)
+    if sys.platform.startswith('win'):
+        assert shared_mem is False
+    assert pool_folder.endswith(pool_folder_name)


### PR DESCRIPTION
This PR addresses issue #510 and moves the code used to compute the path to the `temp_folder` from `joblib.pool.MemmapingPool` to a separate private function, so that it could be potentially (carefully) reused with `joblib.Memory`. 