### PR TITLE
Reset parallel batch statistics at the end of a run

### DIFF
--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -170,14 +170,14 @@ class AutoBatchingMixin(object):
     MAX_IDEAL_BATCH_DURATION = 2
 
     # Batching counters default values
-    DEFAULT_EFFECTIVE_BATCH_SIZE = 1
-    DEFAULT_SMOOTHED_BATCH_DURATION = 0.0
+    _DEFAULT_EFFECTIVE_BATCH_SIZE = 1
+    _DEFAULT_SMOOTHED_BATCH_DURATION = 0.0
 
     def __init__(self):
         """Constructor"""
         # Batching counters
-        self._effective_batch_size = self.DEFAULT_EFFECTIVE_BATCH_SIZE
-        self._smoothed_batch_duration = self.DEFAULT_SMOOTHED_BATCH_DURATION
+        self._effective_batch_size = self._DEFAULT_EFFECTIVE_BATCH_SIZE
+        self._smoothed_batch_duration = self._DEFAULT_SMOOTHED_BATCH_DURATION
 
 
     def compute_batch_size(self):
@@ -223,7 +223,7 @@ class AutoBatchingMixin(object):
             # we need to reset the estimate whenever we re-tune the batch
             # size.
             self._smoothed_batch_duration = \
-                self.DEFAULT_SMOOTHED_BATCH_DURATION
+                self._DEFAULT_SMOOTHED_BATCH_DURATION
 
         return batch_size
 
@@ -233,7 +233,7 @@ class AutoBatchingMixin(object):
             # Update the smoothed streaming estimate of the duration of a batch
             # from dispatch to completion
             old_duration = self._smoothed_batch_duration
-            if old_duration == self.DEFAULT_SMOOTHED_BATCH_DURATION:
+            if old_duration == self._DEFAULT_SMOOTHED_BATCH_DURATION:
                 # First record of duration for this batch size after the last
                 # reset.
                 new_duration = duration
@@ -248,8 +248,8 @@ class AutoBatchingMixin(object):
 
         This avoids interferences with future jobs.
         """
-        self._effective_batch_size = self.DEFAULT_EFFECTIVE_BATCH_SIZE
-        self._smoothed_batch_duration = self.DEFAULT_SMOOTHED_BATCH_DURATION
+        self._effective_batch_size = self._DEFAULT_EFFECTIVE_BATCH_SIZE
+        self._smoothed_batch_duration = self._DEFAULT_SMOOTHED_BATCH_DURATION
 
 
 class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -170,7 +170,7 @@ class AutoBatchingMixin(object):
     MAX_IDEAL_BATCH_DURATION = 2
 
     # Batching counters
-    _effective_batch_size = _initial_batch_size = 1
+    _effective_batch_size = _initial_effective_batch_size = 1
     _smoothed_batch_duration = _initial_smoothed_batch_duration = 0.0
 
     def compute_batch_size(self):
@@ -241,7 +241,7 @@ class AutoBatchingMixin(object):
 
         This avoids interferences with future jobs.
         """
-        self._effective_batch_size = self._initial_batch_size
+        self._effective_batch_size = self._initial_effective_batch_size
         self._smoothed_batch_duration = self._initial_smoothed_batch_duration
 
 

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -174,8 +174,6 @@ class AutoBatchingMixin(object):
     _DEFAULT_SMOOTHED_BATCH_DURATION = 0.0
 
     def __init__(self):
-        """Constructor"""
-        # Batching counters
         self._effective_batch_size = self._DEFAULT_EFFECTIVE_BATCH_SIZE
         self._smoothed_batch_duration = self._DEFAULT_SMOOTHED_BATCH_DURATION
 

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -169,9 +169,16 @@ class AutoBatchingMixin(object):
     # on a single worker while other workers have no work to process any more.
     MAX_IDEAL_BATCH_DURATION = 2
 
-    # Batching counters
-    _effective_batch_size = _initial_effective_batch_size = 1
-    _smoothed_batch_duration = _initial_smoothed_batch_duration = 0.0
+    # Batching counters default values
+    DEFAULT_EFFECTIVE_BATCH_SIZE = 1
+    DEFAULT_SMOOTHED_BATCH_DURATION = 0.0
+
+    def __init__(self):
+        """Constructor"""
+        # Batching counters
+        self._effective_batch_size = self.DEFAULT_EFFECTIVE_BATCH_SIZE
+        self._smoothed_batch_duration = self.DEFAULT_SMOOTHED_BATCH_DURATION
+
 
     def compute_batch_size(self):
         """Determine the optimal batch size"""
@@ -216,7 +223,7 @@ class AutoBatchingMixin(object):
             # we need to reset the estimate whenever we re-tune the batch
             # size.
             self._smoothed_batch_duration = \
-                self._initial_smoothed_batch_duration
+                self.DEFAULT_SMOOTHED_BATCH_DURATION
 
         return batch_size
 
@@ -226,7 +233,7 @@ class AutoBatchingMixin(object):
             # Update the smoothed streaming estimate of the duration of a batch
             # from dispatch to completion
             old_duration = self._smoothed_batch_duration
-            if old_duration == self._initial_smoothed_batch_duration:
+            if old_duration == self.DEFAULT_SMOOTHED_BATCH_DURATION:
                 # First record of duration for this batch size after the last
                 # reset.
                 new_duration = duration
@@ -241,8 +248,8 @@ class AutoBatchingMixin(object):
 
         This avoids interferences with future jobs.
         """
-        self._effective_batch_size = self._initial_effective_batch_size
-        self._smoothed_batch_duration = self._initial_smoothed_batch_duration
+        self._effective_batch_size = self.DEFAULT_EFFECTIVE_BATCH_SIZE
+        self._smoothed_batch_duration = self.DEFAULT_SMOOTHED_BATCH_DURATION
 
 
 class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -958,14 +958,16 @@ def test_backend_batch_statistics_reset(backend):
     start_time = time.time()
     p(delayed(time.sleep)(task_time) for i in range(n_inputs))
     ref_time = time.time() - start_time
-    assert p._backend._effective_batch_size == p._backend._initial_batch_size
+    assert p._backend._effective_batch_size == \
+        p._backend._initial_effective_batch_size
     assert (p._backend._smoothed_batch_duration ==
             p._backend._initial_smoothed_batch_duration)
 
     start_time = time.time()
     p(delayed(time.sleep)(task_time) for i in range(n_inputs))
     test_time = time.time() - start_time
-    assert p._backend._effective_batch_size == p._backend._initial_batch_size
+    assert p._backend._effective_batch_size == \
+        p._backend._initial_effective_batch_size
     assert (p._backend._smoothed_batch_duration ==
             p._backend._initial_smoothed_batch_duration)
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -946,10 +946,7 @@ def test_delayed_check_pickle_deprecated():
 @parametrize('backend', ['multiprocessing', 'loky'])
 def test_backend_batch_statistics_reset(backend):
     """Test that a parallel backend correctly resets its batch statistics."""
-
-    # let's tolerate 20% error between compuration times to avoid random
-    # failures because of variable available ressources on CIs.
-    error = 0.2
+    relative_tolerance = 0.2
     n_jobs = 2
     n_inputs = 500
     task_time = 2. / n_inputs
@@ -971,4 +968,5 @@ def test_backend_batch_statistics_reset(backend):
     assert (p._backend._smoothed_batch_duration ==
             p._backend._DEFAULT_SMOOTHED_BATCH_DURATION)
 
-    assert (test_time / ref_time) <= (1 + error)
+    # Tolerance in the timing comparison to avoid random failures on CIs
+    assert test_time / ref_time <= 1 + relative_tolerance

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -951,24 +951,24 @@ def test_backend_batch_statistics_reset(backend):
     # failures because of variable available ressources on CIs.
     error = 0.2
     n_jobs = 2
-    n_inputs = 500
-    task_time = 2. / n_inputs
+    n_inputs = 1000
+    task_time = 1. / n_inputs
 
     p = Parallel(verbose=10, n_jobs=n_jobs, backend=backend)
     start_time = time.time()
     p(delayed(time.sleep)(task_time) for i in range(n_inputs))
     ref_time = time.time() - start_time
     assert p._backend._effective_batch_size == \
-        p._backend._initial_effective_batch_size
+        p._backend.DEFAULT_EFFECTIVE_BATCH_SIZE
     assert (p._backend._smoothed_batch_duration ==
-            p._backend._initial_smoothed_batch_duration)
+            p._backend.DEFAULT_SMOOTHED_BATCH_DURATION)
 
     start_time = time.time()
     p(delayed(time.sleep)(task_time) for i in range(n_inputs))
     test_time = time.time() - start_time
     assert p._backend._effective_batch_size == \
-        p._backend._initial_effective_batch_size
+        p._backend.DEFAULT_EFFECTIVE_BATCH_SIZE
     assert (p._backend._smoothed_batch_duration ==
-            p._backend._initial_smoothed_batch_duration)
+            p._backend.DEFAULT_SMOOTHED_BATCH_DURATION)
 
     assert (test_time / ref_time) <= (1 + error)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -969,13 +969,4 @@ def test_backend_batch_statistics_reset(backend):
     assert (p._backend._smoothed_batch_duration ==
             p._backend._initial_smoothed_batch_duration)
 
-    assert (
-        # With loky backend, the test run is a lot faster (it exceeds the 20%
-        # error tolerance) than the reference run because it reuses previously
-        # created workers. Having test_time smaller than reference time is ok
-        # for both multiprocessing and loky backends.
-        test_time < ref_time or
-        # With multiprocessing the computation times are similar but can
-        # be slightly higher sometimes. Ensuring relative error is
-        # reasonable is ok in this case.
-        abs(test_time - ref_time) / ref_time <= error)
+    assert (test_time / ref_time) <= (1 + error)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -958,16 +958,16 @@ def test_backend_batch_statistics_reset(backend):
     start_time = time.time()
     p(delayed(time.sleep)(task_time) for i in range(n_inputs))
     ref_time = time.time() - start_time
-    assert p._backend._effective_batch_size == \
-        p._backend._DEFAULT_EFFECTIVE_BATCH_SIZE
+    assert (p._backend._effective_batch_size ==
+            p._backend._DEFAULT_EFFECTIVE_BATCH_SIZE)
     assert (p._backend._smoothed_batch_duration ==
             p._backend._DEFAULT_SMOOTHED_BATCH_DURATION)
 
     start_time = time.time()
     p(delayed(time.sleep)(task_time) for i in range(n_inputs))
     test_time = time.time() - start_time
-    assert p._backend._effective_batch_size == \
-        p._backend._DEFAULT_EFFECTIVE_BATCH_SIZE
+    assert (p._backend._effective_batch_size ==
+            p._backend._DEFAULT_EFFECTIVE_BATCH_SIZE)
     assert (p._backend._smoothed_batch_duration ==
             p._backend._DEFAULT_SMOOTHED_BATCH_DURATION)
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -951,24 +951,24 @@ def test_backend_batch_statistics_reset(backend):
     # failures because of variable available ressources on CIs.
     error = 0.2
     n_jobs = 2
-    n_inputs = 1000
-    task_time = 1. / n_inputs
+    n_inputs = 500
+    task_time = 2. / n_inputs
 
     p = Parallel(verbose=10, n_jobs=n_jobs, backend=backend)
     start_time = time.time()
     p(delayed(time.sleep)(task_time) for i in range(n_inputs))
     ref_time = time.time() - start_time
     assert p._backend._effective_batch_size == \
-        p._backend.DEFAULT_EFFECTIVE_BATCH_SIZE
+        p._backend._DEFAULT_EFFECTIVE_BATCH_SIZE
     assert (p._backend._smoothed_batch_duration ==
-            p._backend.DEFAULT_SMOOTHED_BATCH_DURATION)
+            p._backend._DEFAULT_SMOOTHED_BATCH_DURATION)
 
     start_time = time.time()
     p(delayed(time.sleep)(task_time) for i in range(n_inputs))
     test_time = time.time() - start_time
     assert p._backend._effective_batch_size == \
-        p._backend.DEFAULT_EFFECTIVE_BATCH_SIZE
+        p._backend._DEFAULT_EFFECTIVE_BATCH_SIZE
     assert (p._backend._smoothed_batch_duration ==
-            p._backend.DEFAULT_SMOOTHED_BATCH_DURATION)
+            p._backend._DEFAULT_SMOOTHED_BATCH_DURATION)
 
     assert (test_time / ref_time) <= (1 + error)


### PR DESCRIPTION
This PR is an attempt to fix #533

It implements the 'reset backend dict' suggestion and adds a non regression test. This test checks that the dict is correctly reset after a job and that the computation time is stable across several runs.