### PR TITLE
Implement in_store method to check if a result is already in store

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -324,6 +324,9 @@ class NotMemorizedFunc(object):
     def call_and_shelve(self, *args, **kwargs):
         return NotMemorizedResult(self.func(*args, **kwargs))
 
+    def in_store(self, *args, **kwargs):    
+        return False
+
     def __reduce__(self):
         return (self.__class__, (self.func,))
 
@@ -517,6 +520,25 @@ class MemorizedFunc(Logger):
         """
         return (self.__class__, (self.func, self.store_backend, self.ignore,
                 self.mmap_mode, self.compress, self._verbose))
+
+    def in_store(self, *args, **kwargs):
+        """"Return true if the store contains results for set of parameters.
+
+        Note that this will not check if results can be loaded, call the
+        function to achieve this.
+
+        Returns
+        -------
+            cached: bool
+                True if calling function with these arguments would
+                load from backend, else False.
+        """
+        func_id, args_id = self._get_output_identifiers(*args, **kwargs)
+        if (self._check_previous_func_code(stacklevel=4) and
+                self.store_backend.contains_item([func_id, args_id])):
+            return True
+        else:
+            return False
 
     # ------------------------------------------------------------------------
     # Private interface

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -324,7 +324,7 @@ class NotMemorizedFunc(object):
     def call_and_shelve(self, *args, **kwargs):
         return NotMemorizedResult(self.func(*args, **kwargs))
 
-    def in_store(self, *args, **kwargs):    
+    def cached(self, *args, **kwargs):
         return False
 
     def __reduce__(self):
@@ -521,24 +521,15 @@ class MemorizedFunc(Logger):
         return (self.__class__, (self.func, self.store_backend, self.ignore,
                 self.mmap_mode, self.compress, self._verbose))
 
-    def in_store(self, *args, **kwargs):
+    def cached(self, *args, **kwargs):
         """"Return true if the store contains results for set of parameters.
 
         Note that this will not check if results can be loaded, call the
         function to achieve this.
-
-        Returns
-        -------
-            cached: bool
-                True if calling function with these arguments would
-                load from backend, else False.
         """
         func_id, args_id = self._get_output_identifiers(*args, **kwargs)
-        if (self._check_previous_func_code(stacklevel=4) and
-                self.store_backend.contains_item([func_id, args_id])):
-            return True
-        else:
-            return False
+        return (self._check_previous_func_code(stacklevel=4)
+                and self.store_backend.contains_item([func_id, args_id]))
 
     # ------------------------------------------------------------------------
     # Private interface

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -141,8 +141,8 @@ def test_memory_kwarg(tmpdir):
     assert g(l=30, m=2) == 30
 
 
-def test_in_store(tmpdir):
-    " Test in_store function."
+def test_cached(tmpdir):
+    " Test cached function."
 
     def g(a, b, c, d, e=None, f=1):
         return (a, b, c, d, e, f)
@@ -152,10 +152,10 @@ def test_in_store(tmpdir):
     args = (1, 2, 3, 4)
     kwargs = {'e': 5, 'f': 6}
     g(*args, **kwargs)
-    assert(g.in_store(*args, **kwargs))
-    assert(not g.in_store(*args[::-1], **kwargs))
+    assert(g.cached(*args, **kwargs))
+    assert(not g.cached(*args[::-1], **kwargs))
     g.clear()
-    assert(not g.in_store(*args, **kwargs))
+    assert(not g.cached(*args, **kwargs))
 
 
 def test_memory_lambda(tmpdir):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -152,10 +152,10 @@ def test_cached(tmpdir):
     args = (1, 2, 3, 4)
     kwargs = {'e': 5, 'f': 6}
     g(*args, **kwargs)
-    assert(g.cached(*args, **kwargs))
-    assert(not g.cached(*args[::-1], **kwargs))
+    assert g.cached(*args, **kwargs)
+    assert not g.cached(*args[::-1], **kwargs)
     g.clear()
-    assert(not g.cached(*args, **kwargs))
+    assert not g.cached(*args, **kwargs)
 
 
 def test_memory_lambda(tmpdir):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -158,6 +158,21 @@ def test_cached(tmpdir):
     assert not g.cached(*args, **kwargs)
 
 
+def test_load(tmpdir):
+    " Test load function."
+
+    def g(a, b=1):
+        return a, b
+
+    memory = Memory(location=tmpdir.strpath, verbose=0)
+    g = memory.cache(g)
+    a, b = 1, 4
+    g(a, b=b)
+    assert (a, b) == g.load(a, b=b)
+    with raises(ValueError):
+        g.load(0, b=0)
+
+
 def test_memory_lambda(tmpdir):
     " Test memory with a function with a lambda."
     accumulator = list()

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -141,6 +141,23 @@ def test_memory_kwarg(tmpdir):
     assert g(l=30, m=2) == 30
 
 
+def test_in_store(tmpdir):
+    " Test in_store function."
+
+    def g(a, b, c, d, e=None, f=1):
+        return (a, b, c, d, e, f)
+
+    memory = Memory(location=tmpdir.strpath, verbose=0)
+    g = memory.cache(g)
+    args = (1, 2, 3, 4)
+    kwargs = {'e': 5, 'f': 6}
+    g(*args, **kwargs)
+    assert(g.in_store(*args, **kwargs))
+    assert(not g.in_store(*args[::-1], **kwargs))
+    g.clear()
+    assert(not g.in_store(*args, **kwargs))
+
+
 def test_memory_lambda(tmpdir):
     " Test memory with a function with a lambda."
     accumulator = list()


### PR DESCRIPTION
In some cases it is nice to be able to check if the result of a function call is already available in the backend store. For example, when dispatching long computations to a cluster this allows to check if and which computations have already run. Being able to check for this makes it particularly easy to collect all available results without triggering computation of those that are still running. At least two issues have mentioned this ( #407 - a pull request which now does not merge with master and #668). 

This is an attemt to provide this functionality by introducing an 'in_store' method that can be called with the same signature as the original function. When a result is in store for some input arguments it returns True, else False. 

