### PR TITLE
Support registration of external backends

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,7 @@ Matthew Rocklin
 
     Allow ``parallel_backend`` to be used globally instead of only as a context
     manager.
+    Support lazy registration of external parallel backends
 
 Release 0.11
 ------------

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -179,13 +179,14 @@ A problem exists that external packages that register new parallel backends
 must now be imported explicitly for their backends to be identified by joblib::
 
    >>> import joblib
-   >>> with joblib.parallel_backend('custom'):
-       ...  # this fails
-    KeyError: 'custom' does not exist in BACKENDS
+   >>> with joblib.parallel_backend('custom'):  # doctest: +SKIP
+   ...     ...  # this fails
+   KeyError: 'custom'
 
-   >>> import my_custom_backend_library  # Register external joblib
-   >>> with joblib.parallel_backend('custom'):
-       ...  # this works
+   # Import library to register external backend
+   >>> import my_custom_backend_library  # doctest: +SKIP
+   >>> with joblib.parallel_backend('custom'):  # doctest: +SKIP
+   ...     ... # this works
 
 This can be confusing for users.  To resolve this, external packages can
 safely register their backends directly within the joblib codebase by creating

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -175,6 +175,35 @@ uses :class:`joblib.Parallel` internally while not exposing the ``backend``
 argument in its own API.
 
 
+A problem exists that external packages that register new parallel backends
+must now be imported explicitly for their backends to be identified by joblib::
+
+   >>> import joblib
+   >>> with joblib.parallel_backend('custom'):
+       ...  # this fails
+    KeyError: 'custom' does not exist in BACKENDS
+
+   >>> import my_custom_backend_library  # Register external joblib
+   >>> with joblib.parallel_backend('custom'):
+       ...  # this works
+
+This can be confusing for users.  To resolve this, external packages can
+safely register their backends directly within the joblib codebase by creating
+a small function that registers their backend, and including this function
+within the ``joblib.parallel.EXTERNAL_PACKAGES`` dictionary::
+
+   def _register_custom():
+       try:
+           import my_custom_library
+       except ImportError:
+           raise ImportError("an informative error message")
+
+   EXTERNAL_BACKENDS['custom'] = _register_custom
+
+This is subject to community review, but can reduce the confusion for users
+when relying on side effects of external package imports.
+
+
 Old multiprocessing backend
 ===========================
 

--- a/examples/parallel/distributed_backend_simple.py
+++ b/examples/parallel/distributed_backend_simple.py
@@ -20,16 +20,13 @@ orchestrate well the computation.
 ###############################################################################
 # Setup the distributed client
 ###############################################################################
-from distributed import Client
-# Typically, to execute on a remote machine, the address of the scheduler
-# would go there
-client = Client()
+from dask.distributed import Client
 
-# Recover the address
-address = client.scheduler_info()['address']
+# If you have a remote cluster running Dask
+# client = Client('tcp://scheduler-address:8786')
 
-# This import registers the dask.distributed backend for joblib
-import distributed.joblib  # noqa
+# If you want Dask to set itself up on your personal computer
+client = Client(processes=False)
 
 ###############################################################################
 # Run parallel computation using dask.distributed
@@ -47,11 +44,11 @@ def long_running_function(i):
 ###############################################################################
 # The verbose messages below show that the backend is indeed the
 # dask.distributed one
-with joblib.parallel_backend('dask.distributed', scheduler_host=address):
-    joblib.Parallel(n_jobs=2, verbose=100)(
+with joblib.parallel_backend('dask'):
+    joblib.Parallel(verbose=100)(
         joblib.delayed(long_running_function)(i)
         for i in range(10))
 
 ###############################################################################
 # Progress in computation can be followed on the distributed web
-# interface, see http://distributed.readthedocs.io/en/latest/web.html
+# interface, see http://dask.pydata.org/en/latest/diagnostics-distributed.html

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -42,7 +42,6 @@ BACKENDS = {
     'sequential': SequentialBackend,
     'loky': LokyBackend,
 }
-
 # name of the backend used by default by Parallel outside of any context
 # managed by ``parallel_backend``.
 DEFAULT_BACKEND = 'loky'
@@ -55,6 +54,16 @@ _backend = threading.local()
 
 VALID_BACKEND_HINTS = ('processes', 'threads', None)
 VALID_BACKEND_CONSTRAINTS = ('sharedmem', None)
+
+
+def _register_dask():
+    """ Register Dask Backend if called with parallel_backend("dask") """
+    import distributed.joblib  # noqa: #F401
+
+
+EXTERNAL_BACKENDS = {
+    'dask': _register_dask,
+}
 
 
 def get_active_backend(prefer=None, require=None, verbose=0):
@@ -131,6 +140,10 @@ class parallel_backend(object):
     """
     def __init__(self, backend, n_jobs=-1, **backend_params):
         if isinstance(backend, _basestring):
+            if backend not in BACKENDS and backend in EXTERNAL_BACKENDS:
+                register = EXTERNAL_BACKENDS[backend]
+                register()
+
             backend = BACKENDS[backend](**backend_params)
 
         self.old_backend_and_jobs = getattr(_backend, 'backend_and_jobs', None)

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -58,7 +58,14 @@ VALID_BACKEND_CONSTRAINTS = ('sharedmem', None)
 
 def _register_dask():
     """ Register Dask Backend if called with parallel_backend("dask") """
-    import distributed.joblib  # noqa: #F401
+    try:
+        import distributed.joblib  # noqa: #F401
+    except ImportError:
+        msg = ("To use the dask.distributed backend you must install both "
+               "the `dask` and distributed modules.\n\n"
+               "See http://dask.pydata.org/en/latest/install.html for more "
+               "information."
+        raise ImportError(msg)
 
 
 EXTERNAL_BACKENDS = {

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -64,7 +64,7 @@ def _register_dask():
         msg = ("To use the dask.distributed backend you must install both "
                "the `dask` and distributed modules.\n\n"
                "See http://dask.pydata.org/en/latest/install.html for more "
-               "information."
+               "information.")
         raise ImportError(msg)
 
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -59,7 +59,7 @@ from joblib.parallel import Parallel, delayed
 from joblib.parallel import register_parallel_backend, parallel_backend
 from joblib.parallel import effective_n_jobs, cpu_count
 
-from joblib.parallel import mp, BACKENDS, DEFAULT_BACKEND
+from joblib.parallel import mp, BACKENDS, DEFAULT_BACKEND, EXTERNAL_BACKENDS
 from joblib.my_exceptions import JoblibException
 
 
@@ -1215,3 +1215,13 @@ def test_global_parallel_backend():
 
     pb.unregister()
     assert type(Parallel()._backend) is type(default)
+
+
+def test_external_backends():
+    def register_foo():
+        BACKENDS['foo'] = ThreadingBackend
+
+    EXTERNAL_BACKENDS['foo'] = register_foo
+
+    with parallel_backend('foo'):
+        assert isinstance(Parallel()._backend, ThreadingBackend)


### PR DESCRIPTION
Fixes https://github.com/joblib/joblib/issues/653

Currently when using external backends with joblib you need to know to
`import distributed.joblib`, which is not particularly intuitive.

```python
from joblib import parallel_backend
with parallel_backend("dask"):
    pass

KeyError: 'dask'
```

Now implementers of downstream parallel backends can register small
functions within the Joblib codebase that register their backends
appropriately when triggered by users.

FWIW I suspect that not everyone will agree with this change.  I will not be surprised if it does not get merged.  It was simple enough to implement though that I thought I'd throw it up here just to make conversation about it easier.  