### PR TITLE
Add `allow_override` kwarg to Parallel

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -91,7 +91,8 @@ def parallel_backend(backend, n_jobs=None, **backend_params):
 
     >>> from operator import neg
     >>> with parallel_backend('threading'):
-    ...     print(Parallel(allow_override=True)(delayed(neg)(i + 1) for i in range(5)))
+    ...     print(Parallel(allow_override=True)(
+    ...           delayed(neg)(i + 1) for i in range(5)))
     ...
     [-1, -2, -3, -4, -5]
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -53,6 +53,12 @@ DEFAULT_N_JOBS = 1
 _backend = threading.local()
 
 
+def has_active_backend():
+    """Returns True if an active backend is registered"""
+    active_backend_and_jobs = getattr(_backend, 'backend_and_jobs', None)
+    return active_backend_and_jobs is not None
+
+
 def get_active_backend():
     """Return the active default backend"""
     active_backend_and_jobs = getattr(_backend, 'backend_and_jobs', None)
@@ -300,6 +306,12 @@ class Parallel(Logger):
             - finally, you can register backends by calling
               register_parallel_backend. This will allow you to implement
               a backend of your liking.
+        allow_override: bool, optional
+            Whether the specified backend should be overridden if enclosed in a
+            ``parallel_backend`` contextmanager. If False [default] the
+            specified backend will be used even if enclosed in a
+            ``parallel_backend`` contextmanager. Otherwise the current active
+            backend will be used.
         verbose: int, optional
             The verbosity level: if non zero, progress messages are
             printed. Above 50, the output is sent to stdout.
@@ -470,19 +482,10 @@ class Parallel(Logger):
         [Parallel(n_jobs=2)]: Done 6 out of 6 | elapsed:  0.0s finished
 
     '''
-    def __init__(self, n_jobs=1, backend=None, verbose=0, timeout=None,
-                 pre_dispatch='2 * n_jobs', batch_size='auto',
-                 temp_folder=None, max_nbytes='1M', mmap_mode='r'):
-        active_backend, default_n_jobs = get_active_backend()
-        if backend is None and n_jobs == 1:
-            # If we are under a parallel_backend context manager, look up
-            # the default number of jobs and use that instead:
-            n_jobs = default_n_jobs
-        self.n_jobs = n_jobs
-        self.verbose = verbose
-        self.timeout = timeout
-        self.pre_dispatch = pre_dispatch
-
+    def __init__(self, n_jobs=None, backend=None, allow_override=False,
+                 verbose=0, timeout=None, pre_dispatch='2 * n_jobs',
+                 batch_size='auto', temp_folder=None, max_nbytes='1M',
+                 mmap_mode='r'):
         if isinstance(max_nbytes, _basestring):
             max_nbytes = memstr_to_bytes(max_nbytes)
 
@@ -490,13 +493,16 @@ class Parallel(Logger):
             max_nbytes=max_nbytes,
             mmap_mode=mmap_mode,
             temp_folder=temp_folder,
-            verbose=max(0, self.verbose - 50),
+            verbose=max(0, verbose - 50),
         )
         if DEFAULT_MP_CONTEXT is not None:
             self._backend_args['context'] = DEFAULT_MP_CONTEXT
 
-        if backend is None:
-            backend = active_backend
+        if backend is None or allow_override and has_active_backend():
+            backend, default_n_jobs = get_active_backend()
+            if n_jobs is None:
+                # If not specified in `Parallel`, use the global default
+                n_jobs = default_n_jobs
         elif isinstance(backend, ParallelBackendBase):
             # Use provided backend as is
             pass
@@ -514,13 +520,22 @@ class Parallel(Logger):
                                  % (backend, sorted(BACKENDS.keys())))
             backend = backend_factory()
 
-        if (batch_size == 'auto' or isinstance(batch_size, Integral) and
+        if n_jobs is None:
+            # If not specified, fallback to 1
+            n_jobs = 1
+
+        if not (batch_size == 'auto' or isinstance(batch_size, Integral) and
                 batch_size > 0):
-            self.batch_size = batch_size
-        else:
             raise ValueError(
                 "batch_size must be 'auto' or a positive integer, got: %r"
                 % batch_size)
+
+        self.batch_size = batch_size
+        self.allow_override = allow_override
+        self.n_jobs = n_jobs
+        self.verbose = verbose
+        self.timeout = timeout
+        self.pre_dispatch = pre_dispatch
 
         self._backend = backend
         self._output = None

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -488,7 +488,7 @@ def check_backend_context_manager(backend_name):
         active_backend, active_n_jobs = parallel.get_active_backend()
         assert active_n_jobs == 3
         assert effective_n_jobs(3) == 3
-        p = Parallel()
+        p = Parallel(allow_override=True)
         assert p.n_jobs == 3
         if backend_name == 'multiprocessing':
             assert type(active_backend) == MultiprocessingBackend
@@ -515,7 +515,7 @@ def test_backend_context_manager(monkeypatch, backend):
     # check that this possible to switch parallel backends sequentially
     check_backend_context_manager(backend)
 
-    # The default backend is retored
+    # The default backend is restored
     assert _active_backend_type() == MultiprocessingBackend
 
     # Check that context manager switching is thread safe:
@@ -523,7 +523,7 @@ def test_backend_context_manager(monkeypatch, backend):
         delayed(check_backend_context_manager)(b)
         for b in all_backends_for_context_manager if not b)
 
-    # The default backend is again retored
+    # The default backend is again restored
     assert _active_backend_type() == MultiprocessingBackend
 
 
@@ -546,7 +546,7 @@ def test_parameterized_backend_context_manager(monkeypatch):
         assert type(active_backend) == ParameterizedParallelBackend
         assert active_backend.param == 42
         assert active_n_jobs == 3
-        p = Parallel()
+        p = Parallel(allow_override=True)
         assert p.n_jobs == 3
         assert p._backend is active_backend
         results = p(delayed(sqrt)(i) for i in range(5))
@@ -566,13 +566,13 @@ def test_direct_parameterized_backend_context_manager():
         assert type(active_backend) == ParameterizedParallelBackend
         assert active_backend.param == 43
         assert active_n_jobs == 5
-        p = Parallel()
+        p = Parallel(allow_override=True)
         assert p.n_jobs == 5
         assert p._backend is active_backend
         results = p(delayed(sqrt)(i) for i in range(5))
     assert results == [sqrt(i) for i in range(5)]
 
-    # The default backend is again retored
+    # The default backend is again restored
     assert _active_backend_type() == MultiprocessingBackend
 
 
@@ -583,14 +583,16 @@ def test_backend_allow_override(monkeypatch):
 
     for default in ['threading', None]:
         with parallel_backend(backend, n_jobs=5):
-            # If n_jobs specified in Parallel, use that
+            # If n_jobs specified in parallel_backend, use that
             p = Parallel(n_jobs=2, backend=default, allow_override=True)
             assert type(p._backend) == FakeParallelBackend
-            assert p.n_jobs == 2
-            # Not specified, use global default
-            p = Parallel(backend=default, allow_override=True)
-            assert type(p._backend) == FakeParallelBackend
             assert p.n_jobs == 5
+
+        with parallel_backend(backend):
+            # n_jobs not specified, fallback to Parallel
+            p = Parallel(backend=default, allow_override=True, n_jobs=2)
+            assert type(p._backend) == FakeParallelBackend
+            assert p.n_jobs == 2
 
     with parallel_backend(backend, n_jobs=2):
         # n_jobs not specified, fallback to 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ universal=1
 addopts =
     --doctest-glob="doc/*.rst"
     --doctest-modules
+     -p no:warnings
 testpaths = joblib
 
 [flake8]


### PR DESCRIPTION
If true, wrapping a call to `Parallel` with a `parallel_backend` contextmanager will use the active backend instead of the backend specified in the `Parallel` call. Default is False (existing behavior).

This allows overriding what backend is used inside libraries that depend on joblib (e.g. scikit-learn), and is motivated by the `dask.distributed` joblib backend (see https://github.com/scikit-learn/scikit-learn/issues/8804).

**Example**

```python
# Uses threading
with parallel_backend('threading'):
    Parallel(backend='multiprocessing', allow_override=True, ...)(...)

# Uses multiprocessing since `allow_override=False`
with parallel_backend('threading'):
    Parallel(backend='multiprocessing', ...)(...)

# Uses specified n_jobs in Parallel (10)
with parallel_backend('threading', n_jobs=2):
    Parallel(backend='multiprocessing', allow_override=True, n_jobs=10)

# Uses context specified n_jobs (2), since none specified in Parallel
with parallel_backend('threading', n_jobs=2):
    Parallel(backend='multiprocessing', allow_override=True)

# Uses default n_jobs (1), since none specified in Parallel and allow_override=False
with parallel_backend('threading', n_jobs=2):
    Parallel(backend='multiprocessing')
```

---

The `n_jobs` behavior with `allow_override` is a bit wonky, as `parallel_backend` may or may not specify `n_jobs`, and the default for `parallel_backend` is `-1` but the default for `Parallel` is `1`. The approach taken here is that `allow_override` only means the backend can be overridden, not `n_jobs` in the call to `Parallel` (if specified). Alternative solutions would be:

- Remove the `n_jobs` kwarg from `parallel_backend`, as `n_jobs` and `backend` are two separate concepts
- Switch the kwarg default for `n_jobs` in `parallel_backend` to `None`. This would allow checking if a global `n_jobs` was set, and use that to override the `n_jobs` specified in `Parallel` if `allow_override` is True. The logic in `Parallel` would then look like:

  ```python
  if allow_override or backend is None:
      backend, default_n_jobs = get_active_backend()
      if default_n_jobs is not None:  # n_jobs set in parallel_backend, use that
          n_jobs = default_n_jobs
      elif n_jobs is None:            # otherwise if specified locally use that
          n_jobs = 1                  # fallback to 1
  ```

  The downside of this is it would change the behavior of
  
  ```python
  with parallel_backend('some_backend'):
      Parallel()(...)
  ```
  from using `n_jobs=-1` (fallback to `parallel_backend` defaults) to `n_jobs=1` (fallback to `Parallel` defaults). Since the `parallel_backend` contextmanager has a warning that it may change any time this may be acceptable.