### PR TITLE
Define namedtuple outside the method.

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -156,7 +156,10 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
         module = [_clean_win_chars(s) for s in module]
     return module, name
 
-
+import collections
+tuple_fields = ('args varargs varkw defaults kwonlyargs '
+                'kwonlydefaults annotations')
+tuple_type = collections.namedtuple('FullArgSpec', tuple_fields)
 def getfullargspec(func):
     """Compatibility function to provide inspect.getfullargspec in Python 2
 
@@ -169,11 +172,6 @@ def getfullargspec(func):
         return inspect.getfullargspec(func)
     except AttributeError:
         arg_spec = inspect.getargspec(func)
-        import collections
-        tuple_fields = ('args varargs varkw defaults kwonlyargs '
-                        'kwonlydefaults annotations')
-        tuple_type = collections.namedtuple('FullArgSpec', tuple_fields)
-
         return tuple_type(args=arg_spec.args,
                           varargs=arg_spec.varargs,
                           varkw=arg_spec.keywords,

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -11,11 +11,16 @@ import inspect
 import warnings
 import re
 import os
+import collections
 
 from ._compat import _basestring
 from .logger import pformat
 from ._memory_helpers import open_py_source
 from ._compat import PY3_OR_LATER
+
+full_argspec_fields = ('args varargs varkw defaults kwonlyargs '
+                       'kwonlydefaults annotations')
+full_argspec_type = collections.namedtuple('FullArgSpec', full_argspec_fields)
 
 
 def get_func_code(func):
@@ -156,10 +161,7 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
         module = [_clean_win_chars(s) for s in module]
     return module, name
 
-import collections
-tuple_fields = ('args varargs varkw defaults kwonlyargs '
-                'kwonlydefaults annotations')
-tuple_type = collections.namedtuple('FullArgSpec', tuple_fields)
+
 def getfullargspec(func):
     """Compatibility function to provide inspect.getfullargspec in Python 2
 
@@ -172,13 +174,13 @@ def getfullargspec(func):
         return inspect.getfullargspec(func)
     except AttributeError:
         arg_spec = inspect.getargspec(func)
-        return tuple_type(args=arg_spec.args,
-                          varargs=arg_spec.varargs,
-                          varkw=arg_spec.keywords,
-                          defaults=arg_spec.defaults,
-                          kwonlyargs=[],
-                          kwonlydefaults=None,
-                          annotations={})
+        return full_argspec_type(args=arg_spec.args,
+                                 varargs=arg_spec.varargs,
+                                 varkw=arg_spec.keywords,
+                                 defaults=arg_spec.defaults,
+                                 kwonlyargs=[],
+                                 kwonlydefaults=None,
+                                 annotations={})
 
 
 def _signature_str(function_name, arg_spec):


### PR DESCRIPTION
Reduce the latency of the method call, especially in a big loop.

Please refer to issue -> https://github.com/joblib/joblib/issues/546

Fix #546.