### PR TITLE
Fixed bug : loading with corrupted cache with mmap mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Latest changes
 master
 ------
 
+Maxime Weyl
+
+    Loading a corrupted cached file with mmap mode enabled would
+    recompute the results and return them without memmory mapping.
+
 
 Release 0.12.3
 --------------
@@ -38,12 +43,7 @@ Maxime Weyl
     Prevent MemorizedFunc.call_and_shelve from loading cached results to
     RAM when not necessary. Results in big performance improvements
 
-Maxime Weyl
 
-    Added a new test for for getting a corrupted cached file with mmap mode.
-    It reveals a bug because the file is loaded without mmap.
-    Fixing the bug.
-    
 Release 0.12.2
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,8 +27,13 @@ Maxime Weyl
 
     Prevent MemorizedFunc.call_and_shelve from loading cached results to
     RAM when not necessary. Results in big performance improvements
-    
 
+Maxime Weyl
+
+    Added a new test for for getting a corrupted cached file with mmap mode.
+    It reveals a bug because the file is loaded without mmap.
+    Fixing the bug.
+    
 Release 0.12.2
 --------------
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -326,7 +326,7 @@ def test_memory_numpy_check_mmap_mode(tmpdir, monkeypatch):
     assert isinstance(b, np.memmap)
     assert b.mode == 'r'
 
-    # Corrupts the file,  Deleting b and c mmaps 
+    # Corrupts the file,  Deleting b and c mmaps
     # is necessary to be able edit the file
     del b
     del c


### PR DESCRIPTION
While reading memory.py, it seemed to me that it should be possible to use the mmap mode when loading the cache fails.
This PR adds the test and fixes it. I refactored the function call in `_cached_call`, since it is used twice, and I think there is no difference between the two.

There is a small change in the behavior, that I thought was OK (do you agree ?) : 
There was this line: `args_id = None` which I think was not usefull. Removing it does not break any test and it does not match the docstring. 
https://travis-ci.org/MaximeWeyl/joblib/builds/421280052
https://github.com/MaximeWeyl/joblib/commit/c7bbaca03f821b9607449ce727d9a40421537280

So in this PR, I assumed I could forget about this line. Or maybe I should put it back.
