### PR TITLE
[MRG] Make it possible to configure the reusable executor workers timeout

### DIFF
--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -427,14 +427,14 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
     supports_timeout = True
 
     def configure(self, n_jobs=1, parallel=None, prefer=None, require=None,
-                  **memmappingexecutor_args):
+                  idle_worker_timeout=300, **memmappingexecutor_args):
         """Build a process executor and return the number of workers"""
         n_jobs = self.effective_n_jobs(n_jobs)
         if n_jobs == 1:
             raise FallbackToBackend(SequentialBackend())
 
         self._workers = get_memmapping_executor(
-            n_jobs, **memmappingexecutor_args)
+            n_jobs, timeout=idle_worker_timeout, **memmappingexecutor_args)
         self.parallel = parallel
         return n_jobs
 

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -17,7 +17,7 @@ from .externals.loky.reusable_executor import get_reusable_executor
 _backend_args = None
 
 
-def get_memmapping_executor(n_jobs, **backend_args):
+def get_memmapping_executor(n_jobs, timeout=300, **backend_args):
     """Factory for ReusableExecutor with automatix memmapping for large numpy
     arrays.
     """
@@ -30,7 +30,7 @@ def get_memmapping_executor(n_jobs, **backend_args):
         id_executor, **backend_args)
     _executor = get_reusable_executor(n_jobs, job_reducers=job_reducers,
                                       result_reducers=result_reducers,
-                                      reuse=reuse)
+                                      reuse=reuse, timeout=timeout)
     # If executor doesn't have a _temp_folder, it means it is a new executor
     # and the reducers have been used. Else, the previous reducers are used
     # and we should not change this attibute.


### PR DESCRIPTION
And change the default value to 5min.

I have noticed that initializing 88 Python workers on a machine with 88 logical CPUs and an NFS filesystem can take 20 to 30s. Therefore I think using 10s as default worker timeout is too low to be useful on large computing servers. I think 5 min is a more useful default value.

I think 5 min should also be the default value for loky itself.