### PR TITLE
fix kwonlydefaults key error in filter_args

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -240,8 +240,10 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
     arg_spec = getfullargspec(func)
     arg_names = arg_spec.args + arg_spec.kwonlyargs
     arg_defaults = arg_spec.defaults or ()
-    arg_defaults = arg_defaults + tuple(arg_spec.kwonlydefaults[k]
-                                        for k in arg_spec.kwonlyargs)
+    if arg_spec.kwonlydefaults:
+        arg_defaults = arg_defaults + tuple(arg_spec.kwonlydefaults[k]
+                                            for k in arg_spec.kwonlyargs
+                                            if k in arg_spec.kwonlydefaults)
     arg_varargs = arg_spec.varargs
     arg_varkw = arg_spec.varkw
 

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -99,11 +99,25 @@ def test_filter_varargs(func, args, filtered_args):
     assert filter_args(func, *args) == filtered_args
 
 
+test_filter_kwargs_extra_params = []
+if PY3_OR_LATER:
+    m1 = m2 = None
+    # The following statements raise SyntaxError in python 2
+    # because kwargonly is not supported
+    exec("def m1(x, *, y): pass")
+    exec("def m2(x, *, y, z=3): pass")
+    test_filter_kwargs_extra_params.extend([
+        (m1, [[], (1,), {'y': 2}], {'x': 1, 'y': 2}),
+        (m2, [[], (1,), {'y': 2}], {'x': 1, 'y': 2, 'z': 3})
+    ])
+
+
 @parametrize('func,args,filtered_args',
              [(k, [[], (1, 2), {'ee': 2}],
                {'*': [1, 2], '**': {'ee': 2}}),
               (k, [[], (3, 4)],
-               {'*': [3, 4], '**': {}})])
+               {'*': [3, 4], '**': {}})] +
+             test_filter_kwargs_extra_params)
 def test_filter_kwargs(func, args, filtered_args):
     assert filter_args(func, *args) == filtered_args
 


### PR DESCRIPTION
Fix for key error which were thrown from filter_args when default values were not specified for kw only arguments.

For example, in the following case arg_spec.kwonlydefaults is None:
```
def foo(x, *, y):
    pass

filter_args(foo, [], [1], dict(y=2))

.../env/lib/python3.5/site-packages/sklearn/externals/joblib/func_inspect.py in <genexpr>(.0)
    242     arg_defaults = arg_spec.defaults or ()
    243     arg_defaults = arg_defaults + tuple(arg_spec.kwonlydefaults[k]
--> 244                                         for k in arg_spec.kwonlyargs)
    245     arg_varargs = arg_spec.varargs
    246     arg_varkw = arg_spec.varkw

TypeError: 'NoneType' object is not subscriptable
```

In another example, arg_spec.kwonlydefaults is not None, but it does not contain 'y':

```
def foo(x, *, y, z=3):
    pass

filter_args(foo, [], [1], dict(y=2))

.../env/lib/python3.5/site-packages/sklearn/externals/joblib/func_inspect.py in <genexpr>(.0)
    242     arg_defaults = arg_spec.defaults or ()
    243     arg_defaults = arg_defaults + tuple(arg_spec.kwonlydefaults[k]
--> 244                                         for k in arg_spec.kwonlyargs)
    245     arg_varargs = arg_spec.varargs
    246     arg_varkw = arg_spec.varkw

KeyError: 'y'
```