### PR TITLE
DOC: various enhancements in memory.rst documentation

### DIFF
--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -12,12 +12,12 @@ On demand recomputing: the `Memory` class
 
 .. currentmodule:: joblib.memory
 
-Usecase
+Use case
 --------
 
 The `Memory` class defines a context for lazy evaluation of function, by
-storing the results to the disk, and not rerunning the function twice for
-the same arguments.
+putting the results in a store, by default using a disk, and not re-running
+the function twice for the same arguments.
 
 ..
  Commented out in favor of briefness
@@ -37,23 +37,23 @@ such as numpy arrays.
 A simple example:
 ~~~~~~~~~~~~~~~~~
 
-  First we define the cache directory::
+  First define the cache directory::
 
-    >>> cachedir = 'your_cache_dir_goes_here'
+    >>> cachedir = 'your_cache_location_directory'
 
-  We can instantiate a memory context, using this cache directory::
+  A memory context must first be instanciated, using this cache directory::
 
     >>> from joblib import Memory
-    >>> memory = Memory(cachedir=cachedir, verbose=0)
+    >>> memory = Memory(location=cachedir, verbose=0)
 
-  Then we can decorate a function to be cached in this context::
+  Then a function can decorated to be cached in this context::
 
     >>> @memory.cache
     ... def f(x):
     ...     print('Running f(%s)' % x)
     ...     return x
 
-  When we call this function twice with the same argument, it does not
+  When the function is called twice with the same argument, it does not
   get executed the second time, and the output gets loaded from the pickle
   file::
 
@@ -63,8 +63,8 @@ A simple example:
     >>> print(f(1))
     1
 
-  However, when we call it a third time, with a different argument, the
-  output gets recomputed::
+  However, when the functions is called a third time, with a different
+  argument, the output gets recomputed::
 
     >>> print(f(2))
     Running f(2)
@@ -90,18 +90,18 @@ input and output objects, and aggressive persistence to disk.
 
 
 Using with `numpy`
--------------------
+------------------
 
-The original motivation behind the `Memory` context was to be able to a
+The original motivation behind the `Memory` context was to have a
 memoize-like pattern on numpy arrays. `Memory` uses fast cryptographic
 hashing of the input arguments to check if they have been computed;
 
 An example
-~~~~~~~~~~~
+~~~~~~~~~~
 
-  We define two functions, the first with a number as an argument,
-  outputting an array, used by the second one. We decorate both
-  functions with `Memory.cache`::
+  Define two functions, the first with a number as an argument,
+  outputting an array, used by the second one. Both functions are decorated
+  with `Memory.cache`::
 
     >>> import numpy as np
 
@@ -115,7 +115,7 @@ An example
     ...     print('A second long-running calculation, using g(x)')
     ...     return np.vander(x)
 
-  If we call the function h with the array created by the same call to g,
+  If the function h is called with the array created by the same call to g,
   h is not re-run::
 
     >>> a = g(3)
@@ -138,11 +138,11 @@ An example
 Using memmapping
 ~~~~~~~~~~~~~~~~
 
-To speed up cache looking of large numpy arrays, you can load them
-using memmapping (memory mapping)::
+Large numpy arrays can be loaded using memmapping (memory mapping) to speed up
+cache looking::
 
-    >>> cachedir2 = 'your_cachedir2_goes_here
-    >>> memory2 = Memory(cachedir=cachedir2, mmap_mode='r')
+    >>> cachedir2 = 'your_cachedir2_location'
+    >>> memory2 = Memory(location=cachedir2, mmap_mode='r')
     >>> square = memory2.cache(np.square)
     >>> a = np.vander(np.arange(3)).astype(np.float)
     >>> square(a)
@@ -172,7 +172,7 @@ return value is loaded from the disk using memmapping::
 
 ..
 
- We need to close the memmap file to avoid file locking on Windows; closing
+ The memmap file must be closed to avoid file locking on Windows; closing
  numpy.memmap objects is done with del, which flushes changes to the disk
 
     >>> del res
@@ -244,9 +244,9 @@ Gotchas
 --------
 
 * **Across sessions, function cache is identified by the function's name**.
-  Thus if you assign the same name to different functions, their cache will
-  override each-others (you have 'name collisions'), and you will get
-  unwanted re-run::
+  Thus if the same name is assigned to different functions, their cache will
+  override each-others (e.g there are 'name collisions'), and unwanted re-run
+  will happen::
 
     >>> @memory.cache
     ... def func(x):
@@ -258,7 +258,7 @@ Gotchas
     ... def func(x):
     ...     print('Running a different func(%s)' % x)
 
-  As long as you stay in the same session, there are no collisions (in joblib
+  As long as the same session is used, there are no collisions (in joblib
   0.8 and above), altough joblib does warn you that you are doing something
   dangerous::
 
@@ -279,7 +279,7 @@ Gotchas
      >>> import joblib.memory
      >>> joblib.memory._FUNCTION_HASHES.clear()
 
-  But suppose you exit the interpreter and restart it, the cache will not
+  But suppose the interpreter is exited and then restarted, the cache will not
   be identified properly, and the functions will be rerun::
 
     >>> func(1) #doctest: +ELLIPSIS
@@ -288,7 +288,7 @@ Gotchas
     >>> func2(1)  #doctest: +ELLIPSIS
     Running func(1)
 
-  As long as you stay in the same session, you are not getting needless
+  As long as the same session is used, there are no needless
   recomputation::
 
     >>> func(1) # No recomputation now
@@ -324,7 +324,7 @@ Gotchas
     0.0
 
 * **caching methods: memory is designed for pure functions and it is
-  not recommended to use it for methods**. If you want to use cache
+  not recommended to use it for methods**. If one wants to use cache
   inside a class the recommended pattern is to cache a pure function
   and use the cached function inside your class, i.e. something like
   this::
@@ -345,11 +345,11 @@ Gotchas
 
   Using ``Memory`` for methods is not recommended and has some caveats
   that make it very fragile from a maintenance point of view because
-  it is very easy to forget about these caveats when your software
-  evolves. If you still want to do it (we would be interested about
+  it is very easy to forget about these caveats when a software
+  evolves. If this cannot be avoided (we would be interested about
   your use case by the way), here are a few known caveats:
 
-  1. you cannot decorate a method at class definition,
+  1. a method cannot be decorated at class definition,
      because when the class is instantiated, the first argument (self) is
      *bound*, and no longer accessible to the `Memory` object. The
      following code won't work::
@@ -384,7 +384,7 @@ Gotchas
 
 
 Ignoring some arguments
-------------------------
+-----------------------
 
 It may be useful not to recalculate a function when certain arguments
 change, for instance a debug flag. `Memory` provides the `ignore` list::
@@ -402,13 +402,13 @@ change, for instance a debug flag. `Memory` provides the `ignore` list::
 .. _memory_reference:
 
 Reference documentation of the `Memory` class
-----------------------------------------------
+---------------------------------------------
 
 .. autoclass:: Memory
     :members: __init__, cache, eval, clear
 
 Useful methods of decorated functions
---------------------------------------
+-------------------------------------
 
 Function decorated by :meth:`Memory.cache` are :class:`MemorizedFunc`
 objects that, in addition of behaving like normal functions, expose

--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -37,25 +37,26 @@ such as numpy arrays.
 A simple example:
 ~~~~~~~~~~~~~~~~~
 
-  First define the cache directory::
+  First, define the cache directory::
 
     >>> cachedir = 'your_cache_location_directory'
 
-  A memory context must first be instanciated, using this cache directory::
+  Then, instanciate a memory context that uses this cache directory::
 
     >>> from joblib import Memory
     >>> memory = Memory(location=cachedir, verbose=0)
 
-  Then a function can decorated to be cached in this context::
+  After these initial steps, just decorate a function to cache its output in
+  this context::
 
     >>> @memory.cache
     ... def f(x):
     ...     print('Running f(%s)' % x)
     ...     return x
 
-  When the function is called twice with the same argument, it does not
-  get executed the second time, and the output gets loaded from the pickle
-  file::
+  Calling this function twice with the same argument does not execute it the
+  second time, the output is just reloaded from a pickle file in the cache
+  directory::
 
     >>> print(f(1))
     Running f(1)
@@ -63,8 +64,8 @@ A simple example:
     >>> print(f(1))
     1
 
-  However, when the functions is called a third time, with a different
-  argument, the output gets recomputed::
+  However, calling the function with a different parameter executes it and
+  recomputes the output::
 
     >>> print(f(2))
     Running f(2)
@@ -99,7 +100,7 @@ hashing of the input arguments to check if they have been computed;
 An example
 ~~~~~~~~~~
 
-  Define two functions, the first with a number as an argument,
+  Define two functions: the first with a number as an argument,
   outputting an array, used by the second one. Both functions are decorated
   with `Memory.cache`::
 
@@ -115,8 +116,8 @@ An example
     ...     print('A second long-running calculation, using g(x)')
     ...     return np.vander(x)
 
-  If the function h is called with the array created by the same call to g,
-  h is not re-run::
+  If the function `h` is called with the array created by the same call to `g`,
+  `h` is not re-run::
 
     >>> a = g(3)
     A long-running calculation, with parameter 3
@@ -138,8 +139,8 @@ An example
 Using memmapping
 ~~~~~~~~~~~~~~~~
 
-Large numpy arrays can be loaded using memmapping (memory mapping) to speed up
-cache looking::
+Memmapping (memory mapping) speeds up cache looking when reloading large numpy
+arrays::
 
     >>> cachedir2 = 'your_cachedir2_location'
     >>> memory2 = Memory(location=cachedir2, mmap_mode='r')
@@ -244,8 +245,8 @@ Gotchas
 --------
 
 * **Across sessions, function cache is identified by the function's name**.
-  Thus if the same name is assigned to different functions, their cache will
-  override each-others (e.g there are 'name collisions'), and unwanted re-run
+  Thus assigning the same name to different functions, their cache will
+  override each-others (e.g. there are 'name collisions'), and unwanted re-run
   will happen::
 
     >>> @memory.cache


### PR DESCRIPTION
This PR tries to reword and cleanup a bit the memory documentation:
* avoid use of we/you
* fix a typo: usecase => use case
* cachedir => location parameter when instanciating a Memory
* removes extra underline characters