### PR TITLE
[MRG+1] MAINT use latest miniconda3 installer

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -43,10 +43,11 @@ create_new_conda_env() {
 
     # Use the miniconda installer for faster download / install of conda
     # itself
-    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
+    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
          -O miniconda.sh
-    chmod +x miniconda.sh && ./miniconda.sh -b
-    export PATH=/home/travis/miniconda2/bin:$PATH
+    MINICONDA_PREFIX=/home/travis/miniconda
+    chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PREFIX
+    export PATH=$MINICONDA_PREFIX/bin:$PATH
     conda update --yes conda
 
     # Configure the conda environment and put it in the path using the


### PR DESCRIPTION
Turns out Miniconda-latest is actually a semi-old miniconda2 installer ...

I'll merge this one if the CIs are green.