### PR TITLE
[MRG+1] global func_with_kwonly_args, func_with_signature

### DIFF
--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -146,14 +146,17 @@ def test_func_inspect_errors():
     assert get_func_code(ff)[1] == __file__.replace('.pyc', '.py')
 
 
-def func_with_kwonly_args(a, b, kw1='kw1', kw2='kw2'):
-    pass
-
-
-def func_with_signature(a, b):
-    pass
-
 if PY3_OR_LATER:
+    # Avoid flake8 F821 "undefined name" warning. func_with_kwonly_args and
+    # func_with_signature are redefined in the exec statement a few lines below
+    def func_with_kwonly_args():
+        pass
+
+    def func_with_signature():
+        pass
+
+    # exec is needed to define a function with a keyword-only argument and a
+    # function with signature while avoiding a SyntaxError on Python 2
     exec("""
 def func_with_kwonly_args(a, b, *, kw1='kw1', kw2='kw2'): pass
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -595,6 +595,7 @@ def func_with_signature(a: int, b: float) -> float:
 """)
 
     def test_memory_func_with_kwonly_args(tmpdir):
+        global func_with_kwonly_args, func_with_signature
         memory = Memory(location=tmpdir.strpath, verbose=0)
         func_cached = memory.cache(func_with_kwonly_args)
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -586,6 +586,16 @@ def test_clear_memory_with_none_location():
 
 
 if PY3_OR_LATER:
+    # Avoid flake8 F821 "undefined name" warning. func_with_kwonly_args and
+    # func_with_signature are redefined in the exec statement a few lines below
+    def func_with_kwonly_args():
+        pass
+
+    def func_with_signature():
+        pass
+
+    # exec is needed to define a function with a keyword-only argument and a
+    # function with signature while avoiding a SyntaxError on Python 2
     exec("""
 def func_with_kwonly_args(a, b, *, kw1='kw1', kw2='kw2'):
     return a, b, kw1, kw2
@@ -595,7 +605,6 @@ def func_with_signature(a: int, b: float) -> float:
 """)
 
     def test_memory_func_with_kwonly_args(tmpdir):
-        global func_with_kwonly_args, func_with_signature
         memory = Memory(location=tmpdir.strpath, verbose=0)
         func_cached = memory.cache(func_with_kwonly_args)
 


### PR DESCRIPTION
Fixes #711  Declare as global these two functions which are not created in the normal way.  This PR helps both humans and linters to understand this unusual situation.