### PR TITLE
[MRG+1] memory: make API more consistent and improve documentation

### DIFF
--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -147,7 +147,7 @@ class StoreBackendMixin(object):
     def load_item(self, path, verbose=1, msg=None):
         """Load an item from the store given its path as a list of
            strings."""
-        full_path = os.path.join(self._location, *path)
+        full_path = os.path.join(self.location, *path)
 
         if verbose > 1:
             if verbose < 10:
@@ -175,7 +175,7 @@ class StoreBackendMixin(object):
         """Dump an item in the store at the path given as a list of
            strings."""
         try:
-            item_path = os.path.join(self._location, *path)
+            item_path = os.path.join(self.location, *path)
             if not self._item_exists(item_path):
                 self.create_location(item_path)
             filename = os.path.join(item_path, 'output.pkl')
@@ -193,27 +193,27 @@ class StoreBackendMixin(object):
 
     def clear_item(self, path):
         """Clear the item at the path, given as a list of strings."""
-        item_path = os.path.join(self._location, *path)
+        item_path = os.path.join(self.location, *path)
         if self._item_exists(item_path):
             self.clear_location(item_path)
 
     def contains_item(self, path):
         """Check if there is an item at the path, given as a list of
            strings"""
-        item_path = os.path.join(self._location, *path)
+        item_path = os.path.join(self.location, *path)
         filename = os.path.join(item_path, 'output.pkl')
 
         return self._item_exists(filename)
 
     def get_item_info(self, path):
         """Return information about item."""
-        return {'location': os.path.join(self._location,
+        return {'location': os.path.join(self.location,
                                          *path)}
 
     def get_metadata(self, path):
         """Return actual metadata of an item."""
         try:
-            item_path = os.path.join(self._location, *path)
+            item_path = os.path.join(self.location, *path)
             filename = os.path.join(item_path, 'metadata.json')
             with self._open_item(filename, 'rb') as f:
                 return json.loads(f.read().decode('utf-8'))
@@ -223,7 +223,7 @@ class StoreBackendMixin(object):
     def store_metadata(self, path, metadata):
         """Store metadata of a computation."""
         try:
-            item_path = os.path.join(self._location, *path)
+            item_path = os.path.join(self.location, *path)
             self.create_location(item_path)
             filename = os.path.join(item_path, 'metadata.json')
 
@@ -237,18 +237,18 @@ class StoreBackendMixin(object):
 
     def contains_path(self, path):
         """Check cached function is available in store."""
-        func_path = os.path.join(self._location, *path)
+        func_path = os.path.join(self.location, *path)
         return self.object_exists(func_path)
 
     def clear_path(self, path):
         """Clear all items with a common path in the store."""
-        func_path = os.path.join(self._location, *path)
+        func_path = os.path.join(self.location, *path)
         if self._item_exists(func_path):
             self.clear_location(func_path)
 
     def store_cached_func_code(self, path, func_code=None):
         """Store the code of the cached function."""
-        func_path = os.path.join(self._location, *path)
+        func_path = os.path.join(self.location, *path)
         if not self._item_exists(func_path):
             self.create_location(func_path)
 
@@ -260,7 +260,7 @@ class StoreBackendMixin(object):
     def get_cached_func_code(self, path):
         """Store the code of the cached function."""
         path += ['func_code.py', ]
-        filename = os.path.join(self._location, *path)
+        filename = os.path.join(self.location, *path)
         try:
             with self._open_item(filename, 'rb') as f:
                 return f.read().decode('utf-8')
@@ -269,11 +269,11 @@ class StoreBackendMixin(object):
 
     def get_cached_func_info(self, path):
         """Return information related to the cached function if it exists."""
-        return {'location': os.path.join(self._location, *path)}
+        return {'location': os.path.join(self.location, *path)}
 
     def clear(self):
         """Clear the whole store content."""
-        self.clear_location(self._location)
+        self.clear_location(self.location)
 
     def reduce_store_size(self, bytes_limit):
         """Reduce store size to keep it under the given bytes limit."""
@@ -327,7 +327,7 @@ class StoreBackendMixin(object):
 
     def __repr__(self):
         """Printable representation of the store location."""
-        return self._location
+        return self.location
 
 
 class FileSystemStoreBackend(StoreBackendBase, StoreBackendMixin):
@@ -339,7 +339,7 @@ class FileSystemStoreBackend(StoreBackendBase, StoreBackendMixin):
 
     def clear_location(self, location):
         """Delete location on store."""
-        if (location == self._location):
+        if (location == self.location):
             rm_subdirs(location)
         else:
             shutil.rmtree(location, ignore_errors=True)
@@ -352,7 +352,7 @@ class FileSystemStoreBackend(StoreBackendBase, StoreBackendMixin):
         """Returns the whole list of items available in the store."""
         items = []
 
-        for dirpath, _, filenames in os.walk(self._location):
+        for dirpath, _, filenames in os.walk(self.location):
             is_cache_hash_dir = re.match('[a-f0-9]{32}',
                                          os.path.basename(dirpath))
 
@@ -390,10 +390,10 @@ class FileSystemStoreBackend(StoreBackendBase, StoreBackendMixin):
         For this backend, valid store options are 'compress' and 'mmap_mode'
         """
 
-        # setup locationdir
-        self._location = location
-        if not os.path.exists(self._location):
-            mkdirp(self._location)
+        # setup location directory
+        self.location = location
+        if not os.path.exists(self.location):
+            mkdirp(self.location)
 
         # item can be stored compressed for faster I/O
         self.compress = backend_options['compress']

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -118,7 +118,7 @@ class StoreBackendBase(with_metaclass(ABCMeta)):
         """
 
     @abstractmethod
-    def configure(self, location, verbose=0, store_options=dict()):
+    def configure(self, location, verbose=0, backend_options=dict()):
         """Configures the store.
 
         Parameters
@@ -128,7 +128,7 @@ class StoreBackendBase(with_metaclass(ABCMeta)):
             corresponds to a directory.
         verbose: int
             The level of verbosity of the store
-        store_options: dict
+        backend_options: dict
             Contains a dictionnary of named paremeters used to configure the
             store backend.
         """
@@ -384,7 +384,7 @@ class FileSystemStoreBackend(StoreBackendBase, StoreBackendMixin):
 
         return items
 
-    def configure(self, location, verbose=1, store_options={}):
+    def configure(self, location, verbose=1, backend_options={}):
         """Configure the store backend.
 
         For this backend, valid store options are 'compress' and 'mmap_mode'
@@ -396,14 +396,13 @@ class FileSystemStoreBackend(StoreBackendBase, StoreBackendMixin):
             mkdirp(self._location)
 
         # item can be stored compressed for faster I/O
-        self.compress = (False if 'compress' not in store_options
-                         else store_options['compress'])
+        self.compress = backend_options['compress']
 
         # FileSystemStoreBackend can be used with mmap_mode options under
         # certain conditions.
         mmap_mode = None
-        if 'mmap_mode' in store_options:
-            mmap_mode = store_options['mmap_mode']
+        if 'mmap_mode' in backend_options:
+            mmap_mode = backend_options['mmap_mode']
             if self.compress and mmap_mode is not None:
                 warnings.warn('Compressed items cannot be memmapped in a '
                               'filesystem store. Option will be ignored.',

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -96,7 +96,7 @@ def register_store_backend(backend_name, backend):
     _STORE_BACKENDS[backend_name] = backend
 
 
-def _store_backend_factory(backend, location, verbose=0, store_options={}):
+def _store_backend_factory(backend, location, verbose=0, backend_options={}):
     """Return the correct store object for the given location."""
     if isinstance(location, StoreBackendBase):
         return location
@@ -118,7 +118,8 @@ def _store_backend_factory(backend, location, verbose=0, store_options={}):
 
         # The store backend is configured with the extra named parameters,
         # some of them are specific to the underlying store backend.
-        obj.configure(location, verbose=verbose, store_options=store_options)
+        obj.configure(location, verbose=verbose,
+                      backend_options=backend_options)
         return obj
 
     return None
@@ -385,7 +386,7 @@ class MemorizedFunc(Logger):
         # retrieve store object from backend type and location.
         self.store_backend = _store_backend_factory(backend, location,
                                                     verbose=verbose,
-                                                    store_options=dict(
+                                                    backend_options=dict(
                                                         compress=compress,
                                                         mmap_mode=mmap_mode),
                                                     )
@@ -758,7 +759,7 @@ class Memory(Logger):
 
     def __init__(self, location=None, backend='local', cachedir=None,
                  mmap_mode=None, compress=False, verbose=1, bytes_limit=None,
-                 store_options={}):
+                 backend_options={}):
         """
             Parameters
             ----------
@@ -770,7 +771,9 @@ class Memory(Logger):
 
             backend: str or 'local'
                 Type of store backend for reading/writing cache files.
-                Default is 'local'.
+                Default is 'local'. The 'local' backend is using regular
+                filesystem operations to manipulate data (open, mv, etc) in the
+                backend.
 
             cachedir: str or None
                 cachedir is deprecated since version 0.11 and will be
@@ -796,6 +799,10 @@ class Memory(Logger):
 
             bytes_limit: int, optional
                 Limit in bytes of the size of the cache.
+
+            backend_options: dict, optional
+                Contains a dictionnary of named parameters used to configure
+                the store backend.
 
         """
         # XXX: Bad explanation of the None value of cachedir
@@ -827,8 +834,8 @@ class Memory(Logger):
 
         self.store_backend = _store_backend_factory(
             backend, location, verbose=self._verbose,
-            store_options=dict(compress=compress, mmap_mode=mmap_mode,
-                               **store_options))
+            backend_options=dict(compress=compress, mmap_mode=mmap_mode,
+                                 **backend_options))
 
     def cache(self, func=None, ignore=None, verbose=None, mmap_mode=False):
         """ Decorates the given function func to only compute its return

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -380,7 +380,7 @@ def test_func_dir(tmpdir):
     g = memory.cache(f)
     # Test that the function directory is created on demand
     func_id = _build_func_identifier(f)
-    location = os.path.join(g.store_backend._location, func_id)
+    location = os.path.join(g.store_backend.location, func_id)
     assert location == path
     assert os.path.exists(path)
 
@@ -394,7 +394,7 @@ def test_func_dir(tmpdir):
 
     # Test the robustness to failure of loading previous results.
     func_id, args_id = g._get_output_idendifiers(1)
-    output_dir = os.path.join(g.store_backend._location, func_id, args_id)
+    output_dir = os.path.join(g.store_backend.location, func_id, args_id)
     a = g(1)
     assert os.path.exists(output_dir)
     os.remove(os.path.join(output_dir, 'output.pkl'))
@@ -410,11 +410,11 @@ def test_persistence(tmpdir):
     h = pickle.loads(pickle.dumps(g))
 
     func_id, args_id = h._get_output_idendifiers(1)
-    output_dir = os.path.join(h.store_backend._location, func_id, args_id)
+    output_dir = os.path.join(h.store_backend.location, func_id, args_id)
     assert os.path.exists(output_dir)
     assert output == h.store_backend.load_item([func_id, args_id])
     memory2 = pickle.loads(pickle.dumps(memory))
-    assert memory.store_backend._location == memory2.store_backend._location
+    assert memory.store_backend.location == memory2.store_backend.location
 
     # Smoke test that pickling a memory with location=None works
     memory = Memory(location=None, verbose=0)
@@ -638,7 +638,7 @@ def _setup_toy_cache(tmpdir, num_inputs=10):
     hash_dirnames = [get_1000_bytes._get_output_idendifiers(arg)[1]
                      for arg in inputs]
 
-    full_hashdirs = [os.path.join(get_1000_bytes.store_backend._location,
+    full_hashdirs = [os.path.join(get_1000_bytes.store_backend.location,
                                   func_id, dirname)
                      for dirname in hash_dirnames]
     return memory, full_hashdirs, get_1000_bytes
@@ -738,7 +738,7 @@ def test_memory_clear(tmpdir):
     memory, _, _ = _setup_toy_cache(tmpdir)
     memory.clear()
 
-    assert os.listdir(memory.store_backend._location) == []
+    assert os.listdir(memory.store_backend.location) == []
 
 
 def fast_func_with_complex_output():
@@ -885,14 +885,14 @@ def test_cachedir_deprecation_warning(tmpdir):
     # option instead of new location parameter.
     with warns(None) as w:
         memory = Memory(location=tmpdir.strpath, cachedir=tmpdir, verbose=0)
-        assert memory.store_backend._location.startswith(tmpdir.strpath)
+        assert memory.store_backend.location.startswith(tmpdir.strpath)
 
     assert len(w) == 1
     assert "You set both location and cachedir options" in str(w[-1].message)
 
     with warns(None) as w:
         memory = Memory(cachedir=tmpdir.strpath, verbose=0)
-        assert memory.store_backend._location.startswith(tmpdir.strpath)
+        assert memory.store_backend.location.startswith(tmpdir.strpath)
 
     assert len(w) == 1
     assert "cachedir option is deprecated since version" in str(w[-1].message)


### PR DESCRIPTION
This PR rename to `store_options` named parameter to `backend_options`, which is more in sync with the `backend` parameter.
This PR also improves the Memory documentation.