### PR TITLE
[MRG] Test codecov fix and remove debugging code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,11 @@ after_success:
     - |
       if [[ "$COVERAGE" == "true" ]]; then
           ls -ltrh .coverage*
-          # running joblib tests with coverage enabled produces empty .coverage.*
-          # files when starting subprocesses. They prevent proper combinations of
-          # .coverage.* files through "coverage combine" (run under the hood by
-          # codecov >= 2.0.13) The next line cleans up empty .coverage.* files
+          # Running joblib tests with coverage enabled produces empty
+          # .coverage.* files when starting subprocesses. They prevent proper
+          # combinations of .coverage.* files through "coverage combine" (run
+          # under the hood by codecov >= 2.0.13). The next line cleans up empty
+          # .coverage.* files
           find -name '.coverage.*' -size 0 -delete
-          # coverage report || true
-          # explicitly run coverage combine -a otherwise codecov runs coverage
-          # combine and overrides .coverage
-          coverage combine -a || true
-          # coverage report || true
           codecov
       fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,16 +42,10 @@ artifacts:
 
 on_success:
   # - TODO: upload the content of dist/*.whl to a public wheelhouse
-  # - ps: ls .coverage*
-  # running joblib tests with coverage enabled produces empty .coverage.* files
+  - ps: ls .coverage*
+  # Running joblib tests with coverage enabled produces empty .coverage.* files
   # when starting subprocesses. They prevent proper combinations of .coverage.*
-  # files through "coverage combine" (run under the hood by codecov >= 2.0.13)
+  # files through "coverage combine" (run under the hood by codecov >= 2.0.13).
   # The next line cleans up empty .coverage.* files
   - ps: Get-ChildItem -Path .coverage.* | where {$_.length -eq 0} | remove-Item
-  # - ps: ls .coverage*
-  # - coverage report
-  # explicitly run coverage combine -a otherwise codecov runs coverage combine
-  # and overrides .coverage
-  - coverage combine -a
-  # - coverage report
   - codecov


### PR DESCRIPTION
codecov 2.0.14 should have the fix from https://github.com/codecov/codecov-python/issues/135 so we don't need to do `codecov combine -a` before calling `codecov`.