### PR TITLE
Support using parallel_backend globally

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,11 @@ Alexandre Abadie
     The ``cachedir`` parameter of ``Memory`` is now marked as deprecated, use
     ``location`` instead.
 
+Matthew Rocklin
+
+    Allow ``parallel_backend`` to be used globally instead of only as a context
+    manager.
+
 Release 0.11
 ------------
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -15,7 +15,6 @@ import time
 import threading
 import itertools
 from numbers import Integral
-from contextlib import contextmanager
 import warnings
 
 from ._multiprocessing_helpers import mp
@@ -101,8 +100,7 @@ def get_active_backend(prefer=None, require=None, verbose=0):
     return backend, DEFAULT_N_JOBS
 
 
-@contextmanager
-def parallel_backend(backend, n_jobs=-1, **backend_params):
+class parallel_backend(object):
     """Change the default backend used by Parallel inside a with block.
 
     If ``backend`` is a string it must match a previously registered
@@ -130,19 +128,24 @@ def parallel_backend(backend, n_jobs=-1, **backend_params):
     .. versionadded:: 0.10
 
     """
-    if isinstance(backend, _basestring):
-        backend = BACKENDS[backend](**backend_params)
-    old_backend_and_jobs = getattr(_backend, 'backend_and_jobs', None)
-    try:
+    def __init__(self, backend, n_jobs=-1, **backend_params):
+        if isinstance(backend, _basestring):
+            backend = BACKENDS[backend](**backend_params)
+
+        self.old_backend_and_jobs = getattr(_backend, 'backend_and_jobs', None)
+        self.new_backend_and_jobs = (backend, n_jobs)
+
         _backend.backend_and_jobs = (backend, n_jobs)
-        # return the backend instance to make it easier to write tests
-        yield backend, n_jobs
-    finally:
-        if old_backend_and_jobs is None:
+
+    def __enter__(self):
+        return self.new_backend_and_jobs
+
+    def __exit__(self, type, value, traceback):
+        if self.old_backend_and_jobs is None:
             if getattr(_backend, 'backend_and_jobs', None) is not None:
                 del _backend.backend_and_jobs
         else:
-            _backend.backend_and_jobs = old_backend_and_jobs
+            _backend.backend_and_jobs = self.old_backend_and_jobs
 
 
 # Under Linux or OS X the default start method of multiprocessing

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -141,6 +141,9 @@ class parallel_backend(object):
         return self.new_backend_and_jobs
 
     def __exit__(self, type, value, traceback):
+        self.unregister()
+
+    def unregister(self):
         if self.old_backend_and_jobs is None:
             if getattr(_backend, 'backend_and_jobs', None) is not None:
                 del _backend.backend_and_jobs

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1142,3 +1142,13 @@ def test_invalid_backend_hinting_and_constraints():
         Parallel(backend='loky', require='sharedmem')
     with raises(ValueError):
         Parallel(backend='multiprocessing', require='sharedmem')
+
+
+def test_global_parallel_backend():
+    default = Parallel()._backend
+
+    pb = parallel_backend('threading')
+    assert isinstance(Parallel()._backend, ThreadingBackend)
+
+    pb.unregister()
+    assert type(Parallel()._backend) is type(default)


### PR DESCRIPTION
Fixes #652 

Currently when users want to use a separate backend (like dask) they wrap their code in a context manager

```python
with parallel_backend('dask'):
    # joblib code here
```

This is probably ideal for cleanliness, but can be somewhat awkward in interactive sessions.  It might be convenient to optionally allow users to set the parallel backend globally:

```python
parallel_backend('dask')

# joblib code here
```

This PR implements this logic by converting the existing parallel_backend context manager into a proper context manager class, implementing `__enter__` and `__exit__`.  It now does the backend wiring on instantiation, rather than in `__enter__`.