### PR TITLE
[MRG+1] Backend hints and shared memory constraints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ Olivier Grisel
     docker containers ``/dev/shm`` is only 64 MB by default which would cause
     frequent failures when running joblib in Docker containers.
 
+    Make it possible to hint for thread-based parallelism with
+    ``prefer='threads'`` or enforce shared-memory semantics with
+    ``require='sharedmem'``.
+
 
 Release 0.11
 ------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Development
 -----------
 
 Elizabeth Sander
+
     Prevent numpy arrays with the same shape and data from hashing to
     the same memmap, to prevent jobs with preallocated arrays from
     writing over each other.

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -21,85 +21,78 @@ can be spread over 2 CPUs using the following::
     >>> Parallel(n_jobs=2)(delayed(sqrt)(i ** 2) for i in range(10))
     [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 
-By default joblib uses the ``'loky'`` backend to safely and efficiently
-use a pool of worker Python processes to execute the delayed functions
-on each set of arguments in the comprehension.
 
-
-Old multiprocessing backend
-===========================
-
-Prior to version 0.12, joblib used the ``'multiprocessing'`` backend as
-default backend instead of ``'loky'``.
-
-This backend creates an instance of `multiprocessing.Pool` that forks
-the Python interpreter in multiple processes to execute each of the
-items of the list. The `delayed` function is a simple trick to be able
-to create a tuple `(function, args, kwargs)` with a function-call
-syntax.
-
-.. warning::
-
-   Under Windows, the use of ``multiprocessing.Pool`` requires to
-   protect the main loop of code to avoid recursive spawning of
-   subprocesses when using ``joblib.Parallel``. In other words, you
-   should be writing code like this when using the ``'multiprocessing'``
-   backend:
-
-   .. code-block:: python
-
-      import ....
-
-      def function1(...):
-          ...
-
-      def function2(...):
-          ...
-
-      ...
-      if __name__ == '__main__':
-          # do stuff with imports and functions defined about
-          ...
-
-   **No** code should *run* outside of the ``"if __name__ ==
-   '__main__'"`` blocks, only imports and definitions.
-
-   The ``'loky'`` backend used by default in joblib 0.12 and later does
-   not impose this anymore.
-
-
-Using the threading backend
-===========================
+Thread-based parallelism vs process-based parallelism
+=====================================================
 
 By default :class:`Parallel` uses the ``'loky'`` backend module to start
 separate Python worker processes to execute tasks concurrently on
 separate CPUs. This is a reasonable default for generic Python programs
-but it induces some overhead as the input and output data need to be
-serialized in a queue for communication with the worker processes.
+but can induce a significant overhead as the input and output data need
+to be serialized in a queue for communication with the worker processes.
 
-If you know that the function you are calling is based on a compiled extension
-that releases the Python Global Interpreter Lock (GIL) during most of its
-computation then it might be more efficient to use threads instead of Python
-processes as concurrent workers. For instance this is the case if you write the
-CPU intensive part of your code inside a `with nogil`_ block of a Cython
-function.
+When you know that the function you are calling is based on a compiled
+extension that releases the Python Global Interpreter Lock (GIL) during
+most of its computation then it is more efficient to use threads instead
+of Python processes as concurrent workers. For instance this is the case
+if you write the CPU intensive part of your code inside a `with nogil`_
+block of a Cython function.
 
 .. _`with nogil`: http://docs.cython.org/src/userguide/external_C_code.html#acquiring-and-releasing-the-gil
 
-To use the threads, just pass ``"threading"`` as the value of the ``backend``
-parameter of the :class:`Parallel` constructor:
+To hint that your code can efficiently use threads, just pass
+``prefer="threads"`` as parameter of the :class:`Parallel` constructor.
+In this case joblib will automatically use the ``"threading"`` backend
+instead of the default ``"loky"`` backend:
 
-    >>> Parallel(n_jobs=2, backend="threading")(
+    >>> Parallel(n_jobs=2, prefer="threads")(
     ...     delayed(sqrt)(i ** 2) for i in range(10))
     [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 
-or alternatively using a context manager:
+It is also possible to manually select a specific backend implementation
+with the help of a context manager:
 
     >>> from joblib import parallel_backend
     >>> with parallel_backend('threading'):
     ...    Parallel(n_jobs=2)(delayed(sqrt)(i ** 2) for i in range(10))
     [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 
+The latter is especially useful when calling a library that uses
+``joblib.Parallel`` internally without exposing backend selection as
+part of its public API.
+
+Note that the ``prefer="threads"`` option was introduced in joblib 0.12.
+In prior versions, the same effect could be achieved by hardcoding a
+specific backend implementation such as ``backend="threading"`` in the
+call to ``Parallel`` but this is now considered a bad pattern (when done
+in a library) as it does not make it possible to override that choice
+with the ``parallel_backend`` context manager.
+
+
+Shared-memory semantics
+=======================
+
+The default backend of joblib will run each function call in isolated
+Python processes, therefore they cannot mutate a common Python object
+defined in the main program.
+
+However if the parallel function really needs to rely on the shared
+memory semantics of threads, it should be made explicit with
+``require='sharedmem'``, for instance:
+
+    >>> shared_set = set()
+    >>> def collect(x):
+    ...    shared_set.add(x)
+    ...
+    >>> Parallel(n_jobs=2, require='sharedmem')(
+    ...     delayed(collect)(i) for i in range(5))
+    [None, None, None, None, None]
+    >>> sorted(shared_set)
+    [0, 1, 2, 3, 4]
+
+Keep in mind that relying a on the shared-memory semantics is probably
+suboptimal from a performance point of view as concurrent access to a
+shared Python object will suffer from lock contention.
 
 Reusing a pool of workers
 =========================
@@ -131,43 +124,6 @@ the ``Parallel`` object::
 Note that the ``'loky'`` backend now used by default for process-based
 parallelism automatically tries to maintain and reuse a pool of workers
 by it-self even for calls without the context manager.
-
-
-Bad interaction of multiprocessing and third-party libraries
-============================================================
-
-Using the ``'multiprocessing'`` backend can cause a crash when using
-third party libraries that manage their own native thread-pool if the
-library is first used in the main process and subsequently called again
-in a worker process (inside the ``Parallel`` call).
-
-Joblib version 0.12 and later are no longer subject to this problem
-thanks to the use of `loky <https://github.com/tomMoral/loky>`_ as the
-new default backend for process-based parallelism.
-
-Prior to Python 3.4 the ``'multiprocessing'`` backend of joblib can only
-use the ``fork`` strategy to create worker processes under non-Windows
-systems. This can cause some third-party libraries to crash or freeze.
-Such libraries include Apple vecLib / Accelerate (used by NumPy under
-OSX), some old version of OpenBLAS (prior to 0.2.10) or the OpenMP
-runtime implementation from GCC which is used internally by third-party
-libraries such as XGBoost, spaCy, OpenCV...
-
-The best way to avoid this problem is to use the ``'loky'`` backend
-instead of the ``multiprocessing`` backend. Prior to joblib 0.12, it is
-also possible  to get ``joblib.Parallel`` configured to use the
-``'forkserver'`` start method on Python 3.4 and later. The start method
-has to be configured by setting the ``JOBLIB_START_METHOD`` environment
-variable to ``'forkserver'`` instead of the default ``'fork'`` start
-method. However the user should be aware that using the ``'forkserver'``
-method prevents ``joblib.Parallel`` to call function interactively
-defined in a shell session.
-
-You can read more on this topic in the `multiprocessing documentation
-<https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
-
-Under Windows the ``fork`` system call does not exist at all so this problem
-does not exist (but multiprocessing has more overhead).
 
 
 Custom backend API (experimental)
@@ -215,6 +171,85 @@ The connection parameters can then be passed to the
 Using the context manager can be helpful when using a third-party library that
 uses :class:`joblib.Parallel` internally while not exposing the ``backend``
 argument in its own API.
+
+
+Old multiprocessing backend
+===========================
+
+Prior to version 0.12, joblib used the ``'multiprocessing'`` backend as
+default backend instead of ``'loky'``.
+
+This backend creates an instance of `multiprocessing.Pool` that forks
+the Python interpreter in multiple processes to execute each of the
+items of the list. The `delayed` function is a simple trick to be able
+to create a tuple `(function, args, kwargs)` with a function-call
+syntax.
+
+.. warning::
+
+   Under Windows, the use of ``multiprocessing.Pool`` requires to
+   protect the main loop of code to avoid recursive spawning of
+   subprocesses when using ``joblib.Parallel``. In other words, you
+   should be writing code like this when using the ``'multiprocessing'``
+   backend:
+
+   .. code-block:: python
+
+      import ....
+
+      def function1(...):
+          ...
+
+      def function2(...):
+          ...
+
+      ...
+      if __name__ == '__main__':
+          # do stuff with imports and functions defined about
+          ...
+
+   **No** code should *run* outside of the ``"if __name__ ==
+   '__main__'"`` blocks, only imports and definitions.
+
+   The ``'loky'`` backend used by default in joblib 0.12 and later does
+   not impose this anymore.
+
+
+Bad interaction of multiprocessing and third-party libraries
+============================================================
+
+Using the ``'multiprocessing'`` backend can cause a crash when using
+third party libraries that manage their own native thread-pool if the
+library is first used in the main process and subsequently called again
+in a worker process (inside the ``Parallel`` call).
+
+Joblib version 0.12 and later are no longer subject to this problem
+thanks to the use of `loky <https://github.com/tomMoral/loky>`_ as the
+new default backend for process-based parallelism.
+
+Prior to Python 3.4 the ``'multiprocessing'`` backend of joblib can only
+use the ``fork`` strategy to create worker processes under non-Windows
+systems. This can cause some third-party libraries to crash or freeze.
+Such libraries include Apple vecLib / Accelerate (used by NumPy under
+OSX), some old version of OpenBLAS (prior to 0.2.10) or the OpenMP
+runtime implementation from GCC which is used internally by third-party
+libraries such as XGBoost, spaCy, OpenCV...
+
+The best way to avoid this problem is to use the ``'loky'`` backend
+instead of the ``multiprocessing`` backend. Prior to joblib 0.12, it is
+also possible  to get ``joblib.Parallel`` configured to use the
+``'forkserver'`` start method on Python 3.4 and later. The start method
+has to be configured by setting the ``JOBLIB_START_METHOD`` environment
+variable to ``'forkserver'`` instead of the default ``'fork'`` start
+method. However the user should be aware that using the ``'forkserver'``
+method prevents ``joblib.Parallel`` to call function interactively
+defined in a shell session.
+
+You can read more on this topic in the `multiprocessing documentation
+<https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
+
+Under Windows the ``fork`` system call does not exist at all so this problem
+does not exist (but multiprocessing has more overhead).
 
 
 `Parallel` reference documentation

--- a/doc/parallel_numpy.rst
+++ b/doc/parallel_numpy.rst
@@ -26,9 +26,17 @@ worker processes.
 
 .. note::
 
-  The following only applies with the default ``"multiprocessing"`` backend. If
-  your code can release the GIL, then using ``backend="threading"`` is even
-  more efficient.
+  The following only applies with the ``"loky"` and
+  ``'multiprocessing'`` process-backends. If your code can release the
+  GIL, then using a thread-based backend backend by passing
+  ``prefer='threads'`` is even more efficient because it makes it
+  possible to avoid the communication overhead of process-based
+  parallelism.
+
+  Scientific Python libraries such as numpy, scipy, pandas and
+  scikit-learn often release the GIL in performance critical code paths.
+  It is therefore advised to always measure the speed of thread-based
+  parallelism and use it when the scalability is not limited by the GIL.
 
 
 Automated array to memmap conversion

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -134,7 +134,7 @@ class SequentialBackend(ParallelBackendBase):
     overhead. Used when n_jobs == 1.
     """
 
-    use_threads = True
+    uses_threads = True
     supports_sharedmem = True
 
     def effective_n_jobs(self, n_jobs):
@@ -304,7 +304,7 @@ class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):
     """
 
     supports_timeout = True
-    use_threads = True
+    uses_threads = True
     supports_sharedmem = True
 
     def configure(self, n_jobs=1, parallel=None, **backend_args):

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -834,6 +834,8 @@ Sub-process traceback:
             n_jobs = self._initialize_backend()
         else:
             n_jobs = self._effective_n_jobs()
+        self._print("Using backend %s with %d concurrent workers.",
+                    (self._backend.__class__.__name__, n_jobs))
 
         iterator = iter(iterable)
         pre_dispatch = self.pre_dispatch

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -91,9 +91,9 @@ def get_active_backend(prefer=None, require=None, verbose=0):
     # create the default backend instance now.
     backend = BACKENDS[DEFAULT_BACKEND]()
     supports_sharedmem = getattr(backend, 'supports_sharedmem', False)
-    use_threads = getattr(backend, 'use_threads', False)
+    uses_threads = getattr(backend, 'uses_threads', False)
     if ((require == 'sharedmem' and not supports_sharedmem) or
-            (prefer == 'threads' and not use_threads)):
+            (prefer == 'threads' and not uses_threads)):
         # Make sure the selected default backend match the soft hints and
         # hard constraints:
         backend = BACKENDS[DEFAULT_THREAD_BACKEND]()

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -50,6 +50,7 @@ except ImportError:
 from joblib._parallel_backends import SequentialBackend
 from joblib._parallel_backends import ThreadingBackend
 from joblib._parallel_backends import MultiprocessingBackend
+from joblib._parallel_backends import ParallelBackendBase
 from joblib._parallel_backends import LokyBackend
 from joblib._parallel_backends import SafeFunction
 from joblib._parallel_backends import WorkerInterrupt
@@ -1015,3 +1016,107 @@ def test_backend_batch_statistics_reset(backend):
 
     # Tolerance in the timing comparison to avoid random failures on CIs
     assert test_time / ref_time <= 1 + relative_tolerance
+
+
+def test_backend_hinting_and_constraints():
+    for n_jobs in [1, 2, -1]:
+        assert type(Parallel(n_jobs=n_jobs)._backend) == LokyBackend
+
+        p = Parallel(n_jobs=n_jobs, prefer='threads')
+        assert type(p._backend) == ThreadingBackend
+
+        p = Parallel(n_jobs=n_jobs, prefer='processes')
+        assert type(p._backend) == LokyBackend
+
+        p = Parallel(n_jobs=n_jobs, require='sharedmem')
+        assert type(p._backend) == ThreadingBackend
+
+    # Explicit backend selection can override backend hinting although it
+    # is useless to pass a hint when selecting a backend.
+    p = Parallel(n_jobs=2, backend='loky', prefer='threads')
+    assert type(p._backend) == LokyBackend
+
+    with parallel_backend('loky'):
+        # Explicit backend selection by the user with the context manager
+        # should be respected when combined with backend hints only.
+        p = Parallel(n_jobs=2, prefer='threads')
+        assert type(p._backend) == LokyBackend
+
+    with parallel_backend('loky'):
+        # Explicit backend selection by the user with the context manager
+        # should be ignored when the Parallel call has hard constraints.
+        # In this case
+        p = Parallel(n_jobs=2, require='sharedmem')
+        assert type(p._backend) == ThreadingBackend
+
+
+def test_backend_hinting_and_constraints_with_custom_backends(capsys):
+    # Custom backends can declare that they use threads and have shared memory
+    # semantics:
+    class MyCustomThreadingBackend(ParallelBackendBase):
+        supports_sharedmem = True
+        use_threads = True
+
+        def apply_async(self):
+            pass
+
+        def effective_n_jobs(self, n_jobs):
+            return n_jobs
+
+    with parallel_backend(MyCustomThreadingBackend()):
+        p = Parallel(n_jobs=2, prefer='processes')  # ignored
+        assert type(p._backend) == MyCustomThreadingBackend
+
+        p = Parallel(n_jobs=2, require='sharedmem')
+        assert type(p._backend) == MyCustomThreadingBackend
+
+    class MyCustomProcessingBackend(ParallelBackendBase):
+        supports_sharedmem = False
+        use_threads = False
+
+        def apply_async(self):
+            pass
+
+        def effective_n_jobs(self, n_jobs):
+            return n_jobs
+
+    with parallel_backend(MyCustomProcessingBackend()):
+        p = Parallel(n_jobs=2, prefer='processes')
+        assert type(p._backend) == MyCustomProcessingBackend
+
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert err == ""
+
+        p = Parallel(n_jobs=2, require='sharedmem', verbose=10)
+        assert type(p._backend) == ThreadingBackend
+
+        out, err = capsys.readouterr()
+        expected = ("Using ThreadingBackend as joblib.Parallel backend "
+                    "instead of MyCustomProcessingBackend as the latter "
+                    "does not provide shared memory semantics.")
+        assert out.strip() == expected
+        assert err == ""
+
+    with raises(ValueError):
+        Parallel(backend=MyCustomProcessingBackend(), require='sharedmem')
+
+
+def test_invalid_backend_hinting_and_constraints():
+    with raises(ValueError):
+        Parallel(prefer='invalid')
+
+    with raises(ValueError):
+        Parallel(require='invalid')
+
+    with raises(ValueError):
+        # It is inconsistent to prefer process-based parallelism while
+        # requiring shared memory semantics.
+        Parallel(prefer='processes', require='sharedmem')
+
+    # It is inconsistent to ask explictly for a process-based parallelism
+    # while requiring shared memory semantics.
+    with raises(ValueError):
+        Parallel(backend='loky', require='sharedmem')
+    with raises(ValueError):
+        Parallel(backend='multiprocessing', require='sharedmem')


### PR DESCRIPTION
Sorry, I deleted my remote branch by accident and it closed #595. Here is the same PR again.

This is an alternative implementation of #537. I reimplemented it from scratch because joblib had diverged a bit and I did not agree with the semantics of constraints violations in #537.

TODO:

- [x] test by running `RandomForestClassifier` on dask-distributed cluster and check that fit run trees in parallel (done with this branch of sklearn: https://github.com/scikit-learn/scikit-learn/compare/master...ogrisel:joblib-backend-hints);
- [x] decide whether we should use `prefer='threads'` and `require='sharedmem'` or keep the currently implemented boolean flags for hinting and hard constraints;
- [x] update Parallel docstring to document the new options.