### PR TITLE
[MRG+1] Passing both location and cachedir to Memory should raise an error

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -815,20 +815,21 @@ class Memory(Logger):
             warnings.warn('Compressed results cannot be memmapped',
                           stacklevel=2)
         if cachedir is not None:
-            if location is None:
-                warnings.warn(
-                    "The 'cachedir' parameter has been deprecated in version "
+            if location is not None:
+                raise ValueError(
+                    'You set both "location={0!r} and "cachedir={1!r}". '
+                    "'cachedir' has been deprecated in version "
                     "0.12 and will be removed in version 0.14.\n"
-                    'You provided "cachedir={!r}", '
-                    'use "location={!r}" instead.'.format(cachedir, location),
-                    DeprecationWarning, stacklevel=2)
-                location = cachedir
-            else:
-                warnings.warn("You set both location and cachedir options."
-                              "cachedir is deprecated since version "
-                              "0.12 and will be removed in version 0.14.\n"
-                              "cachedir value will be ignored.",
-                              DeprecationWarning, stacklevel=2)
+                    'Please only set "location={0!r}"'.format(
+                        location, cachedir))
+
+            warnings.warn(
+                "The 'cachedir' parameter has been deprecated in version "
+                "0.12 and will be removed in version 0.14.\n"
+                'You provided "cachedir={!r}", '
+                'use "location={!r}" instead.'.format(cachedir, location),
+                DeprecationWarning, stacklevel=2)
+            location = cachedir
 
         self.location = location
         if isinstance(location, _basestring):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -885,16 +885,9 @@ def test_memory_recomputes_after_an_error_why_loading_results(tmpdir,
     assert recomputed_timestamp > timestamp
 
 
-def test_cachedir_deprecation_warning(tmpdir):
+def test_deprecated_cachedir_behaviour(tmpdir):
     # verify the right deprecation warnings are raised when using cachedir
     # option instead of new location parameter.
-    with warns(None) as w:
-        memory = Memory(location=tmpdir.strpath, cachedir=tmpdir, verbose=0)
-        assert memory.store_backend.location.startswith(tmpdir.strpath)
-
-    assert len(w) == 1
-    assert "You set both location and cachedir options" in str(w[-1].message)
-
     with warns(None) as w:
         memory = Memory(cachedir=tmpdir.strpath, verbose=0)
         assert memory.store_backend.location.startswith(tmpdir.strpath)
@@ -908,6 +901,11 @@ def test_cachedir_deprecation_warning(tmpdir):
 
     assert len(w) == 1
     assert "The 'cachedir' attribute has been deprecated" in str(w[-1].message)
+
+    error_regex = """You set both "location='.+ and "cachedir='.+"""
+    with raises(ValueError, match=error_regex):
+        memory = Memory(location=tmpdir.strpath, cachedir=tmpdir.strpath,
+                        verbose=0)
 
 
 class IncompleteStoreBackend(StoreBackendBase):


### PR DESCRIPTION
rather than a warning. There is no use case where allowing the user to set both cachedir and location is useful.