### PR TITLE
[MRG+1] FIX: fix misleading 'cachedir' deprecation warnings

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -776,12 +776,10 @@ class Memory(Logger):
                 backend.
 
             cachedir: str or None
-                cachedir is deprecated since version 0.12 and will be
-                removed in 0.14. Please consider using 'location' option
-                instead.
-                The path of the base directory to use as a data store
-                or None. If None is given, no caching is done and
-                the Memory object is completely transparent.
+
+                .. deprecated: 0.12
+                    'cachedir' has been deprecated in 0.12 and will be
+                    removed in 0.14. Use the 'location' parameter instead.
 
             mmap_mode: {None, 'r+', 'r', 'w+', 'c'}, optional
                 The memmapping mode used when loading from cache
@@ -819,7 +817,7 @@ class Memory(Logger):
         if cachedir is not None:
             if location is None:
                 warnings.warn(
-                    "The 'cachedir' parameter is deprecated since version "
+                    "The 'cachedir' parameter has been deprecated in version "
                     "0.12 and will be removed in version 0.14.\n"
                     "You provided 'cachedir={!r}', "
                     "use 'location={!r}' instead.".format(cachedir, location),
@@ -843,10 +841,11 @@ class Memory(Logger):
 
     @property
     def cachedir(self):
-        warnings.warn("The 'cachedir' attribute is deprecated since version "
-                      "0.12 and will be removed in version 0.14.\n"
-                      "Use the 'location' attribute instead.",
-                      DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            "The 'cachedir' attribute has been deprecated in version 0.12 "
+            "and will be removed in version 0.14.\n"
+            "Use the 'location' attribute instead.",
+            DeprecationWarning, stacklevel=2)
         return self.location
 
     def cache(self, func=None, ignore=None, verbose=None, mmap_mode=False):

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -819,8 +819,8 @@ class Memory(Logger):
                 warnings.warn(
                     "The 'cachedir' parameter has been deprecated in version "
                     "0.12 and will be removed in version 0.14.\n"
-                    "You provided 'cachedir={!r}', "
-                    "use 'location={!r}' instead.".format(cachedir, location),
+                    'You provided "cachedir={!r}", '
+                    'use "location={!r}" instead.'.format(cachedir, location),
                     DeprecationWarning, stacklevel=2)
                 location = cachedir
             else:

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -818,10 +818,12 @@ class Memory(Logger):
                           stacklevel=2)
         if cachedir is not None:
             if location is None:
-                warnings.warn("cachedir option is deprecated since version "
-                              "0.12 and will be removed in version 0.14.\n"
-                              "Use option location='store location' "
-                              "instead.", DeprecationWarning, stacklevel=2)
+                warnings.warn(
+                    "The 'cachedir' parameter is deprecated since version "
+                    "0.12 and will be removed in version 0.14.\n"
+                    "You provided 'cachedir={!r}', "
+                    "use 'location={!r}' instead.".format(cachedir, location),
+                    DeprecationWarning, stacklevel=2)
                 location = cachedir
             else:
                 warnings.warn("You set both location and cachedir options."
@@ -841,9 +843,9 @@ class Memory(Logger):
 
     @property
     def cachedir(self):
-        warnings.warn("cachedir option is deprecated since version "
+        warnings.warn("The 'cachedir' attribute is deprecated since version "
                       "0.12 and will be removed in version 0.14.\n"
-                      "Use 'location' attribute instead.",
+                      "Use the 'location' attribute instead.",
                       DeprecationWarning, stacklevel=2)
         return self.location
 

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -777,7 +777,8 @@ class Memory(Logger):
 
             cachedir: str or None
                 cachedir is deprecated since version 0.12 and will be
-                removed in 0.14. Please consider using location option instead.
+                removed in 0.14. Please consider using 'location' option
+                instead.
                 The path of the base directory to use as a data store
                 or None. If None is given, no caching is done and
                 the Memory object is completely transparent.
@@ -819,7 +820,7 @@ class Memory(Logger):
             if location is None:
                 warnings.warn("cachedir option is deprecated since version "
                               "0.12 and will be removed in version 0.14.\n"
-                              "Use option location=<store location> "
+                              "Use option location='store location' "
                               "instead.", DeprecationWarning, stacklevel=2)
                 location = cachedir
             else:

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -842,8 +842,8 @@ class Memory(Logger):
     def cachedir(self):
         warnings.warn("cachedir option is deprecated since version "
                       "0.12 and will be removed in version 0.14.\n"
-                      "Use option location=<store location> "
-                      "instead.", DeprecationWarning, stacklevel=2)
+                      "Use 'location' attribute instead.",
+                      DeprecationWarning, stacklevel=2)
         return self.location
 
     def cache(self, func=None, ignore=None, verbose=None, mmap_mode=False):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -387,7 +387,7 @@ def test_func_dir(tmpdir):
     with warns(DeprecationWarning) as w:
         assert memory.cachedir == os.path.dirname(g.store_backend.location)
     assert len(w) == 1
-    assert "cachedir option is deprecated since version" in str(w[-1].message)
+    assert "The 'cachedir' attribute has been deprecated" in str(w[-1].message)
 
     # Test that the code is stored.
     # For the following test to be robust to previous execution, we clear
@@ -900,7 +900,7 @@ def test_cachedir_deprecation_warning(tmpdir):
         assert memory.store_backend.location.startswith(tmpdir.strpath)
 
     assert len(w) == 1
-    assert "cachedir option is deprecated since version" in str(w[-1].message)
+    assert "The 'cachedir' parameter has been deprecated" in str(w[-1].message)
 
 
 class IncompleteStoreBackend(StoreBackendBase):


### PR DESCRIPTION
Follow-up of #639 as suggested by this [comment](https://github.com/joblib/joblib/pull/639#issuecomment-372964288).