### PR TITLE
FIX: re-establish argument_hash attribute for backward compat

### DIFF
--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -206,7 +206,7 @@ Getting a reference to the cache can be done using the
     >>> result = g.call_and_shelve(4)
     A long-running calculation, with parameter 4
     >>> result  #doctest: +ELLIPSIS
-    MemorizedResult(location="...", func="...g...", argument_id="...")
+    MemorizedResult(location="...", func="...g...", args_id="...")
 
 Once computed, the output of `g` is stored on disk, and deleted from
 memory. Reading the associated value can then be performed with the

--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -206,7 +206,7 @@ Getting a reference to the cache can be done using the
     >>> result = g.call_and_shelve(4)
     A long-running calculation, with parameter 4
     >>> result  #doctest: +ELLIPSIS
-    MemorizedResult(location="...", func="...g...", argument_hash="...")
+    MemorizedResult(location="...", func="...g...", argument_id="...")
 
 Once computed, the output of `g` is stored on disk, and deleted from
 memory. Reading the associated value can then be performed with the

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -250,11 +250,11 @@ class MemorizedResult(Logger):
 
     def __repr__(self):
         return ('{class_name}(location="{location}", func="{func}", '
-                'argument_id="{arg_id}")'
+                'args_id="{args_id}")'
                 .format(class_name=self.__class__.__name__,
                         location=self.store_backend,
                         func=self.func,
-                        arg_id=self.args_id
+                        args_id=self.args_id
                         ))
     def __reduce__(self):
         return (self.__class__,

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -224,6 +224,15 @@ class MemorizedResult(Logger):
         self.verbose = verbose
         self.timestamp = timestamp
 
+    @property
+    def argument_hash(self):
+        warnings.warn(
+            "The 'argument_hash' attribute has been deprecated in version 0.12 "
+            "and will be removed in version 0.14.\n"
+            "Use `args_id` attribute instead.",
+            DeprecationWarning, stacklevel=2)
+        return self.args_id
+
     def get(self):
         """Read value from cache and return it."""
         if self.verbose:
@@ -241,13 +250,12 @@ class MemorizedResult(Logger):
 
     def __repr__(self):
         return ('{class_name}(location="{location}", func="{func}", '
-                'argument_hash="{argument_hash}")'
+                'argument_id="{arg_id}")'
                 .format(class_name=self.__class__.__name__,
                         location=self.store_backend,
                         func=self.func,
-                        argument_hash=self.args_id
+                        arg_id=self.args_id
                         ))
-
     def __reduce__(self):
         return (self.__class__,
                 (self.store_backend, self.func, self.args_id),

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -227,8 +227,8 @@ class MemorizedResult(Logger):
     @property
     def argument_hash(self):
         warnings.warn(
-            "The 'argument_hash' attribute has been deprecated in version 0.12 "
-            "and will be removed in version 0.14.\n"
+            "The 'argument_hash' attribute has been deprecated in version "
+            "0.12 and will be removed in version 0.14.\n"
             "Use `args_id` attribute instead.",
             DeprecationWarning, stacklevel=2)
         return self.args_id

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -451,6 +451,19 @@ def test_call_and_shelve(tmpdir):
         result.clear()  # Do nothing if there is no cache.
 
 
+def test_call_and_shelve_argument_hash(tmpdir):
+    # Verify that a warning is raised when accessing arguments_hash
+    # attribute from MemorizedResult
+    func = Memory(location=tmpdir.strpath, verbose=0).cache(f)
+    result = func.call_and_shelve(2)
+    assert isinstance(result, MemorizedResult)
+    with warns(DeprecationWarning) as w:
+        assert result.argument_hash == result.args_id
+    assert len(w) == 1
+    assert "The 'argument_hash' attribute has been deprecated" \
+        in str(w[-1].message)
+
+
 def test_memorized_pickling(tmpdir):
     for func in (MemorizedFunc(f, tmpdir.strpath), NotMemorizedFunc(f)):
         filename = tmpdir.join('pickling_test.dat').strpath


### PR DESCRIPTION
This PR is an attempt to fix #714:

- it reestablish the `argument_hash` attribute for backward compatibility, since it appears that some people were using it
- the argument_hash is now marked deprecated
- the string representation of MemorizedResult don't use `argument_hash` anymore but `args_id` instead.