### PR TITLE
MISC: fix typo in private function name

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -431,7 +431,7 @@ class MemorizedFunc(Logger):
         """
         # Compare the function code with the previous to see if the
         # function code has changed
-        func_id, args_id = self._get_output_idendifiers(*args, **kwargs)
+        func_id, args_id = self._get_output_identifiers(*args, **kwargs)
         metadata = None
         msg = None
         # FIXME: The statements below should be try/excepted
@@ -518,7 +518,7 @@ class MemorizedFunc(Logger):
         return hashing.hash(filter_args(self.func, self.ignore, args, kwargs),
                             coerce_mmap=(self.mmap_mode is not None))
 
-    def _get_output_idendifiers(self, *args, **kwargs):
+    def _get_output_identifiers(self, *args, **kwargs):
         """Return the func identifier and input parameter hash of a result."""
         func_id = _build_func_identifier(self.func)
         argument_hash = self._get_argument_hash(*args, **kwargs)
@@ -663,7 +663,7 @@ class MemorizedFunc(Logger):
             persist the output values.
         """
         start_time = time.time()
-        func_id, args_id = self._get_output_idendifiers(*args, **kwargs)
+        func_id, args_id = self._get_output_identifiers(*args, **kwargs)
         if self._verbose > 0:
             print(format_call(self.func, args, kwargs))
         output = self.func(*args, **kwargs)
@@ -705,7 +705,7 @@ class MemorizedFunc(Logger):
         # concurrent joblibs removing the file or the directory
         metadata = {"duration": duration, "input_args": input_repr}
 
-        func_id, args_id = self._get_output_idendifiers(*args, **kwargs)
+        func_id, args_id = self._get_output_identifiers(*args, **kwargs)
         self.store_backend.store_metadata([func_id, args_id], metadata)
 
         this_duration = time.time() - start_time

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -398,7 +398,7 @@ def test_func_dir(tmpdir):
     assert g._check_previous_func_code()
 
     # Test the robustness to failure of loading previous results.
-    func_id, args_id = g._get_output_idendifiers(1)
+    func_id, args_id = g._get_output_identifiers(1)
     output_dir = os.path.join(g.store_backend.location, func_id, args_id)
     a = g(1)
     assert os.path.exists(output_dir)
@@ -414,7 +414,7 @@ def test_persistence(tmpdir):
 
     h = pickle.loads(pickle.dumps(g))
 
-    func_id, args_id = h._get_output_idendifiers(1)
+    func_id, args_id = h._get_output_identifiers(1)
     output_dir = os.path.join(h.store_backend.location, func_id, args_id)
     assert os.path.exists(output_dir)
     assert output == h.store_backend.load_item([func_id, args_id])
@@ -640,7 +640,7 @@ def _setup_toy_cache(tmpdir, num_inputs=10):
         get_1000_bytes(arg)
 
     func_id = _build_func_identifier(get_1000_bytes)
-    hash_dirnames = [get_1000_bytes._get_output_idendifiers(arg)[1]
+    hash_dirnames = [get_1000_bytes._get_output_identifiers(arg)[1]
                      for arg in inputs]
 
     full_hashdirs = [os.path.join(get_1000_bytes.store_backend.location,


### PR DESCRIPTION
Trivial PR to fix a harmless typo in a name.

It's a change of a private API. This could break people's code that use private API, hence the question is open of whether or not we should merge this.