### PR TITLE
Make input task generator aware of intermediate results

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -213,6 +213,7 @@ class BatchCompletionCallBack(object):
         self.parallel = parallel
 
     def __call__(self, out):
+        self.parallel.last_async_output = out
         self.parallel.n_completed_tasks += self.batch_size
         this_batch_duration = time.time() - self.dispatch_timestamp
 
@@ -529,6 +530,7 @@ class Parallel(Logger):
 
         self._backend = backend
         self._output = None
+        self.last_async_output = None
         self._jobs = list()
         self._managed_backend = False
 
@@ -792,6 +794,7 @@ Sub-process traceback:
             # that pre_dispatch == "all", n_jobs == 1 or that the first batch
             # was very quick and its callback already dispatched all the
             # remaining jobs.
+            self.last_async_output = None
             self._iterating = False
             if self.dispatch_one_batch(iterator):
                 self._iterating = self._original_iterator is not None
@@ -817,6 +820,7 @@ Sub-process traceback:
             self._jobs = list()
         output = self._output
         self._output = None
+        self.last_async_output = None
         return output
 
     def __repr__(self):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -978,7 +978,7 @@ def test_backend_batch_statistics_reset(backend):
 
 
 @with_multiprocessing
-@parametrize('backend', ['multiprocessing', 'loky'])
+@parametrize('backend', PARALLEL_BACKENDS)
 def test_read_output_from_task_generator(backend):
     """Check that the task generator can read the flow of outputs."""
 
@@ -998,7 +998,9 @@ def test_read_output_from_task_generator(backend):
         i = 0
         while i < n_iter:
             time.sleep(0.01 * random.randint(1, 100))
-            next_element = pool.last_async_output.result()
+            next_element = pool.last_async_output
+            if hasattr(next_element, 'result'):
+                next_element = next_element.result()
             for e in next_element:
                 if i < n_iter:
                     time.sleep(0.001 * random.randint(1, 100))
@@ -1011,7 +1013,8 @@ def test_read_output_from_task_generator(backend):
     n_iter = 20
 
     pool = Parallel(n_jobs=n_jobs, pre_dispatch=pre_dispatch,
-                    batch_size=batch_size, verbose=0)
+                    batch_size=batch_size, verbose=0,
+                    backend=backend)
 
     output = pool(delayed(some_function)(i) for i in
                   task_generator(pool, pre_dispatch, batch_size,


### PR DESCRIPTION
Those few changes to parallel.py are intended to enable reading intermediate outputs during the call to `Parallel` (Related to #79 and #217).

The callback passed to `apply_async` now update an attribute `last_async_output` to the running `Parallel` instance. It stores the result that has triggered the callback. This value can now be read and processed by the input generator, e.g for logging / printing purpose or to generate new tasks (see example in `test_parallel.py`).

It seems to work without unexpected behavior for the same reason that the line 217 `self.parallel.n_completed_tasks += self.batch_size` is safe: multiprocessing (and loky ?) only use one thread to sequentially execute the callbacks. Hence if the input generator reads `Parallel.last_async_output` the value is guaranteed to be the result that has triggered the callback that had himself triggered one more read into the generator.

(edit: I also tried to make the generator directly read `parallel._output` but it can happen that the result that has triggered the callback is not added to `parallel._output` yet)