### PR TITLE
MAINT: move to circleci v2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,17 +1,28 @@
-machine:
-  environment:
-    MINICONDA_PATH: $HOME/miniconda
-    CONDA_ENV_NAME: testenv
+version: 2
 
-dependencies:
-  override:
-    - ./continuous_integration/circle/build_doc.sh:
-        timeout: 3600 # seconds
-test:
-  override:
-    - cat ~/log.txt && if grep -q "Traceback (most recent call last):" ~/log.txt; then false; else true; fi
-
-general:
-  artifacts:
-    - "doc/_build/html"
-    - "~/log.txt"
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.2
+    steps:
+      - checkout
+      - run:
+          command: ./continuous_integration/circle/build_doc.sh
+          no_output_timeout: 60m
+          environment:
+            MINICONDA_PATH: ~/miniconda
+            CONDA_ENV_NAME: testenv
+      - run: 
+          command: |
+            cat log.txt && \
+            if grep -q "Traceback (most recent call last):" log.txt; \
+            then false; \
+            else true; \
+            fi
+      - run:
+          command: |
+            mkdir -p /tmp/data
+            cp -R doc/_build/html /tmp/data/html
+            cp log.txt /tmp/data/log.txt
+      - store_artifacts:
+          path: /tmp/data

--- a/circle.yml
+++ b/circle.yml
@@ -8,21 +8,9 @@ jobs:
       - checkout
       - run:
           command: ./continuous_integration/circle/build_doc.sh
-          no_output_timeout: 60m
           environment:
             MINICONDA_PATH: ~/miniconda
             CONDA_ENV_NAME: testenv
-      - run: 
-          command: |
-            cat log.txt && \
-            if grep -q "Traceback (most recent call last):" log.txt; \
-            then false; \
-            else true; \
-            fi
-      - run:
-          command: |
-            mkdir -p /tmp/data
-            cp -R doc/_build/html /tmp/data/html
-            cp log.txt /tmp/data/log.txt
       - store_artifacts:
-          path: /tmp/data
+          path: doc/_build/html
+          destination: doc

--- a/continuous_integration/circle/build_doc.sh
+++ b/continuous_integration/circle/build_doc.sh
@@ -23,5 +23,5 @@ ls -l
 python setup.py develop
 
 # The pipefail is requested to propagate exit code
-set -o pipefail && make doc 2>&1 | tee log.txt
+set -o pipefail && make doc 2>&1
 set +o pipefail

--- a/continuous_integration/circle/build_doc.sh
+++ b/continuous_integration/circle/build_doc.sh
@@ -19,9 +19,6 @@ source activate $CONDA_ENV_NAME
 conda install --yes --quiet pip numpy sphinx=1.6.3 matplotlib pillow
 pip install sphinx-gallery
 
-ls -l
 python setup.py develop
 
-# The pipefail is requested to propagate exit code
-set -o pipefail && make doc 2>&1
-set +o pipefail
+make doc 2>&1

--- a/continuous_integration/circle/build_doc.sh
+++ b/continuous_integration/circle/build_doc.sh
@@ -19,12 +19,9 @@ source activate $CONDA_ENV_NAME
 conda install --yes --quiet pip numpy sphinx=1.6.3 matplotlib pillow
 pip install sphinx-gallery
 
-cd "$HOME/$CIRCLE_PROJECT_REPONAME"
 ls -l
 python setup.py develop
 
 # The pipefail is requested to propagate exit code
-set -o pipefail && make doc 2>&1 | tee ~/log.txt
-
-cd -
+set -o pipefail && make doc 2>&1 | tee log.txt
 set +o pipefail


### PR DESCRIPTION
This PR is an attempt to move the circleci configuration file to v2.

I received a mail from them recently:
`You’ll need to update all of your config files to the CircleCI 2.0 syntax in order to migrate your projects to CircleCI 2.0 over the next 6 months.`