### PR TITLE
DOC: fine tune compressor example dataset size for ReadTheDocs

### DIFF
--- a/examples/compressors_comparison.py
+++ b/examples/compressors_comparison.py
@@ -33,7 +33,7 @@ names = ("duration, protocol_type, service, flag, src_bytes, "
          "root_shell, su_attempted, num_root, "
          "num_file_creations, ").split(', ')
 
-data = pd.read_csv(url, names=names, nrows=1000)
+data = pd.read_csv(url, names=names, nrows=500000)
 
 ###############################################################################
 # Dump and load the dataset without compression
@@ -196,7 +196,7 @@ p2 = plt.bar(ind, load_durations, width, bottom=dump_durations)
 plt.ylabel('Time in seconds')
 plt.title('Dump and load durations')
 plt.xticks(ind, ('Raw', 'LZ4', 'Zlib', 'LZMA'))
-plt.yticks(np.arange(0, lzma_load_duration + lzma_dump_duration, 0.01))
+plt.yticks(np.arange(0, lzma_load_duration + lzma_dump_duration))
 plt.legend((p1[0], p2[0]), ('Dump duration', 'Load duration'))
 
 ###############################################################################

--- a/examples/compressors_comparison.py
+++ b/examples/compressors_comparison.py
@@ -33,7 +33,7 @@ names = ("duration, protocol_type, service, flag, src_bytes, "
          "root_shell, su_attempted, num_root, "
          "num_file_creations, ").split(', ')
 
-data = pd.read_csv(url, names=names, nrows=2e6)
+data = pd.read_csv(url, names=names, nrows=1e6)
 
 ###############################################################################
 # Dump and load the dataset without compression

--- a/examples/compressors_comparison.py
+++ b/examples/compressors_comparison.py
@@ -33,7 +33,7 @@ names = ("duration, protocol_type, service, flag, src_bytes, "
          "root_shell, su_attempted, num_root, "
          "num_file_creations, ").split(', ')
 
-data = pd.read_csv(url, names=names, nrows=500000)
+data = pd.read_csv(url, names=names, nrows=1e6)
 
 ###############################################################################
 # Dump and load the dataset without compression

--- a/examples/compressors_comparison.py
+++ b/examples/compressors_comparison.py
@@ -33,7 +33,7 @@ names = ("duration, protocol_type, service, flag, src_bytes, "
          "root_shell, su_attempted, num_root, "
          "num_file_creations, ").split(', ')
 
-data = pd.read_csv(url, names=names, nrows=1e6)
+data = pd.read_csv(url, names=names, nrows=2e6)
 
 ###############################################################################
 # Dump and load the dataset without compression


### PR DESCRIPTION
This PR increase significantly the dataset size used in the compressor comparison example. Now durations measured are more realistic and are more inline with the example conclusions.

This PR follows the conclusions provided in [this comment](https://github.com/joblib/joblib/pull/735#issuecomment-415016321).