### PR TITLE
Bugfix for wrong hashing/pickling behavior

### DIFF
--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -139,17 +139,8 @@ class Hasher(Pickler):
 
     def _batch_setitems(self, items):
         # forces order of keys in dict to ensure consistent hash.
-        try:
-            # Trying first to compare dict assuming the type of keys is
-            # consistent and orderable.
-            # This fails on python 3 when keys are unorderable
-            # but we keep it in a try as it's faster.
-            Pickler._batch_setitems(self, iter(sorted(items)))
-        except TypeError:
-            # If keys are unorderable, sorting them using their hash. This is
-            # slower but works in any case.
-            Pickler._batch_setitems(self, iter(sorted((hash(k), v)
-                                                      for k, v in items)))
+        Pickler._batch_setitems(self, iter(sorted((hash(k), v)
+                                                  for k, v in items)))
 
     def save_set(self, set_items):
         # forces order of items in Set to ensure consistent hash


### PR DESCRIPTION
Bug can be triggered by the following code snippet

```python
from joblib import Memory
from collections import OrderedDict
import sympy as sp

cache = Memory(cachedir="/tmp/joblib").cache
@cache
def testFunc(arg):
    return arg

r1 = testFunc(OrderedDict([(sp.Symbol("a"), 1),
                           (sp.Symbol("b"), 2) ]))

r2 = testFunc(OrderedDict([(sp.Symbol("a"), 1),
                           (sp.Symbol("b"), 4) ]))

assert(r1 != r2, "Bug!")
```

Bug is caused because iteration over 'items' iterator is possible only once.
When exception is caught, 'items' is not valid any more.
Could be solved alternatively by `items = list(items)` in the beginning of `_bach_setitems` functions.
Probably this would destroy the performance advantage gained by the more complicated exception construct. So this simpler solution was chosen.