### PR TITLE
[MRG] DOC: use the .joblib extension instead of .pkl

### DIFF
--- a/doc/persistence.rst
+++ b/doc/persistence.rst
@@ -21,7 +21,7 @@ First create a temporary directory::
   >>> from tempfile import mkdtemp
   >>> savedir = mkdtemp()
   >>> import os
-  >>> filename = os.path.join(savedir, 'test.pkl')
+  >>> filename = os.path.join(savedir, 'test.joblib')
 
 Then create an object to be persisted::
 
@@ -32,7 +32,7 @@ which is saved into `filename`::
 
   >>> import joblib
   >>> joblib.dump(to_persist, filename)  # doctest: +ELLIPSIS
-  ['...test.pkl']
+  ['...test.joblib']
 
 The object can then be reloaded from the file::
 
@@ -60,13 +60,13 @@ Setting the `compress` argument to `True` in :func:`joblib.dump` will allow to
 save space on disk:
 
   >>> joblib.dump(to_persist, filename + '.compressed', compress=True)  # doctest: +ELLIPSIS
-  ['...test.pkl.compressed']
+  ['...test.joblib.compressed']
 
 If the filename extension corresponds to one of the supported compression
 methods, the compressor will be used automatically:
 
   >>> joblib.dump(to_persist, filename + '.z')  # doctest: +ELLIPSIS
-  ['...test.pkl.z']
+  ['...test.joblib.z']
 
 By default, :func:`joblib.dump` uses the zlib compression method as it gives
 the best tradeoff between speed and disk space. The other supported compression
@@ -74,11 +74,11 @@ methods are 'gzip', 'bz2', 'lzma' and 'xz':
 
   >>> # Dumping in a gzip compressed file using a compress level of 3.
   >>> joblib.dump(to_persist, filename + '.gz', compress=('gzip', 3))  # doctest: +ELLIPSIS
-  ['...test.pkl.gz']
+  ['...test.joblib.gz']
   >>> joblib.load(filename + '.gz')
   [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
   >>> joblib.dump(to_persist, filename + '.bz2', compress=('bz2', 3))  # doctest: +ELLIPSIS
-  ['...test.pkl.bz2']
+  ['...test.joblib.bz2']
   >>> joblib.load(filename + '.bz2')
   [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
 
@@ -87,7 +87,7 @@ string corresponding to the name of the compressor used. When using this, the
 default compression level is used by the compressor:
 
   >>> joblib.dump(to_persist, filename + '.gz', compress='gzip')  # doctest: +ELLIPSIS
-  ['...test.pkl.gz']
+  ['...test.joblib.gz']
 
 .. note::
 
@@ -108,7 +108,7 @@ If the ``lz4`` package is installed, this compression method is automatically
 available with the dump function.
 
   >>> joblib.dump(to_persist, filename + '.lz4')  # doctest: +ELLIPSIS
-  ['...test.pkl.lz4']
+  ['...test.joblib.lz4']
   >>> joblib.load(filename + '.lz4')
   [('a', [1, 2, 3]), ('b', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))]
 

--- a/examples/compressors_comparison.py
+++ b/examples/compressors_comparison.py
@@ -43,7 +43,7 @@ data = pd.read_csv(url, names=names)
 
 from joblib import dump, load
 
-pickle_file = './pickle_data.pkl'
+pickle_file = './pickle_data.joblib'
 
 ###############################################################################
 # Start by measuring the time spent for dumping the raw data:


### PR DESCRIPTION
This is a fix for #694.