### PR TITLE
MAINT: update documentation URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@
 
 The homepage of joblib with user documentation is located on:
 
-https://pythonhosted.org/joblib/
+https://joblib.readthedocs.io
 
 Getting the latest code
 =======================

--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -12,7 +12,7 @@ data and has specific optimizations for `numpy` arrays. It is
 
 
     ==================== ===============================================
-    **Documentation:**       http://pythonhosted.org/joblib
+    **Documentation:**       https://joblib.readthedocs.io
 
     **Download:**            http://pypi.python.org/pypi/joblib#downloads
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
           version=joblib.__version__,
           author='Gael Varoquaux',
           author_email='gael.varoquaux@normalesup.org',
-          url='http://pythonhosted.org/joblib/',
+          url='https://joblib.readthedocs.io',
           description=("Lightweight pipelining: using Python functions "
                        "as pipeline jobs."),
           long_description=joblib.__doc__,


### PR DESCRIPTION
fixes #737 

This PR replaces all occurrences of pythonhosted URL with the one on readthedocs.