### PR TITLE
FIX: automatic build on readthedocs

### DIFF
--- a/.readthedocs-requirements.txt
+++ b/.readthedocs-requirements.txt
@@ -1,7 +1,7 @@
-# rtd comes with sphinx 1.3.5 and we need sphinx>=1.4 for sphinx.ext.imgmath
+# rtd comes with sphinx 1.3.5 and we need sphinx master for numpydoc
 sphinx>=1.4
 numpy
 matplotlib
 pillow
-sphinx-gallery
+-e git+http://github.com/sphinx-gallery/sphinx-gallery#egg=sphinx-gallery 
 numpydoc

--- a/.readthedocs-requirements.txt
+++ b/.readthedocs-requirements.txt
@@ -4,3 +4,4 @@ numpy
 matplotlib
 pillow
 sphinx-gallery
+numpydoc


### PR DESCRIPTION
This PR is an attempt to fix the failing documentation build on readthedocs.

The issue is related to the sphinx extension numpydoc that is broken apparently. I followed [this comment](https://github.com/sphinx-gallery/sphinx-gallery/pull/352#issuecomment-367090938) to fix it.

This PR is based on a branch pushed directly on the joblib organisation project, this allows to triggers builds on readthedocs (from the admin tab).

Now it seems to pass, see the result here: http://joblib.readthedocs.io/en/readthedocs_failing/index.html