### PR TITLE
RF(loky): use psutil.Process to deduce children processes

### DIFF
--- a/joblib/externals/loky/backend/utils.py
+++ b/joblib/externals/loky/backend/utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import errno
+import psutil
 import signal
 import warnings
 import threading
@@ -33,51 +34,11 @@ def recursive_terminate(process):
 def _recursive_terminate(pid):
     """Recursively kill the descendants of a process before killing it.
     """
-
-    if sys.platform == "win32":
-        # On windows, the taskkill function with option `/T` terminate a given
-        # process pid and its children.
+    process = psutil.Process(pid=pid)
+    children = process.children(recursive=True)
+    for pid_ in [c.pid for c in children] + [pid]:
         try:
-            subprocess.check_output(
-                ["taskkill", "/F", "/T", "/PID", str(pid)],
-                stderr=None)
-        except subprocess.CalledProcessError as e:
-            # In windows, taskkill return 1 for permission denied and 128, 255
-            # for no process found.
-            if e.returncode not in [1, 128, 255]:
-                raise
-            elif e.returncode == 1:
-                # Try to kill the process without its descendants if taskkill
-                # was denied permission. If this fails too, with an error
-                # different from process not found, let the top level function
-                # raise a warning and retry to kill the process.
-                try:
-                    os.kill(pid, signal.SIGTERM)
-                except OSError as e:
-                    if e.errno != errno.ESRCH:
-                        raise
-
-    else:
-        try:
-            children_pids = subprocess.check_output(
-                ["pgrep", "-P", str(pid)],
-                stderr=None
-            )
-        except subprocess.CalledProcessError as e:
-            # `ps` returns 1 when no child process has been found
-            if e.returncode == 1:
-                children_pids = b''
-            else:
-                raise
-
-        # Decode the result, split the cpid and remove the trailing line
-        children_pids = children_pids.decode().split('\n')[:-1]
-        for cpid in children_pids:
-            cpid = int(cpid)
-            _recursive_terminate(cpid)
-
-        try:
-            os.kill(pid, signal.SIGTERM)
+            os.kill(pid_, signal.SIGTERM)
         except OSError as e:
             # if OSError is raised with [Errno 3] no such process, the process
             # is already terminated, else, raise the error and let the top


### PR DESCRIPTION
Also avoided platform specific implementations and demand optional command line tools such as pgrep on Linux (debian package update has failed due to /dev/shm remained used by some rogue processes).
But that would demand dependency on psutil module

-  didn't test if it really works

This is more of an issue report (dependency on pgrep) than a PR which is incomplete,untested, and should go against loky anyways probably