### PR TITLE
CI: Disable Pytest warnings plugin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ universal=1
 addopts =
     --doctest-glob="doc/*.rst"
     --doctest-modules
+     -p no:warnings
 testpaths = joblib
 
 [flake8]


### PR DESCRIPTION
The new release of pytest adds a plugin to capture all warnings and
output them at the end. This was causing a test failure, as we were
checking that a warning was raised in an external process by checking
the captured stderr. Since the warning is raised in an external process
we can't use `pytest.warns`, and none of the current pytest-warnings
configuration settings allow turning off capturing in a way that works
for this test. For now we disable this plugin entirely.

See https://github.com/pytest-dev/pytest/issues/2430.