### PR TITLE
Improved performance of call_and_shelve

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,12 @@ James Collins
     kwargs several times with different values (#751).
 
 
+Maxime Weyl
+
+    Prevent MemorizedFunc.call_and_shelve from loading cached results to
+    RAM when not necessary. Results in big performance improvements
+    
+
 Release 0.12.2
 --------------
 


### PR DESCRIPTION
Here is a pull request that improves the performance of MemorizedFunc.call_and_shelve when a result has already been cached.

Basically, before the code request, joblib loads the entire cached file into memory, returns a reference to the file and forgets about what is in memory.
With this pull request, joblib creates the reference without loading the file into memory.

This PR  passed the Travis tests on my fork.

## Simple Benchmark

### Definitions

```python
import joblib
import numpy as np
memory = joblib.Memory("C:/TEMP/features/memory/")

@memory.cache
def large_array():
    return np.random.normal(size=(100000,10000))


```

### Before the pull request

#### First call (no cache exists)

It takes 1m34s to create and return the cached array.

```python
%%time
a = large_array.call_and_shelve()
```

    ________________________________________________________________________________
    [Memory] Calling __main__-E%3A-Projets-Maxime-DSSP9-dssp9_maxime_project-02-model-__ipython-input__.large_array...
    large_array()
    _____________________________________________________large_array - 93.3s, 1.6min
    Wall time: 1min 34s
    
#### Second call (array is already cached)

It takes 19.7s to get a reference on the array.

```python
%%time
a = large_array.call_and_shelve()
```

    Wall time: 19.7 s
    

#### Loading into memory

Then it takes 11.9 seconds to load the reference into memory.

```python
%%time
a.get()
```

    Wall time: 11.9 s
    




    array([[-0.22347288,  0.1004392 ,  0.73821429, ..., -0.17401156,
             0.45169724,  0.47828354],
           [-1.17715096, -0.8288893 , -0.39735764, ...,  1.60723914,
            -0.43427087,  2.91798611],
           [-0.42882539,  0.58131643,  0.7192454 , ..., -0.59368638,
            -0.18502537, -0.67700329],
           ...,
           [-1.06988518, -0.40570113,  0.83195304, ...,  1.16679448,
             2.07565885,  0.19337173],
           [-0.99542231, -0.33650311, -1.01535946, ...,  0.36570109,
            -0.42031285, -0.80028137],
           [-0.17242059,  0.36116285, -0.76737515, ...,  0.12322468,
            -1.85473507, -0.6005992 ]])



### After the pull request

#### First call (no cache exists)

It still takes time to create the cached object.


#### Second call (array is already cached)

It takes 120ms to get a reference on the array.
It took near 20s before.

```python
%%time
a = large_array.call_and_shelve()
```

    Wall time: 120 ms
    

#### Loading into memory

Then it takes 21.3 seconds to load the reference into memory.


```python
%%time
a.get()
```

    Wall time: 21.3 s
    
    array([[-1.98366351, -1.48535076,  0.76613301, ..., -0.22057336,
             1.64428191,  1.25740524],
           [-1.49231368,  0.66844315, -1.72310301, ..., -0.68349175,
            -0.85695767,  1.1905448 ],
           [-0.72434763,  0.10530391,  0.28199925, ..., -0.22877864,
             0.61428269, -0.54311867],
           ...,
           [ 1.32977779, -0.95798603, -1.18254297, ..., -2.57229086,
             0.13107809, -1.08506098],
           [ 1.38374842, -0.37575841,  0.84639939, ...,  0.98320816,
            -0.47348908,  1.14810158],
           [-2.18351856, -0.39519966, -2.88522986, ..., -1.30701304,
             0.43026396,  0.37374147]])



