### PR TITLE
[MRG] Fix exception handling in nested parallel calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,15 @@ Olivier Grisel
     ``prefer='threads'`` or enforce shared-memory semantics with
     ``require='sharedmem'``.
 
+    Rely on the built-in exception nesting system of Python 3 to preserve
+    traceback information when an exception is raised on a remote worker
+    process. This avoid verbose and redundant exception reports under
+    Python 3.
+
+    Preserve exception type information when doing nested Parallel calls
+    instead of mapping the exception to the generic ``JoblibException`` type.
+
+
 Alexandre Abadie
 
     Introduce the concept of 'store' and refactor the ``Memory`` internal

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -14,7 +14,7 @@ from abc import ABCMeta, abstractmethod
 from .format_stack import format_exc
 from .my_exceptions import WorkerInterrupt, TransportableException
 from ._multiprocessing_helpers import mp
-from ._compat import with_metaclass
+from ._compat import with_metaclass, PY27
 if mp is not None:
     from .disk import delete_folder
     from .pool import MemmappingPool
@@ -531,10 +531,17 @@ class SafeFunction(object):
             # something different, as multiprocessing does not
             # interrupt processing for a KeyboardInterrupt
             raise WorkerInterrupt()
-        except:
-            e_type, e_value, e_tb = sys.exc_info()
-            text = format_exc(e_type, e_value, e_tb, context=10, tb_offset=1)
-            raise TransportableException(text, e_type)
+        except BaseException:
+            if PY27:
+                # Capture the traceback of the worker to make it part of
+                # the final exception message.
+                e_type, e_value, e_tb = sys.exc_info()
+                text = format_exc(e_type, e_value, e_tb, context=10,
+                                  tb_offset=1)
+                raise TransportableException(text, e_type)
+            else:
+                # Rely on Python 3 built-in Remote Traceback reporting
+                raise
 
 
 class FallbackToBackend(Exception):

--- a/joblib/format_stack.py
+++ b/joblib/format_stack.py
@@ -355,7 +355,7 @@ def format_exc(etype, evalue, etb, context=5, tb_offset=0):
     # Get (safely) a string form of the exception info
     try:
         etype_str, evalue_str = map(str, (etype, evalue))
-    except:
+    except BaseException:
         # User exception is improperly defined.
         etype, evalue = str, sys.exc_info()[:2]
         etype_str, evalue_str = map(str, (etype, evalue))

--- a/joblib/my_exceptions.py
+++ b/joblib/my_exceptions.py
@@ -4,10 +4,8 @@ Exceptions
 # Author: Gael Varoquaux < gael dot varoquaux at normalesup dot org >
 # Copyright: 2010, Gael Varoquaux
 # License: BSD 3 clause
-
-import sys
-
 from ._compat import PY3_OR_LATER
+
 
 class JoblibException(Exception):
     """A simple exception with an error message that you can get to."""
@@ -49,6 +47,17 @@ class TransportableException(JoblibException):
         self.message = message
         self.etype = etype
 
+    def unwrap(self, context_message=""):
+        report = """\
+%s
+---------------------------------------------------------------------------
+Joblib worker traceback:
+---------------------------------------------------------------------------
+%s""" % (context_message, self.message)
+        # Unwrap the exception to a JoblibException
+        exception_type = _mk_exception(self.etype)[0]
+        return exception_type(report)
+
 
 class WorkerInterrupt(Exception):
     """ An exception that is not KeyboardInterrupt to allow subprocesses
@@ -61,6 +70,10 @@ _exception_mapping = dict()
 
 
 def _mk_exception(exception, name=None):
+    if issubclass(exception, JoblibException):
+        # No need to wrap recursively JoblibException
+        return exception, exception.__name__
+
     # Create an exception inheriting from both JoblibException
     # and that exception
     if name is None:

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -22,7 +22,7 @@ from ._multiprocessing_helpers import mp
 
 from .format_stack import format_outer_frames
 from .logger import Logger, short_format_time
-from .my_exceptions import TransportableException, _mk_exception
+from .my_exceptions import TransportableException
 from .disk import memstr_to_bytes
 from ._parallel_backends import (FallbackToBackend, MultiprocessingBackend,
                                  ThreadingBackend, SequentialBackend,
@@ -869,24 +869,14 @@ class Parallel(Logger):
                     ensure_ready = self._managed_backend
                     backend.abort_everything(ensure_ready=ensure_ready)
 
-                if not isinstance(exception, TransportableException):
-                    raise
-                else:
+                if isinstance(exception, TransportableException):
                     # Capture exception to add information on the local
                     # stack in addition to the distant stack
                     this_report = format_outer_frames(context=10,
                                                       stack_start=1)
-                    report = """Multiprocessing exception:
-%s
----------------------------------------------------------------------------
-Sub-process traceback:
----------------------------------------------------------------------------
-%s""" % (this_report, exception.message)
-                    # Convert this to a JoblibException
-                    exception_type = _mk_exception(exception.etype)[0]
-                    exception = exception_type(report)
-
-                    raise exception
+                    raise exception.unwrap(this_report)
+                else:
+                    raise
 
     def __call__(self, iterable):
         if self._jobs:

--- a/joblib/test/test_my_exceptions.py
+++ b/joblib/test/test_my_exceptions.py
@@ -34,11 +34,11 @@ def test_inheritance_special_cases():
             my_exceptions.JoblibException)
 
     # Subclasses of JoblibException should be mapped to
-    # JoblibException by _mk_exception
-    for exception in [my_exceptions.JoblibException,
-                      my_exceptions.TransportableException]:
-        assert (my_exceptions._mk_exception(exception)[0] is
-                my_exceptions.JoblibException)
+    # them-selves by _mk_exception
+    for exception_type in [my_exceptions.JoblibException,
+                           my_exceptions.TransportableException]:
+        assert (my_exceptions._mk_exception(exception_type)[0] is
+                exception_type)
 
     # Non-inheritable exception classes should be mapped to
     # JoblibException by _mk_exception. That can happen with classes

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -509,13 +509,13 @@ def test_nested_exception_dispatch(backend):
 
     if PY3_OR_LATER:
         # Under Python 3, there is no need for exception wrapping as the
-        # exception in worker processes are transportable by default and
-        # preserve the necessary information via the `__cause__` attribute.
+        # exception raised in a worker process is transportable by default and
+        # preserves the necessary information via the `__cause__` attribute.
         assert type(excinfo.value) is ValueError
     else:
         # The wrapping mechanism used to make exception of Python2.7
         # transportable does not create a JoblibJoblibJoblibValueError
-        # despite the nested calls.
+        # despite the 3 nested parallel calls.
         assert type(excinfo.value) is JoblibValueError
 
 
@@ -747,10 +747,9 @@ def test_safe_function():
         with raises(ZeroDivisionError):
             safe_division(1, 0)
     else:
-        # Under Python 2.7, exception are wrapped with a special wrapper
-        # to preserve runtime information of the worker environment.
-        # Python 3 does not need this as it preserve the traceback information
-        # by default.
+        # Under Python 2.7, exception are wrapped with a special wrapper to
+        # preserve runtime information of the worker environment. Python 3 does
+        # not need this as it preserves the traceback information by default.
         with raises(TransportableException) as excinfo:
             safe_division(1, 0)
         assert isinstance(excinfo.value.unwrap(), ZeroDivisionError)


### PR DESCRIPTION
When doing nested parallel calls, all exception would be mapped to the generic `JoblibException` therefore losing the original exception type information (e.g. `ValueError`).

Furthermore, Python 3 already has a builtin `__cause__` exception nesting system that is used by default to trace exception that occurred on a remote worker process. The combination of the Python 3 `__cause__` nesting and the Joblib system yields overwhelmingly verbose and redundant exception reports.

To fix those two problems, we:

- disable useless exception wrapping under Python 3 to only rely on the built-in exception nesting mechanism;
- fix nested exception wrapping under Python 2 to preserve type information.