### PR TITLE
ENH: avoid oversubscription with nested for loops

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -599,7 +599,7 @@ class Parallel(Logger):
 
     '''
     def __init__(self, n_jobs=None, backend=None, verbose=0, timeout=None,
-                 pre_dispatch='2 * n_jobs', batch_size='auto',
+                 pre_dispatch='n_jobs', batch_size='auto',
                  temp_folder=None, max_nbytes='1M', mmap_mode='r',
                  prefer=None, require=None):
         active_backend, context_n_jobs = get_active_backend(


### PR DESCRIPTION
Nested for loops can request many many threads. This leads to oversubscription which leads to too much use of memory and possibly a fork bomb with threads (https://github.com/joblib/joblib/issues/688).

The solution I implemented involves two changes:

- Sharing the thread pool across Parallel backends. This require scaling it when we add parallel instances
- Falling back to sequential computing when too many Parallel backends are around.

This PR fixes #688. It also avoids a very large memory consumption in the following code (use https://github.com/scikit-learn/scikit-learn/pull/11166 to test in scikit-learn):

<pre>
import os
os.environ['SKLEARN_SITE_JOBLIB'] = '1'
import joblib
from sklearn import datasets, model_selection, ensemble

data = datasets.fetch_covtype()
X = data.data
y = data.target


rf = ensemble.RandomForestClassifier(n_estimators=100, n_jobs=-1, verbose=10,
                                     max_depth=1)

model = model_selection.GridSearchCV(estimator=rf,
            param_grid=dict(
                max_features=[.1, .2, .3, .4, .5, .6]),
            n_jobs=-1, verbose=10,
            )

with joblib.parallel_backend('threading', n_jobs=-1):
    model_selection.cross_val_score(model, X, y, n_jobs=-1,
                verbose=10,
                )
</pre>