### PR TITLE
[MRG] Nested parallel call thread bomb mitigation

### DIFF
--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1296,6 +1296,7 @@ def _recursive_backend_info(limit=3):
         return this_level + results[0]
 
 
+@with_multiprocessing
 @parametrize('backend', ['loky', 'threading'])
 def test_nested_parallel_limit(backend):
     with parallel_backend(backend, n_jobs=2):


### PR DESCRIPTION
This does not protect against over-subscription but at least it protects against recursive thread bombs as reported initially in the tests of #690.