### PR TITLE
DOC: add notes about the recently merged store backend feature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Alexandre Abadie
     used by default with Memory. This default store backend is named 'local'
     and corresponds to the local filesystem.
 
+    The store backend API is experimental and thus is subject to change in the
+    future without deprecation.
+
     The ``cachedir`` parameter of ``Memory`` is now marked as deprecated, use
     ``location`` instead.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,19 @@ Olivier Grisel
     ``prefer='threads'`` or enforce shared-memory semantics with
     ``require='sharedmem'``.
 
+Alexandre Abadie
+
+    Introduce the concept of 'store' and refactor the ``Memory`` internal
+    storage implementation to make it accept extra store backends for caching
+    results. ``backend`` and ``backend_options`` are the new options added to
+    ``Memory`` to specify and configure a store backend.
+
+    Add the ``register_store_backend`` function to extend the store backend
+    used by default with Memory. This default store backend is named 'local'
+    and corresponds to the local filesystem.
+
+    The ``cachedir`` parameter of ``Memory`` is now marked as deprecated, use
+    ``location`` instead.
 
 Release 0.11
 ------------


### PR DESCRIPTION
I realized that the new API and internal changes of Memory were not added to the changes.rst file.

This PR provides the update.