### PR TITLE
[MRG] handle permission error in concurrency_safe_rename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Latest changes
 ===============
 
+Development
+-----------
+
+Olivier Grisel
+
+    Make Memory.cache robust to PermissionError (errno 13) under Windows
+    when run in combination with Parallel.
+
+
 Release 0.11
 ------------
 

--- a/joblib/backports.py
+++ b/joblib/backports.py
@@ -33,7 +33,8 @@ except ImportError:
 
 
 if os.name == 'nt':
-    error_access_denied = 5
+    # https://github.com/joblib/joblib/issues/540
+    access_denied_errors = (5, 13)
     try:
         from os import replace
     except ImportError:
@@ -65,7 +66,7 @@ if os.name == 'nt':
                 replace(src, dst)
                 break
             except Exception as exc:
-                if getattr(exc, 'winerror', None) == error_access_denied:
+                if getattr(exc, 'winerror', None) in access_denied_errors:
                     time.sleep(sleep_time)
                     total_sleep_time += sleep_time
                     sleep_time *= 2

--- a/joblib/test/test_backports.py
+++ b/joblib/test/test_backports.py
@@ -16,7 +16,8 @@ def test_memmap(tmpdir):
 
 
 @parametrize('dst_content', [None, 'dst content'])
-def test_concurrency_safe_rename(tmpdir, dst_content):
+@parametrize('backend', [None, 'threading'])
+def test_concurrency_safe_rename(tmpdir, dst_content, backend):
     src_paths = [tmpdir.join('src_%d' % i) for i in range(4)]
     for src_path in src_paths:
         src_path.write('src content')
@@ -24,7 +25,7 @@ def test_concurrency_safe_rename(tmpdir, dst_content):
     if dst_content is not None:
         dst_path.write(dst_content)
 
-    Parallel(n_jobs=4)(
+    Parallel(n_jobs=4, backend=backend)(
         delayed(concurrency_safe_rename)(src_path.strpath, dst_path.strpath)
         for src_path in src_paths
     )

--- a/joblib/test/test_backports.py
+++ b/joblib/test/test_backports.py
@@ -3,6 +3,7 @@ import mmap
 from joblib.backports import make_memmap, concurrency_safe_rename
 from joblib.test.common import with_numpy
 from joblib.testing import parametrize
+from joblib import Parallel, delayed
 
 
 @with_numpy
@@ -14,15 +15,20 @@ def test_memmap(tmpdir):
     assert memmap_obj.offset == offset
 
 
-@parametrize('src_content', [None, 'src content'])
-def test_concurrency_safe_rename(tmpdir, src_content):
-    src_path = tmpdir.join('src')
-    src_path.write('src content')
+@parametrize('dst_content', [None, 'dst content'])
+def test_concurrency_safe_rename(tmpdir, dst_content):
+    src_paths = [tmpdir.join('src_%d' % i) for i in range(4)]
+    for src_path in src_paths:
+        src_path.write('src content')
     dst_path = tmpdir.join('dst')
-    if src_content is not None:
-        dst_path.write('dst content')
+    if dst_content is not None:
+        dst_path.write(dst_content)
 
-    concurrency_safe_rename(src_path.strpath, dst_path.strpath)
-    assert not src_path.exists()
+    Parallel(n_jobs=4)(
+        delayed(concurrency_safe_rename)(src_path.strpath, dst_path.strpath)
+        for src_path in src_paths
+    )
     assert dst_path.exists()
     assert dst_path.read() == 'src content'
+    for src_path in src_paths:
+        assert not src_path.exists()

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -712,12 +712,17 @@ def test_file_handle_persistence_in_memory_mmap():
             'ignored.' % {'mmap_mode': 'r+'})
 
 
-@parametrize('data', [b'a little data as bytes.',
-                      # More bytes
-                      10000 * "{}".format(
-                          random.randint(0, 1000) * 1000).encode('latin-1')])
+TEST_DATA_STORE = {
+    'small': b'a little data as bytes.',
+    'medium': 10000 * "{}".format(
+        random.randint(0, 1000) * 1000).encode('latin-1'),
+}
+
+
+@parametrize('data', ['small', 'medium'])
 @parametrize('compress_level', [1, 3, 9])
 def test_binary_zlibfile(tmpdir, data, compress_level):
+    data = TEST_DATA_STORE[data]
     filename = tmpdir.join('test.pkl').strpath
     # Regular cases
     with open(filename, 'wb') as f:


### PR DESCRIPTION
This is a fix for #540.

I also improved the test to actually test a multi-process concurrent access to the same target file.