### PR TITLE
MAINT: build/clean sphinx documentation using Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-
+.PHONY: all test test-no-multiprocessing doc-html doc-clean
 
 all: test
 
@@ -7,3 +7,11 @@ test:
 
 test-no-multiprocessing:
 	export JOBLIB_MULTIPROCESSING=0 && pytest joblib
+
+# generate html documentation with warning as errors
+doc-html:
+	cd doc && sphinx-build -W -b html . ../build/sphinx/html/
+
+# remove generated sphinx gallery examples and sphinx documentation
+doc-clean:
+	rm -rf doc/auto_examples && rm -rf build

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ To build the docs you need to have setuptools and sphinx (>=0.5) installed.
 Run the command::
 
     pip install -U -r .readthedocs-requirements.txt
-    python setup.py build_sphinx
+    make doc-html
 
 The docs are built in the ``build/sphinx/html`` directory.
 

--- a/continuous_integration/circle/build_doc.sh
+++ b/continuous_integration/circle/build_doc.sh
@@ -24,7 +24,7 @@ ls -l
 python setup.py develop
 
 # The pipefail is requested to propagate exit code
-set -o pipefail && python setup.py build_sphinx 2>&1 | tee ~/log.txt
+set -o pipefail && make doc-html 2>&1 | tee ~/log.txt
 
 cd -
 set +o pipefail

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,7 @@ intersphinx_mapping = {
 
 # sphinx-gallery configuration
 sphinx_gallery_conf = {
-    'default_thumb_file': 'doc/_static/joblib_logo_examples.png',
+    'default_thumb_file': '_static/joblib_logo_examples.png',
     'doc_module': 'joblib',
     'filename_pattern': '',
     'backreferences_dir': os.path.join('generated'),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,5 @@
 [aliases]
 release = egg_info -RDb ''
-# Make sure the sphinx docs are built each time we do a dist.
-bdist = build_sphinx bdist
-sdist = build_sphinx sdist
 # Make sure the docs are uploaded when we do an upload
 upload = upload upload_docs --upload-dir build/sphinx/html
 
@@ -29,6 +26,3 @@ exclude=joblib/externals/*
 
 [metadata]
 license_file = LICENSE.txt
-
-[build_sphinx]
-warning-is-error = 1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import joblib
 # For some commands, use setuptools
 if len(set(('develop', 'sdist', 'release', 'bdist', 'bdist_egg', 'bdist_dumb',
             'bdist_rpm', 'bdist_wheel', 'bdist_wininst', 'install_egg_info',
-            'build_sphinx', 'egg_info', 'easy_install', 'upload',
+            'egg_info', 'easy_install', 'upload',
             )).intersection(sys.argv)) > 0:
     import setuptools
 


### PR DESCRIPTION
As discussed earlier, this PR is an attempt to fix #622 

It removes the use of `python setup.py build_sphinx` to build the doc and adds 2 new targets in the project Makefile:
* doc-html: call sphinx-build directly in the `doc` directory to generate the documentation, with warning as errors
* doc-clean: clean documentation files and examples generated by the previous target

It also changes the examples thumbnail path: it should now work with readthedocs. Finally, I added a .PHONY statement in the Makefile (small cleanup, see [here](https://stackoverflow.com/a/2145605) for some details).

