### PR TITLE
2 new parameters: return a generator / return results asynchronously / add helper function for callbacks

### DIFF
--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -21,6 +21,25 @@ can be spread over 2 CPUs using the following::
     >>> Parallel(n_jobs=2)(delayed(sqrt)(i ** 2) for i in range(10))
     [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 
+The output can be a generator that yields the results as soon as they're
+available, even if the subsequent tasks aren't completed yet. The order
+of the outputs always matches the order of the inputs::
+
+    >>> from math import sqrt
+    >>> from joblib import Parallel, delayed
+    >>> pool = Parallel(n_jobs=2, return_generator=True)
+    >>> input_generator = (delayed(sqrt)(i ** 2) for i in range(10))
+    >>> output_generator = pool(input_generator)
+    >>> type(output_generator)
+    <class 'generator'>
+    >>> next(output_generator)
+    0.0
+    >>> next(output_generator)
+    1.0
+
+By default joblib uses the ``'loky'`` backend to safely and efficiently
+use a pool of worker Python processes to execute the delayed functions
+on each set of arguments in the comprehension.
 
 Thread-based parallelism vs process-based parallelism
 =====================================================

--- a/examples/parallel_generator.py
+++ b/examples/parallel_generator.py
@@ -17,24 +17,24 @@ This example illustrates memory optimization enabled by using
 # Save memory by consuming the outputs of the tasks as soon as it's available
 ##############################################################################
 #
-# We create a task whose output takes about 60MB of RAM
+# We create a task whose output takes about 15MB of RAM
 import time
 import numpy as np
 
 
 def memory_consuming_task(i):
     time.sleep(2)
-    return i * np.ones((10000, 100), dtype=np.float64)
+    return i * np.ones((10000, 200), dtype=np.float64)
 
 
 ###############################################################################
 # We process those many of those tasks in parallel. Normally we should expect
-# a usage of more than 5GB in RAM. Here we reduce the outputs faster than the
+# a usage of more than 3GB in RAM. Here we reduce the outputs faster than the
 # workers can compute new ones. We see a clear benefit: the overall memory
-# footprint is less than 500MB.
+# footprint is less than 150B.
 
 from joblib import Parallel, delayed
 pool = Parallel(n_jobs=2, return_generator=True)
-out = pool(delayed(memory_consuming_task)(i) for i in range(100))
+out = pool(delayed(memory_consuming_task)(i) for i in range(200))
 reduced_output = sum(out)
 print('All tasks completed and reduced successfully.')

--- a/examples/parallel_generator.py
+++ b/examples/parallel_generator.py
@@ -1,0 +1,40 @@
+"""
+========================================
+Returning a generator in joblib.Parallel
+========================================
+
+This example illustrates memory optimization enabled by using
+ :class:`joblib.Parallel` to get a generator on the output of parallel jobs.
+ We first create a task that is very memory demanding. We parallelize
+ several of those tasks such that we should expect a memory error if all
+ of the outputs were to stack. We show that the memory is efficiently
+ managed if we use the generator to perform a reduce step that progressively
+ consumes the outputs and keep the memory at an acceptable level.
+
+"""
+
+##############################################################################
+# Save memory by consuming the outputs of the tasks as soon as it's available
+##############################################################################
+#
+# We create a task whose output takes about 0.6GB of available memory
+import time
+import numpy as np
+
+def memory_consuming_task(i):
+    time.sleep(2)
+    return i*np.ones((100000,100),dtype=np.float64)
+
+
+###############################################################################
+# We process those many of those tasks in parallel. Normally we should expect
+# a usage of more than 50GB in RAM (and the process would terminate with a
+# MemoryError) before we get there on most computers). Here we reduce the
+# outputs faster than the workers need to compute new ones, which controls
+# the memory usage.
+
+from joblib import Parallel, delayed
+pool = Parallel(n_jobs=2, return_generator=True)
+out = pool(delayed(memory_consuming_task)(i) for i in range(100))
+reduced_output = sum(out)
+print('All tasks completed and reduced successfully.')

--- a/examples/parallel_generator.py
+++ b/examples/parallel_generator.py
@@ -17,21 +17,21 @@ This example illustrates memory optimization enabled by using
 # Save memory by consuming the outputs of the tasks as soon as it's available
 ##############################################################################
 #
-# We create a task whose output takes about 0.6GB of available memory
+# We create a task whose output takes about 60MB of RAM
 import time
 import numpy as np
 
+
 def memory_consuming_task(i):
     time.sleep(2)
-    return i*np.ones((100000,100),dtype=np.float64)
+    return i * np.ones((10000, 100), dtype=np.float64)
 
 
 ###############################################################################
 # We process those many of those tasks in parallel. Normally we should expect
-# a usage of more than 50GB in RAM (and the process would terminate with a
-# MemoryError) before we get there on most computers). Here we reduce the
-# outputs faster than the workers need to compute new ones, which controls
-# the memory usage.
+# a usage of more than 5GB in RAM. Here we reduce the outputs faster than the
+# workers can compute new ones. We see a clear benefit: the overall memory
+# footprint is less than 500MB.
 
 from joblib import Parallel, delayed
 pool = Parallel(n_jobs=2, return_generator=True)

--- a/examples/parallel_generator.py
+++ b/examples/parallel_generator.py
@@ -5,16 +5,16 @@ Returning a generator in joblib.Parallel
 
 This example illustrates memory optimization enabled by using
  :class:`joblib.Parallel` to get a generator on the output of parallel jobs.
- We first create a task that is very memory demanding. We parallelize
- several of those tasks such that we should expect a memory error if all
+ We first create tasks that are very memory demanding. We parallelize
+ several of those tasks such that we should observe a high memory usage if all
  of the outputs were to stack. We show that the memory is efficiently
  managed if we use the generator to perform a reduce step that progressively
- consumes the outputs and keep the memory at an acceptable level.
+ consumes the outputs and keeps the memory at an acceptable level.
 
 """
 
 ##############################################################################
-# Save memory by consuming the outputs of the tasks as soon as it's available
+# Save memory by consuming the outputs of the tasks as fast as possible
 ##############################################################################
 #
 # We create a task whose output takes about 15MB of RAM
@@ -22,19 +22,19 @@ import time
 import numpy as np
 
 
-def memory_consuming_task(i):
-    time.sleep(2)
+def memory_demanding_task(i):
+    time.sleep(1)
     return i * np.ones((10000, 200), dtype=np.float64)
 
 
 ###############################################################################
-# We process those many of those tasks in parallel. Normally we should expect
+# We process many of those tasks in parallel. Normally, we should expect
 # a usage of more than 3GB in RAM. Here we reduce the outputs faster than the
 # workers can compute new ones. We see a clear benefit: the overall memory
-# footprint is less than 150B.
+# footprint is at least twice less.
 
 from joblib import Parallel, delayed
-pool = Parallel(n_jobs=2, return_generator=True)
-out = pool(delayed(memory_consuming_task)(i) for i in range(200))
+out = Parallel(n_jobs=2, return_generator=True)(
+    delayed(memory_demanding_task)(i) for i in range(200))
 reduced_output = sum(out)
 print('All tasks completed and reduced successfully.')

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -195,8 +195,8 @@ class PoolManagerMixin(object):
         cberr = {}
         if error_callback is not None:
             cberr['error_callback'] = error_callback
-        return self._get_pool().apply_async(
-                SafeFunction(func), callback=callback, **cberr)
+        return self._get_pool().apply_async(SafeFunction(func),
+                                            callback=callback, **cberr)
 
     def abort_everything(self, ensure_ready=True):
         """Shutdown the pool and restart a new one with the same parameters"""

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -195,8 +195,8 @@ class PoolManagerMixin(object):
         cberr = {}
         if error_callback is not None:
             cberr['error_callback'] = error_callback
-        return self._pool.apply_async(SafeFunction(func), callback=callback,
-                                      **cberr)
+        return self._get_pool().apply_async(
+                SafeFunction(func), callback=callback, **cberr)
 
     def abort_everything(self, ensure_ready=True):
         """Shutdown the pool and restart a new one with the same parameters"""

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -51,7 +51,7 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
         """
 
     @abstractmethod
-    def apply_async(self, func, callback=None):
+    def apply_async(self, func, callback=None, error_callback=None):
         """Schedule a func to be run"""
 
     def configure(self, n_jobs=1, parallel=None, prefer=None, require=None,
@@ -143,12 +143,18 @@ class SequentialBackend(ParallelBackendBase):
             raise ValueError('n_jobs == 0 in Parallel has no meaning')
         return 1
 
-    def apply_async(self, func, callback=None):
+    def apply_async(self, func, callback=None, error_callback=None):
         """Schedule a func to be run"""
-        result = ImmediateResult(func)
-        if callback:
-            callback(result)
-        return result
+        try:
+            result = ImmediateResult(func)
+            if callback:
+                callback(result)
+            return result
+        except Exception as exception:
+            if error_callback:
+                error_callback(exception)
+            else:
+                raise exception
 
     def get_nested_backend(self):
         return self
@@ -182,10 +188,15 @@ class PoolManagerMixin(object):
         """Used by apply_async to make it possible to implement lazy init"""
         return self._pool
 
-    def apply_async(self, func, callback=None):
+    def apply_async(self, func, callback=None, error_callback=None):
         """Schedule a func to be run"""
-        return self._get_pool().apply_async(
-            SafeFunction(func), callback=callback)
+        # HACK: error_callback not implemented in python2
+        # do not even pass error_callback = None
+        cberr = {}
+        if error_callback is not None:
+            cberr['error_callback'] = error_callback
+        return self._pool.apply_async(SafeFunction(func), callback=callback,
+                                      **cberr)
 
     def abort_everything(self, ensure_ready=True):
         """Shutdown the pool and restart a new one with the same parameters"""
@@ -460,10 +471,13 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
             n_jobs = max(cpu_count() + 1 + n_jobs, 1)
         return n_jobs
 
-    def apply_async(self, func, callback=None):
+    def apply_async(self, func, callback=None, error_callback=None):
         """Schedule a func to be run"""
         future = self._workers.submit(SafeFunction(func))
         future.get = functools.partial(self.wrap_future_result, future)
+        if error_callback is not None:
+            raise NotImplementedError('Loky Backend does not support'
+                                      'error callbacks')
         if callback is not None:
             future.add_done_callback(callback)
         return future

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -423,6 +423,8 @@ class Parallel(Logger):
         mmap_mode: {None, 'r+', 'r', 'w+', 'c'}
             Memmapping mode for numpy arrays passed to workers.
             See 'max_nbytes' parameter documentation for more details.
+        return_generator: bool
+            If True, calls to this instance will return a generator.
 
         Notes
         -----
@@ -544,7 +546,7 @@ class Parallel(Logger):
     def __init__(self, n_jobs=None, backend=None, verbose=0, timeout=None,
                  pre_dispatch='2 * n_jobs', batch_size='auto',
                  temp_folder=None, max_nbytes='1M', mmap_mode='r',
-                 prefer=None, require=None):
+                 return_generator=False, prefer=None, require=None):
         active_backend, context_n_jobs = get_active_backend(
             prefer=prefer, require=require, verbose=verbose)
         if backend is None and n_jobs is None:
@@ -559,6 +561,7 @@ class Parallel(Logger):
         self.verbose = verbose
         self.timeout = timeout
         self.pre_dispatch = pre_dispatch
+        self.return_generator = return_generator
 
         if isinstance(max_nbytes, _basestring):
             max_nbytes = memstr_to_bytes(max_nbytes)
@@ -607,7 +610,6 @@ class Parallel(Logger):
                 % batch_size)
 
         self._backend = backend
-        self._output = None
         self._jobs = list()
         self._managed_backend = False
 
@@ -669,6 +671,7 @@ class Parallel(Logger):
 
         dispatch_timestamp = time.time()
         cb = BatchCompletionCallBack(dispatch_timestamp, len(batch), self)
+
         with self._lock:
             job_idx = len(self._jobs)
             job = self._backend.apply_async(batch, callback=cb)
@@ -772,65 +775,43 @@ class Parallel(Logger):
                          short_format_time(remaining_time),
                          ))
 
-    def retrieve(self):
-        self._output = list()
-        while self._iterating or len(self._jobs) > 0:
-            if len(self._jobs) == 0:
-                # Wait for an async callback to dispatch new jobs
-                time.sleep(0.01)
-                continue
-            # We need to be careful: the job list can be filling up as
-            # we empty it and Python list are not thread-safe by default hence
-            # the use of the lock
-            with self._lock:
-                job = self._jobs.pop(0)
+    def _handle_error(self, exception):
+        # Stop dispatching any new job in the async callback thread
+        self._aborting = True
 
-            try:
-                if getattr(self._backend, 'supports_timeout', False):
-                    self._output.extend(job.get(timeout=self.timeout))
-                else:
-                    self._output.extend(job.get())
+        # If the backend allows it, cancel or kill remaining running
+        # tasks without waiting for the results as we will raise
+        # the exception we got back to the caller instead of returning
+        # any result.
+        backend = self._backend
+        if (backend is not None and
+                hasattr(backend, 'abort_everything')):
+            # If the backend is managed externally we need to make sure
+            # to leave it in a working state to allow for future jobs
+            # scheduling.
+            ensure_ready = self._managed_backend
+            backend.abort_everything(ensure_ready=ensure_ready)
 
-            except BaseException as exception:
-                # Note: we catch any BaseException instead of just Exception
-                # instances to also include KeyboardInterrupt.
-
-                # Stop dispatching any new job in the async callback thread
-                self._aborting = True
-
-                # If the backend allows it, cancel or kill remaining running
-                # tasks without waiting for the results as we will raise
-                # the exception we got back to the caller instead of returning
-                # any result.
-                backend = self._backend
-                if (backend is not None and
-                        hasattr(backend, 'abort_everything')):
-                    # If the backend is managed externally we need to make sure
-                    # to leave it in a working state to allow for future jobs
-                    # scheduling.
-                    ensure_ready = self._managed_backend
-                    backend.abort_everything(ensure_ready=ensure_ready)
-
-                if not isinstance(exception, TransportableException):
-                    raise
-                else:
-                    # Capture exception to add information on the local
-                    # stack in addition to the distant stack
-                    this_report = format_outer_frames(context=10,
-                                                      stack_start=1)
-                    report = """Multiprocessing exception:
+        if not isinstance(exception, TransportableException):
+            raise
+        else:
+            # Capture exception to add information on the local
+            # stack in addition to the distant stack
+            this_report = format_outer_frames(context=10,
+                                              stack_start=1)
+            report = """Multiprocessing exception:
 %s
 ---------------------------------------------------------------------------
 Sub-process traceback:
 ---------------------------------------------------------------------------
 %s""" % (this_report, exception.message)
-                    # Convert this to a JoblibException
-                    exception_type = _mk_exception(exception.etype)[0]
-                    exception = exception_type(report)
+            # Convert this to a JoblibException
+            exception_type = _mk_exception(exception.etype)[0]
+            exception = exception_type(report)
 
-                    raise exception
+            raise exception
 
-    def __call__(self, iterable):
+    def _retrieve(self, iterable):
         if self._jobs:
             raise ValueError('This Parallel instance is already running')
         # A flag used to abort the dispatching of jobs in case an
@@ -888,19 +869,42 @@ Sub-process traceback:
                 self._iterating = False
 
             with self._backend.retrieval_context():
-                self.retrieve()
+                while self._iterating or len(self._jobs) > 0:
+                    if len(self._jobs) == 0:
+                        # Wait for an async callback to dispatch new jobs
+                        time.sleep(0.01)
+                        continue
+
+                    # We need to be careful: the buffer list can be filling up
+                    # as we empty it and Python list are not thread-safe by
+                    # default hence the use of the lock
+                    with self._lock:
+                        job = self._jobs.pop(0)
+                    if getattr(self._backend, 'supports_timeout', False):
+                        res_batch = job.get(timeout=self.timeout)
+                    else:
+                        res_batch = job.get()
+
+                    for res in res_batch:
+                        yield res
+
             # Make sure that we get a last message telling us we are done
             elapsed_time = time.time() - self._start_time
             self._print('Done %3i out of %3i | elapsed: %s finished',
-                        (len(self._output), len(self._output),
+                        (self.n_completed_tasks, self.n_completed_tasks,
                          short_format_time(elapsed_time)))
+        # Note: we catch any BaseException instead of just Exception
+        # instances to also include KeyboardInterrupt.
+        except BaseException as exception:
+            self._handle_error(exception)
         finally:
             if not self._managed_backend:
                 self._terminate_backend()
             self._jobs = list()
-        output = self._output
-        self._output = None
-        return output
+
+    def __call__(self, iterable):
+        output = self._retrieve(iterable)
+        return output if self.return_generator else list(output)
 
     def __repr__(self):
         return '%s(n_jobs=%s)' % (self.__class__.__name__, self.n_jobs)

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -13,6 +13,7 @@ that uses a custom alternative to SimpleQueue.
 # Copyright: 2012, Olivier Grisel
 # License: BSD 3 clause
 
+import os
 import sys
 import warnings
 from time import sleep
@@ -316,6 +317,8 @@ class MemmappingPool(PicklingPool):
         n_retries = 10
         for i in range(n_retries):
             try:
+                if os.name != 'nt':
+                    self._inqueue._reader.close()
                 super(MemmappingPool, self).terminate()
                 break
             except OSError as e:

--- a/joblib/test/common.py
+++ b/joblib/test/common.py
@@ -96,6 +96,9 @@ def teardown_autokill(module_name):
         killer.cancel()
 
 
+with_python_3 = skipif(
+    sys.version_info < (3, 0), reason="requires Python3")
+
 with_multiprocessing = skipif(
     mp is None, reason='Needs multiprocessing to run.')
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -10,6 +10,7 @@ import os
 import sys
 import time
 import mmap
+import random
 import threading
 from math import sqrt
 from time import sleep
@@ -20,7 +21,7 @@ from joblib import dump, load
 from joblib import parallel
 
 from joblib.test.common import np, with_numpy
-from joblib.test.common import with_multiprocessing
+from joblib.test.common import with_multiprocessing, with_python_3
 from joblib.testing import (parametrize, raises, check_subprocess_call,
                             SkipTest, warns)
 from joblib._compat import PY3_OR_LATER
@@ -1191,3 +1192,66 @@ def test_global_parallel_backend():
 
     pb.unregister()
     assert type(Parallel()._backend) is type(default)
+
+
+def some_function(i):
+    time.sleep(0.001 * random.randint(1, 100))
+    return (i + 1)
+
+
+@with_multiprocessing
+@parametrize('backend', PARALLEL_BACKENDS)
+def test_read_output_from_task_generator(backend):
+    """Check that the task generator can read the flow of outputs."""
+
+    def task_generator(pool, pre_dispatch, batch_size, n_jobs, n_iter):
+        # pre-computed tasks must be ready for pre-dispatch
+        x = -1
+        for i in range(batch_size * eval(pre_dispatch)):
+            x += 1
+            time.sleep(0.001 * random.randint(1, 100))
+            yield 10**(x)
+
+        # now, new tasks can be created from outputs
+        i = 0
+        while i < n_iter:
+            time.sleep(0.01 * random.randint(1, 100))
+            next_element = pool.get_last_async_result()
+            if hasattr(next_element, 'result'):
+                next_element = next_element.result()
+            for e in next_element:
+                if i < n_iter:
+                    time.sleep(0.001 * random.randint(1, 100))
+                    i += 1
+                    yield e
+
+    pre_dispatch = '2*n_jobs'
+    batch_size = 3  # batch_size != 'auto'
+    n_jobs = 3
+    n_iter = 20
+
+    pool = Parallel(n_jobs=n_jobs, pre_dispatch=pre_dispatch,
+                    batch_size=batch_size, verbose=0,
+                    backend=backend)
+
+    output = pool(delayed(some_function)(i) for i in
+                  task_generator(pool, pre_dispatch, batch_size,
+                                 n_jobs, n_iter))
+
+    assert(len(output) == (n_iter + (batch_size * eval(pre_dispatch))))
+
+
+@with_multiprocessing
+@with_python_3
+@parametrize('backend', ['multiprocessing'])
+def test_async_and_sync_return_same_results(backend):
+    """Check that the outputs in async mode are consistents with sync mode"""
+
+    pool = Parallel(n_jobs=2, as_completed=True, backend=backend)
+    pool2 = Parallel(n_jobs=2, as_completed=False, backend=backend)
+
+    res = pool(delayed(some_function)(i) for i in range(15))
+    res2 = pool2(delayed(some_function)(i) for i in range(15))
+    print(res)  # order is different at each call
+    print(res2)  # order is as expected
+    assert(sorted(res) == res2)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1049,9 +1049,8 @@ def test_backend_batch_statistics_reset(backend):
 @parametrize('backend', BACKENDS)
 @parametrize('n_jobs', [1, 2, -2, -1])
 def test_deadlock_with_generator(backend, n_jobs):
-    # This test used to timeout with multiprocessing backend.
-    # We use a large numpy object to delay the pickler, which causes Pipes
-    # to timeout.
+    # Non-regression test for a race condition in the backends when the pickler
+    # is delayed by a large object.
     def func(arg):
         result = np.ones(int(5 * 1e5), dtype=bool)
         result[0] = False

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -222,8 +222,10 @@ def nested_loop(backend):
 
 @parametrize('child_backend', BACKENDS)
 @parametrize('parent_backend', BACKENDS)
-def test_nested_loop(parent_backend, child_backend):
-    Parallel(n_jobs=2, backend=parent_backend)(
+@parametrize('return_generator', [True, False])
+def test_nested_loop(parent_backend, child_backend, return_generator):
+    Parallel(n_jobs=2, backend=parent_backend,
+             return_generator=return_generator)(
         delayed(nested_loop)(child_backend) for _ in range(2))
 
 
@@ -914,6 +916,23 @@ def test_warning_about_timeout_not_supported_by_backend():
         "will not be used.")
 
 
+def set_list_value(input_list, index, value):
+    input_list[index] = value
+    return value
+
+
+def test_parallel_return_generator():
+    # This test inserts values in a list in some expected order
+    # in sequential computing, and then check that this order has been
+    # respectted by Parallel output generator.
+    input_list = [0] * 5
+    result = Parallel(n_jobs=1, return_generator=True)(
+        delayed(set_list_value)(input_list, i, i) for i in range(5))
+
+    for i, each in enumerate(result):
+        assert input_list[i] == each
+
+
 @parametrize('backend', ALL_VALID_BACKENDS)
 @parametrize('n_jobs', [1, 2, -2, -1])
 def test_abort_backend(n_jobs, backend):
@@ -1024,6 +1043,27 @@ def test_backend_batch_statistics_reset(backend):
 
     # Tolerance in the timing comparison to avoid random failures on CIs
     assert test_time / ref_time <= 1 + relative_tolerance
+
+
+@with_numpy
+@parametrize('backend', BACKENDS)
+@parametrize('n_jobs', [1, 2, -2, -1])
+def test_deadlock_with_generator(backend, n_jobs):
+    # This test used to timeout with multiprocessing backend.
+    # We use a large numpy object to delay the pickler, which causes Pipes
+    # to timeout.
+    def func(arg):
+        result = np.ones(int(5 * 1e5), dtype=bool)
+        result[0] = False
+        return result
+
+    result = Parallel(n_jobs=n_jobs, backend=backend, return_generator=True)(
+        delayed(func)(i) for i in range(10))
+
+    next(result)
+    next(result)
+
+    del result
 
 
 def test_backend_hinting_and_constraints():


### PR DESCRIPTION
Ok, I think I did it! `Parallel` API now include two new keywords:

 - `as_generator`: if `True` the output of `__call__` will be a generator. The user is free to iterate on said generator as he wishes (this does not affect the speed of computations).
 - `async_output` : if `True` the output of `__call__` will not be sorted according to the input `iterable`, instead the first elements in the output list (or the output generator if `as_generator = True` ) are the results that are returned first by the child processes(or threads depending on the backend).

Those two parameters are totally independants. Also, all the nice features of joblib are left untouched (logging,...). Here a little code to test the result (requires PYTHON 3):
```
import time
import random
from joblib import Parallel, delayed


def some_function(i):
    time.sleep(0.001 * random.randint(1, 100))
    return (i + 1)


pool = Parallel(n_jobs=2, async_output=True, backend='multiprocessing')
pool2 = Parallel(n_jobs=2, async_output=False, backend='multiprocessing')

res = pool(delayed(some_function)(i) for i in range(100))
res2 = pool2(delayed(some_function)(i) for i in range(100))
print(res) # order is different at each call
print(res2) # order is as expected
assert(sorted(res) == res2)
```

/!\ for now `async_output` only works in python 3, with `backend = multiprocessing`. I've added some foundations for support for `error_callback` keyword in `_parallel_backend`.

I've also added a helper function `get_last_async_result` that is useful if the user wishes to add callbacks inside the input `iterable`.

Implements #79, #217, and follows the previous (closed) PR #582, #585, #586 (that partially implemented the present PR).
