### PR TITLE
[MRG]: `DeprecationWarning: invalid escape sequence` in Python 3.6

### DIFF
--- a/joblib/_memory_helpers.py
+++ b/joblib/_memory_helpers.py
@@ -7,7 +7,7 @@ except ImportError:
     from codecs import lookup, BOM_UTF8
     import re
     from io import TextIOWrapper, open
-    cookie_re = re.compile("coding[:=]\s*([-\w.]+)")
+    cookie_re = re.compile(r"coding[:=]\s*([-\w.]+)")
 
     def _get_normal_name(orig_enc):
         """Imitates get_normal_name in tokenizer.c."""

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -50,7 +50,7 @@ def get_func_code(func):
             line_no = 1
             if source_file.startswith('<doctest '):
                 source_file, line_no = re.match(
-                    '\<doctest (.*\.rst)\[(.*)\]\>', source_file).groups()
+                    r'\<doctest (.*\.rst)\[(.*)\]\>', source_file).groups()
                 line_no = int(line_no)
                 source_file = '<doctest %s>' % source_file
             return source_code, source_file, line_no

--- a/joblib/test/test_format_stack.py
+++ b/joblib/test/test_format_stack.py
@@ -63,7 +63,7 @@ def test_format_records():
 
         # Check exception stack
         arrow_regex = r'^-+>\s+\d+\s+'
-        assert re.search(arrow_regex + "_raise_exception\('a', 42\)",
+        assert re.search(arrow_regex + r"_raise_exception\('a', 42\)",
                          formatted_records[0],
                          re.MULTILINE)
         assert re.search(arrow_regex + r'helper\(a, b\)',
@@ -72,7 +72,7 @@ def test_format_records():
         assert "a = 'a'" in formatted_records[1]
         assert 'b = 42' in formatted_records[1]
         assert re.search(arrow_regex +
-                         "raise ValueError\('Nope, this can not work'\)",
+                         r"raise ValueError\('Nope, this can not work'\)",
                          formatted_records[2],
                          re.MULTILINE)
 
@@ -121,5 +121,5 @@ def test_format_exc_with_compiled_code():
                                    exc_traceback, context=10)
         # The name of the extension can be something like
         # mtrand.cpython-33m.so
-        pattern = 'mtrand[a-z0-9._-]*\.(so|pyd)'
+        pattern = r'mtrand[a-z0-9._-]*\.(so|pyd)'
         assert re.search(pattern, formatted_exc)

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -193,7 +193,7 @@ def test_bound_methods():
 @parametrize('exception,regex,func,args',
              [(ValueError, 'ignore_lst must be a list of parameters to ignore',
                f, ['bar', (None, )]),
-              (ValueError, 'Ignore list: argument \'(.*)\' is not defined',
+              (ValueError, r'Ignore list: argument \'(.*)\' is not defined',
                g, [['bar'], (None, )]),
               (ValueError, 'Wrong number of arguments',
                h, [[]])])

--- a/joblib/test/test_testing.py
+++ b/joblib/test/test_testing.py
@@ -63,7 +63,7 @@ def test_check_subprocess_call_timeout():
         'sys.stdout.flush()'])
 
     pattern = re.compile('Non-zero return code:.+'
-                         'Stdout:\nbefore sleep on stdout\s+'
+                         'Stdout:\nbefore sleep on stdout\\s+'
                          'Stderr:\nbefore sleep on stderr',
                          re.DOTALL)
 


### PR DESCRIPTION
If python 3.6 is run with the -Wd flags, DeprecationWarnings are thrown whenever a backslash is not used in an escape sequence. I fixed all these warnings, using raw strings where possible and double backslashes otherwise.