### PR TITLE
[MRG] DOC: remove Memory explicit cachedir and location named arg

### DIFF
--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -44,7 +44,7 @@ A simple example:
   Then, instanciate a memory context that uses this cache directory::
 
     >>> from joblib import Memory
-    >>> memory = Memory(location=cachedir, verbose=0)
+    >>> memory = Memory(cachedir, verbose=0)
 
   After these initial steps, just decorate a function to cache its output in
   this context::
@@ -143,7 +143,7 @@ Memmapping (memory mapping) speeds up cache looking when reloading large numpy
 arrays::
 
     >>> cachedir2 = 'your_cachedir2_location'
-    >>> memory2 = Memory(location=cachedir2, mmap_mode='r')
+    >>> memory2 = Memory(cachedir2, mmap_mode='r')
     >>> square = memory2.cache(np.square)
     >>> a = np.vander(np.arange(3)).astype(np.float)
     >>> square(a)
@@ -234,7 +234,7 @@ python interpreter.
 .. topic:: Shelving when cache is disabled
 
     In the case where caching is disabled (e.g.
-    `Memory(cachedir=None)`), the `call_and_shelve` method returns a
+    `Memory(None)`), the `call_and_shelve` method returns a
     `NotMemorizedResult` instance, that stores the full function
     output, instead of just a reference (since there is nothing to
     point to). All the above remains valid though, except for the

--- a/examples/memory_basic_usage.py
+++ b/examples/memory_basic_usage.py
@@ -50,7 +50,7 @@ print('\nThe transformed data are:\n {}'.format(data_trans))
 
 from joblib import Memory
 location = './cachedir'
-memory = Memory(location=location, verbose=0)
+memory = Memory(location, verbose=0)
 
 
 def costly_compute_cached(data, column_index=0):

--- a/examples/nested_parallel_memory.py
+++ b/examples/nested_parallel_memory.py
@@ -58,7 +58,7 @@ print('Elapsed time for the entire processing: {:.2f} s'
 from joblib import Memory
 
 location = './cachedir'
-memory = Memory(location=location, verbose=0)
+memory = Memory(location, verbose=0)
 costly_compute_cached = memory.cache(costly_compute)
 
 

--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -57,7 +57,7 @@ Main features
 
       >>> from joblib import Memory
       >>> cachedir = 'your_cache_dir_goes_here'
-      >>> mem = Memory(cachedir=cachedir)
+      >>> mem = Memory(cachedir)
       >>> import numpy as np
       >>> a = np.vander(np.arange(3)).astype(np.float)
       >>> square = mem.cache(np.square)


### PR DESCRIPTION
I feel this is better to make the doc compatible across different joblib versions. This is about the `cachedir/location` name change introduced by the store backends by @aabadie.

At the moment some of the doc on http://joblib.readthedocs.io/en/latest/ only works on master, which is fine but
1. you can still find it on google and be confused because the example does not work with the latest released joblib
2. even when we release joblib, the released scikit-learn will have an old joblib for a while so some examples will not work with `from sklearn.externals.joblib import ...`.

For completeness, the context I bumped into it was that I wanted to point some people to the nice examples on readthedocs except that they can not use it with the latest released joblib.