### PR TITLE
[MRG] Do not use expensive hash of arrays in auto-mmap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Elizabeth Sander
 
 Olivier Grisel
 
+    Reduce overhead of automatic memmap by removing the need to hash the
+    array.
+
     Make ``Memory.cache`` robust to ``PermissionError (errno 13)`` under
     Windows when run in combination with ``Parallel``.
 

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -13,6 +13,8 @@ import threading
 import atexit
 import tempfile
 import warnings
+import weakref
+from uuid import uuid4
 
 try:
     WindowsError
@@ -38,7 +40,6 @@ except ImportError:
 
 from .numpy_pickle import load
 from .numpy_pickle import dump
-from .hashing import hash
 from .backports import make_memmap
 from .disk import delete_folder
 
@@ -55,6 +56,39 @@ SYSTEM_SHARED_MEM_FS_MIN_SIZE = int(2e9)
 # temporary files and folder.
 FOLDER_PERMISSIONS = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
 FILE_PERMISSIONS = stat.S_IRUSR | stat.S_IWUSR
+
+
+class _WeakArrayKeyMap:
+    """A variant of weakref.WeakKeyDictionary for unhashable numpy arrays.
+
+    This datastructure will be used with numpy arrays as obj keys, therefore we
+    do not use the __get__ / __set__ methods to avoid any conflict with the
+    numpy fancy indexing syntax.
+    """
+
+    def __init__(self):
+        self._data = {}
+
+    def get(self, obj):
+        ref, val = self._data[id(obj)]
+        if ref() is not obj:
+            # In case of race condition with on_destroy.
+            raise KeyError(obj)
+        return val
+
+    def set(self, obj, value):
+        key = id(obj)
+        try:
+            ref, _ = self._data[key]
+            if ref() is not obj:
+                # In case of race condition with on_destroy
+                raise KeyError(obj)
+        except KeyError:
+            def on_destroy(_):
+                del self._data[key]
+            ref = weakref.ref(obj, on_destroy)
+        self._data[key] = ref, value
+
 
 ###############################################################################
 # Support for efficient transient pickling of numpy data structures
@@ -241,6 +275,7 @@ class ArrayMemmapReducer(object):
         self._mmap_mode = mmap_mode
         self.verbose = int(verbose)
         self._prewarm = prewarm
+        self._memmaped_arrays = _WeakArrayKeyMap()
 
     def __call__(self, a):
         m = _get_backing_memmap(a)
@@ -259,15 +294,16 @@ class ArrayMemmapReducer(object):
                 if e.errno != errno.EEXIST:
                     raise e
 
-            # Find a unique, concurrent safe filename for writing the
-            # content of this array only once.
-            if self._mmap_mode in ['r', 'c']:
+            try:
+                basename = self._memmaped_arrays.get(a)
+            except KeyError:
+                # Generate a new unique random filename. The process and thread
+                # ids are only useful for debugging purpose and to make it
+                # easier to cleanup orphaned files in case of hard process
+                # kill (e.g. by "kill -9" or segfault).
                 basename = "{}-{}-{}.pkl".format(
-                    os.getpid(), id(threading.current_thread()), hash(a))
-            else:
-                basename = "{}-{}-{}-{}.pkl".format(
-                    os.getpid(), id(threading.current_thread()),
-                    hash(a), id(a))
+                    os.getpid(), id(threading.current_thread()), uuid4().hex)
+                self._memmaped_arrays.set(a, basename)
             filename = os.path.join(self._temp_folder, basename)
 
             # In case the same array with the same content is passed several

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -608,8 +608,8 @@ def test_weak_array_key_map():
 
     unique_ids = set([get_set_get_collect(m, i) for i in range(1000)])
     if platform.python_implementation() == 'CPython':
-        # On CPython (at least) the same id has been reused for all the the
+        # On CPython (at least) the same id is often reused many times for the
         # temporary arrays created under the local scope of the
         # get_set_get_collect function without causing any spurious lookups /
-        # insertions.
-        assert len(unique_ids) == 1
+        # insertions in the map.
+        assert len(unique_ids) < 100


### PR DESCRIPTION
This is an alternative fix to #565 based on weakref callbacks. It completely removes the need to hash the arrays which should significantly reduce the dispatching overhead.

TODO

- [x] benchmark overhead
- [x] write unit tests for `_WeakArrayKeyMap`