### PR TITLE
CSS: fix verticle space on RTD

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -45,3 +45,8 @@ div.body table.docutils td{
 div.sphinxsidebarwrapper ul:last-of-type {
     margin-bottom: 100px;
 }
+
+/* But don't apply this to nested ul */
+div.sphinxsidebarwrapper ul ul:last-of-type {
+    margin-bottom: 20px;
+}


### PR DESCRIPTION
Fixes vertical space in sidebar for nested list (happens in pages deep in the docs, but not in the main docs).

Ping @aabadie 