### PR TITLE
DOC: Fix docstring for `numpy_pickle.load`

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -533,8 +533,8 @@ def load(filename, mmap_mode=None):
 
     Parameters
     -----------
-    filename: str or pathlib.Path
-        The path of the file from which to load the object
+    filename: str, pathlib.Path, or file object.
+        The file object or path of the file from which to load the object
     mmap_mode: {None, 'r+', 'r', 'w+', 'c'}, optional
         If not None, the arrays are memory-mapped from the disk. This
         mode has no effect for compressed files. Note that in this


### PR DESCRIPTION
Added the use of file_like object in the doctring for the `load` method.

Did not find any other instances in the `numpy_pickle.py` module that required updating.