### PR TITLE
[MRG] deprecate check_pickle in delayed

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -176,17 +176,11 @@ def _verbosity_filter(index, verbose):
 
 
 ###############################################################################
-def delayed(function, check_pickle=True):
-    """Decorator used to capture the arguments of a function.
-
-    Pass `check_pickle=False` when:
-
-    - performing a possibly repeated check is too costly and has been done
-      already once outside of the call to delayed.
-
-    - when used in conjunction `Parallel(backend='threading')`.
-
-    """
+def delayed(function, check_pickle=None):
+    """Decorator used to capture the arguments of a function."""
+    if check_pickle is not None:
+        warnings.warn('check_pickle is deprecated in joblib 0.12 and will be'
+                      ' removed in 0.13', DeprecationWarning)
     # Try to pickle the input function, to catch the problems early when
     # using with multiprocessing:
     if check_pickle:

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -904,3 +904,39 @@ def test_memmapping_leaks(backend, tmpdir):
     p(delayed(check_memmap)(a) for a in [np.random.random(10)] * 2)
 
     assert not os.listdir(tmpdir)
+
+
+def test_lambda_expression():
+    # cloudpickle is used to pickle delayed callables
+    for backend in ALL_VALID_BACKENDS:
+        results = Parallel(n_jobs=2, backend=backend)(
+            delayed(lambda x: x ** 2)(i) for i in range(10))
+        assert results == [i ** 2 for i in range(10)]
+
+
+def test_delayed_check_pickle_deprecated():
+
+    class UnpicklableCallable(object):
+
+        def __call__(self, *args, **kwargs):
+            return 42
+
+        def __reduce__(self):
+            raise ValueError()
+
+    with warns(DeprecationWarning):
+        f, args, kwargs = delayed(lambda x: 42, check_pickle=False)('a')
+    assert f('a') == 42
+    assert args == ('a',)
+    assert kwargs == dict()
+
+    with warns(DeprecationWarning):
+        f, args, kwargs = delayed(UnpicklableCallable(),
+                                  check_pickle=False)('a', option='b')
+        assert f('a', option='b') == 42
+        assert args == ('a',)
+        assert kwargs == dict(option='b')
+
+    with warns(DeprecationWarning):
+        with raises(ValueError):
+            delayed(UnpicklableCallable(), check_pickle=True)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -230,7 +230,7 @@ def test_mutate_input_with_threads():
     """Input is mutable when using the threading backend"""
     q = Queue(maxsize=5)
     Parallel(n_jobs=2, backend="threading")(
-        delayed(q.put, check_pickle=False)(1) for _ in range(5))
+        delayed(q.put)(1) for _ in range(5))
     assert q.full()
 
 


### PR DESCRIPTION
Now that joblib uses cloudpickle by default, any common Python callable (including lambda expressions) should be picklable so there is no point in paying that extra overhead.