### PR TITLE
Stale file handle IOError in Memory.reduce_size on Python 2

### DIFF
--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -285,10 +285,10 @@ class StoreBackendMixin(object):
             try:
                 self.clear_location(item.path)
             except (OSError, IOError):
-                # Even with ignore_errors=True can shutil.rmtree
-                # can raise OSError (IOError in python 2) with 
-                # [Errno 116] Stale file handle if another process 
-                # has deleted the folder already. 
+                # Even with ignore_errors=True shutil.rmtree
+                # can raise OSError (IOError in python 2) with
+                # [Errno 116] Stale file handle if another process
+                # has deleted the folder already.
                 pass
 
     def _get_items_to_delete(self, bytes_limit):

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -284,11 +284,11 @@ class StoreBackendMixin(object):
                 print('Deleting item {0}'.format(item))
             try:
                 self.clear_location(item.path)
-            except OSError:
+            except (OSError, IOError):
                 # Even with ignore_errors=True can shutil.rmtree
-                # can raise OSErrror with [Errno 116] Stale file
-                # handle if another process has deleted the folder
-                # already.
+                # can raise OSError (IOError in python 2) with 
+                # [Errno 116] Stale file handle if another process 
+                # has deleted the folder already. 
                 pass
 
     def _get_items_to_delete(self, bytes_limit):


### PR DESCRIPTION
This addresses issue #672 by improving the robustness of Memory.reduce_size to race conditions that arise when multiple processes are trying to delete the same directory simultaneously. Python 3 raises a OSError in this context, whereas Python 2 raises an IOError. This update catches and ignores both types of errors.

Fix #672.