### PR TITLE
Example of caching to RAM using a global dict

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -26,7 +26,7 @@ import operator
 import collections
 import datetime
 import threading
-from multiprocessing import Manager
+import multiprocessing
 import gc
 
 # Local imports


### PR DESCRIPTION
I've tried to implement caching to RAM for personal needs with the following strategy:

- all objects that are usually pickled to disk, are now stored in a global shared dictionary
- the objects are written to the dictionary instead of written to disk so the only lines that change are the IO lines
- the keys of the dictionary are the paths to files when cached to disk.
- to flush the cache, clear the dictionary then garbage collect.

This is only a POC to show that it can work. It could be easily merged with the current Memory and MemorizedFunc, where an arg would let the user choose the type of caching.

It is probably similar to the work by @aabadie on custom store backends, since using a global shared dict is just another implementation of caching objects.

Caching to RAM is here implemented within MemorizedFuncRAM and MemoryRAM, those two classes inherit from MemorizedFunc and Memory respectively, and simply rewrite the I/O lines. Instead of writing to disk, objects are stored inside a dictionary. To make it simpler, the keys of this dictionary are the paths that those objects would have in the deep folder structure on disk.

(on a side note, it looks like when using multiprocessing, _FUNCTION_HASHES will not be shared by processes ? isn't this an issue in the original implementation ?).