### PR TITLE
pickle: pad numpy bytes to ensure correct alignment with memmap

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -325,12 +325,12 @@ class NumpyPickler(Pickler):
             # The array wrapper is pickled instead of the real array.
             wrapper = self._create_array_wrapper(obj)
 
-            Pickler.save(self, wrapper)
-
             # This is ugly but it avoids pickle to reuse the references of
             # previously pickled NumpyArrayWrapper. This way, pickled numpy
             # arrays can be memapped aligned in memory
             self.clear_memo()
+
+            Pickler.save(self, wrapper)
 
             # A framer was introduced with pickle protocol 4 and we want to
             # ensure the wrapper object is written before the numpy array

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -932,28 +932,29 @@ def test_memmap_alignment_padding(tmpdir, protocol):
     assert memmap.ctypes.data % 8 == 0
     assert memmap.flags.aligned
 
-    # l = [np.random.randn(2), np.random.randn(2),
-    #      np.random.randn(2), np.random.randn(2)]
+    l = [np.random.randn(2), np.random.randn(2),
+         np.random.randn(2), np.random.randn(2)]
 
-    # numpy_pickle.dump(l, fname, protocol=protocol)
-    # l_reloaded = numpy_pickle.load(fname, mmap_mode='r')
+    numpy_pickle.dump(l, fname, protocol=protocol)
+    l_reloaded = numpy_pickle.load(fname, mmap_mode='r')
 
-    # for idx, memmap in enumerate(l_reloaded):
-    #     assert isinstance(memmap, np.memmap)
-    #     np.testing.assert_array_equal(l[idx], memmap)
-    #     assert memmap.ctypes.data % 8 == 0
-    #     assert memmap.flags.aligned
+    for idx, memmap in enumerate(l_reloaded):
+        assert isinstance(memmap, np.memmap)
+        np.testing.assert_array_equal(l[idx], memmap)
+        print("MODULO: {}".format(memmap.ctypes.data % 8))
+        assert memmap.ctypes.data % 8 == 0
+        assert memmap.flags.aligned
 
-    # d = {'a1': np.random.randn(100),
-    #      'a2': np.random.randn(200),
-    #      'a3': np.random.randn(300),
-    #      'a4': np.random.randn(400)}
+    d = {'a1': np.random.randn(100),
+         'a2': np.random.randn(200),
+         'a3': np.random.randn(300),
+         'a4': np.random.randn(400)}
 
-    # numpy_pickle.dump(d, fname, protocol=protocol)
-    # d_reloaded = numpy_pickle.load(fname, mmap_mode='r')
+    numpy_pickle.dump(d, fname, protocol=protocol)
+    d_reloaded = numpy_pickle.load(fname, mmap_mode='r')
 
-    # for key, memmap in d_reloaded.items():
-    #     assert isinstance(memmap, np.memmap)
-    #     np.testing.assert_array_equal(d[key], memmap)
-    #     assert memmap.ctypes.data % 8 == 0
-    #     assert memmap.flags.aligned
+    for key, memmap in d_reloaded.items():
+        assert isinstance(memmap, np.memmap)
+        np.testing.assert_array_equal(d[key], memmap)
+        assert memmap.ctypes.data % 8 == 0
+        assert memmap.flags.aligned

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -919,7 +919,8 @@ def test_load_memmap_with_big_offset(tmpdir):
 
 
 @with_numpy
-def test_memmap_alignment_padding(tmpdir):
+@parametrize('protocol', range(pickle.HIGHEST_PROTOCOL + 1))
+def test_memmap_alignment_padding(tmpdir, protocol):
     # Test that memmaped arrays returned by numpy.load are correctly aligned
 
     fname = tmpdir.join('test.mmap').strpath
@@ -927,7 +928,7 @@ def test_memmap_alignment_padding(tmpdir):
 
     l = [arr, arr, arr, arr]
 
-    numpy_pickle.dump(l, fname)
+    numpy_pickle.dump(l, fname, protocol=protocol)
     l_reloaded = numpy_pickle.load(fname, mmap_mode='r')
 
     for memmap in l_reloaded:

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -919,7 +919,7 @@ def test_load_memmap_with_big_offset(tmpdir):
 
 
 @with_numpy
-@parametrize('protocol', range(1, pickle.HIGHEST_PROTOCOL + 1))
+@parametrize('protocol', range(0, pickle.HIGHEST_PROTOCOL + 1))
 def test_memmap_alignment_padding(tmpdir, protocol):
     # Test that memmaped arrays returned by numpy.load are correctly aligned
     fname = tmpdir.join('test.mmap').strpath
@@ -932,16 +932,17 @@ def test_memmap_alignment_padding(tmpdir, protocol):
     assert memmap.ctypes.data % 8 == 0
     assert memmap.flags.aligned
 
-    l = [np.random.randn(200), np.random.randn(300)]
+    # l = [np.random.randn(2), np.random.randn(2),
+    #      np.random.randn(2), np.random.randn(2)]
 
-    numpy_pickle.dump(l, fname, protocol=protocol)
-    l_reloaded = numpy_pickle.load(fname, mmap_mode='r')
+    # numpy_pickle.dump(l, fname, protocol=protocol)
+    # l_reloaded = numpy_pickle.load(fname, mmap_mode='r')
 
-    for idx, memmap in enumerate(l_reloaded):
-        assert isinstance(memmap, np.memmap)
-        np.testing.assert_array_equal(l[idx], memmap)
-        assert memmap.ctypes.data % 8 == 0
-        assert memmap.flags.aligned
+    # for idx, memmap in enumerate(l_reloaded):
+    #     assert isinstance(memmap, np.memmap)
+    #     np.testing.assert_array_equal(l[idx], memmap)
+    #     assert memmap.ctypes.data % 8 == 0
+    #     assert memmap.flags.aligned
 
     # d = {'a1': np.random.randn(100),
     #      'a2': np.random.randn(200),

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -916,3 +916,21 @@ def test_load_memmap_with_big_offset(tmpdir):
     assert isinstance(memmaps[1], np.memmap)
     assert memmaps[1].offset > size
     np.testing.assert_array_equal(obj, memmaps)
+
+
+@with_numpy
+def test_memmap_alignment_padding(tmpdir):
+    # Test that memmaped arrays returned by numpy.load are correctly aligned
+
+    fname = tmpdir.join('test.mmap').strpath
+    arr = np.random.randn(2)
+
+    l = [arr, arr, arr, arr]
+
+    numpy_pickle.dump(l, fname)
+    l_reloaded = numpy_pickle.load(fname, mmap_mode='r')
+
+    for memmap in l_reloaded:
+        assert isinstance(memmap, np.memmap)
+        np.testing.assert_array_equal(arr, memmap)
+        assert memmap.ctypes.data % 8 == 0

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -943,16 +943,16 @@ def test_memmap_alignment_padding(tmpdir, protocol):
         assert memmap.ctypes.data % 8 == 0
         assert memmap.flags.aligned
 
-    d = {'a1': np.random.randn(100),
-         'a2': np.random.randn(200),
-         'a3': np.random.randn(300),
-         'a4': np.random.randn(400)}
+    # d = {'a1': np.random.randn(100),
+    #      'a2': np.random.randn(200),
+    #      'a3': np.random.randn(300),
+    #      'a4': np.random.randn(400)}
 
-    numpy_pickle.dump(d, fname, protocol=protocol)
-    d_reloaded = numpy_pickle.load(fname, mmap_mode='r')
+    # numpy_pickle.dump(d, fname, protocol=protocol)
+    # d_reloaded = numpy_pickle.load(fname, mmap_mode='r')
 
-    for key, memmap in d_reloaded.items():
-        assert isinstance(memmap, np.memmap)
-        np.testing.assert_array_equal(d[key], memmap)
-        assert memmap.ctypes.data % 8 == 0
-        assert memmap.flags.aligned
+    # for key, memmap in d_reloaded.items():
+    #     assert isinstance(memmap, np.memmap)
+    #     np.testing.assert_array_equal(d[key], memmap)
+    #     assert memmap.ctypes.data % 8 == 0
+    #     assert memmap.flags.aligned

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -934,3 +934,4 @@ def test_memmap_alignment_padding(tmpdir):
         assert isinstance(memmap, np.memmap)
         np.testing.assert_array_equal(arr, memmap)
         assert memmap.ctypes.data % 8 == 0
+        assert memmap.flags.aligned


### PR DESCRIPTION
This is an attempt to fix #563.

The idea is to provide the same strategy that [numpy does](https://github.com/numpy/numpy/blob/1e494f1e283340d545b1c7c15dded04a4aaae939/numpy/lib/format.py#L328-L333) but in the pickle file, since the array bytes are stored inlined in the pickle stream.

For the moment, it doesn't work (I'm even not sure if my test function is valid...).