### PR TITLE
DOC: fix typos in nested parallel memory example

### DIFF
--- a/examples/nested_parallel_memory.py
+++ b/examples/nested_parallel_memory.py
@@ -12,8 +12,8 @@ This example illustrates how to cache intermediate computing results using
 # Embed caching within parallel processing
 ###############################################################################
 # 
-# It is possible to cache a computationally expensive function executing during
-# a parallel process. ``costly_column`` emulates such time consuming function.
+# It is possible to cache a computationally expensive function executed during
+# a parallel process. ``costly_compute`` emulates such time consuming function.
 
 import time
 


### PR DESCRIPTION
I found these typos while reading the nested parallel memory example.