### PR TITLE
FIX: FileSystemStoreBackend string representation only returning location (path)

### DIFF
--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -35,8 +35,7 @@ class StoreBackendBase(with_metaclass(ABCMeta)):
     """Helper Abstract Base Class which defines all methods that
        a StorageBackend must implement."""
 
-    def __init__(self, location=None):
-        self.location = location
+    location = None
 
     @abstractmethod
     def _open_item(self, f, mode):

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -35,6 +35,9 @@ class StoreBackendBase(with_metaclass(ABCMeta)):
     """Helper Abstract Base Class which defines all methods that
        a StorageBackend must implement."""
 
+    def __init__(self, location=None):
+        self.location = location
+
     @abstractmethod
     def _open_item(self, f, mode):
         """Opens an item on the store and return a file-like object.
@@ -327,7 +330,8 @@ class StoreBackendMixin(object):
 
     def __repr__(self):
         """Printable representation of the store location."""
-        return self.location
+        return '{class_name}(location="{location}")'.format(
+            class_name=self.__class__.__name__, location=self.location)
 
 
 class FileSystemStoreBackend(StoreBackendBase, StoreBackendMixin):

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -258,7 +258,7 @@ class MemorizedResult(Logger):
         return ('{class_name}(location="{location}", func="{func}", '
                 'args_id="{args_id}")'
                 .format(class_name=self.__class__.__name__,
-                        location=self.store_backend,
+                        location=self.store_backend.location,
                         func=self.func,
                         args_id=self.args_id
                         ))
@@ -769,9 +769,8 @@ class MemorizedFunc(Logger):
     # ------------------------------------------------------------------------
 
     def __repr__(self):
-        return ("{0}(func={1}, location={2})".format(self.__class__.__name__,
-                                                     self.func,
-                                                     self.store_backend,))
+        return ("{0}(func={1}, location={2})".format(
+            self.__class__.__name__, self.func, self.store_backend.location,))
 
 
 ###############################################################################
@@ -965,7 +964,7 @@ class Memory(Logger):
     def __repr__(self):
         return '{0}(location={1})'.format(
             self.__class__.__name__, (repr(None) if self.store_backend is None
-                                      else repr(self.store_backend)))
+                                      else self.store_backend.location))
 
     def __getstate__(self):
         """ We don't store the timestamp when pickling, to avoid the hash

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -769,8 +769,10 @@ class MemorizedFunc(Logger):
     # ------------------------------------------------------------------------
 
     def __repr__(self):
-        return ("{0}(func={1}, location={2})".format(
-            self.__class__.__name__, self.func, self.store_backend.location,))
+        return ("{class_name}(func={func}, location={location})".format(
+            class_name=self.__class__.__name__,
+            func=self.func,
+            location=self.store_backend.location,))
 
 
 ###############################################################################

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -769,10 +769,10 @@ class MemorizedFunc(Logger):
     # ------------------------------------------------------------------------
 
     def __repr__(self):
-        return ("{class_name}(func={func}, location={location})".format(
+        return '{class_name}(func={func}, location={location})'.format(
             class_name=self.__class__.__name__,
             func=self.func,
-            location=self.store_backend.location,))
+            location=self.store_backend.location,)
 
 
 ###############################################################################

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -962,9 +962,10 @@ class Memory(Logger):
     # ------------------------------------------------------------------------
 
     def __repr__(self):
-        return '{0}(location={1})'.format(
-            self.__class__.__name__, (repr(None) if self.store_backend is None
-                                      else self.store_backend.location))
+        return '{class_name}(location={location})'.format(
+            class_name=self.__class__.__name__,
+            location=(None if self.store_backend is None
+                      else self.store_backend.location))
 
     def __getstate__(self):
         """ We don't store the timestamp when pickling, to avoid the hash

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -1018,26 +1018,24 @@ def test_memory_objects_repr(tmpdir):
     memory = Memory(location=tmpdir.strpath, verbose=0)
     memorized_func = memory.cache(my_func)
 
-    memorized_func_repr = '{class_name}(func={func}, location={location})'
+    memorized_func_repr = 'MemorizedFunc(func={func}, location={location})'
 
     assert str(memorized_func) == memorized_func_repr.format(
-        class_name="MemorizedFunc",
         func=my_func,
         location=memory.store_backend.location)
 
     memorized_result = memorized_func.call_and_shelve(42, 42)
 
-    memorized_result_repr = ('{class_name}(location="{location}", '
+    memorized_result_repr = ('MemorizedResult(location="{location}", '
                              'func="{func}", args_id="{args_id}")')
 
     assert str(memorized_result) == memorized_result_repr.format(
-        class_name="MemorizedResult", location=memory.store_backend.location,
-        func=memorized_result.func_id, args_id=memorized_result.args_id)
+        location=memory.store_backend.location,
+        func=memorized_result.func_id,
+        args_id=memorized_result.args_id)
 
-    memory_repr = '{class_name}(location={location})'
-
-    assert str(memory) == memory_repr.format(
-        class_name="Memory", location=memory.store_backend.location)
+    assert str(memory) == 'Memory(location={location})'.format(
+        location=memory.store_backend.location)
 
 
 def test_memorized_result_pickle(tmpdir):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -1011,6 +1011,38 @@ def test_filesystem_store_backend_repr(tmpdir):
     repr(backend)  # Should not raise an exception
 
 
+def test_memory_objects_repr(tmpdir):
+    # Check that MemorizedResult and MemorizedFunc printable reprs are as
+    # expected.
+
+    def my_func(a, b):
+        return a + b
+
+    memory = Memory(location=tmpdir.strpath, verbose=0)
+    memorized_func = memory.cache(my_func)
+
+    memorized_func_repr = '{class_name}(func={func}, location={location})'
+
+    assert str(memorized_func) == memorized_func_repr.format(
+        class_name="MemorizedFunc",
+        func=my_func,
+        location=memory.store_backend.location)
+
+    memorized_result = memorized_func.call_and_shelve(42, 42)
+
+    memorized_result_repr = ('{class_name}(location="{location}", '
+                             'func="{func}", args_id="{args_id}")')
+
+    assert str(memorized_result) == memorized_result_repr.format(
+        class_name="MemorizedResult", location=memory.store_backend.location,
+        func=memorized_result.func_id, args_id=memorized_result.args_id)
+
+    memory_repr = '{class_name}(location={location})'
+
+    assert str(memory) == memory_repr.format(
+        class_name="Memory", location=memory.store_backend.location)
+
+
 def test_memorized_result_pickle(tmpdir):
     # Verify a MemoryResult object can be pickled/depickled. Non regression
     # test introduced following issue

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -24,7 +24,7 @@ from joblib.memory import register_store_backend, _STORE_BACKENDS
 from joblib.memory import _build_func_identifier, _store_backend_factory
 from joblib.memory import JobLibCollisionWarning
 from joblib.parallel import Parallel, delayed
-from joblib._store_backends import StoreBackendBase
+from joblib._store_backends import StoreBackendBase, FileSystemStoreBackend
 from joblib.test.common import with_numpy, np
 from joblib.test.common import with_multiprocessing
 from joblib.testing import parametrize, raises, warns
@@ -987,6 +987,28 @@ def test_dummy_store_backend():
 
     backend_obj = _store_backend_factory(backend_name, "dummy_location")
     assert isinstance(backend_obj, DummyStoreBackend)
+
+
+def test_filesystem_store_backend_repr(tmpdir):
+    # Verify string representation of a filesystem store backend.
+
+    repr_pattern = '{class_name}(location="{location}")'
+    backend = FileSystemStoreBackend()
+    assert backend.location is None
+
+    repr(backend)  # Should not raise an exception
+
+    assert str(backend) == repr_pattern.format(
+        class_name=backend.__class__.__name__, location=None)
+
+    # backend location is passed explicitely via the configure method (called
+    # by the internal _store_backend_factory function)
+    backend.configure(tmpdir.strpath)
+
+    assert str(backend) == repr_pattern.format(
+        class_name=backend.__class__.__name__, location=tmpdir.strpath)
+
+    repr(backend)  # Should not raise an exception
 
 
 def test_memorized_result_pickle(tmpdir):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -992,21 +992,19 @@ def test_dummy_store_backend():
 def test_filesystem_store_backend_repr(tmpdir):
     # Verify string representation of a filesystem store backend.
 
-    repr_pattern = '{class_name}(location="{location}")'
+    repr_pattern = 'FileSystemStoreBackend(location="{location}")'
     backend = FileSystemStoreBackend()
     assert backend.location is None
 
     repr(backend)  # Should not raise an exception
 
-    assert str(backend) == repr_pattern.format(
-        class_name=backend.__class__.__name__, location=None)
+    assert str(backend) == repr_pattern.format(location=None)
 
     # backend location is passed explicitely via the configure method (called
     # by the internal _store_backend_factory function)
     backend.configure(tmpdir.strpath)
 
-    assert str(backend) == repr_pattern.format(
-        class_name=backend.__class__.__name__, location=tmpdir.strpath)
+    assert str(backend) == repr_pattern.format(location=tmpdir.strpath)
 
     repr(backend)  # Should not raise an exception
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -1012,8 +1012,7 @@ def test_filesystem_store_backend_repr(tmpdir):
 
 
 def test_memory_objects_repr(tmpdir):
-    # Check that MemorizedResult and MemorizedFunc printable reprs are as
-    # expected.
+    # Verify printable reprs of MemorizedResult, MemorizedFunc and Memory.
 
     def my_func(a, b):
         return a + b


### PR DESCRIPTION
Fix #764

A non regression test is also provided.

With this PR, the snippets provided in #764 not returns the following:
```python
In [1]: from joblib import Memory
In [2]: mem = Memory('/tmp/test')
In [3]: mem.store_backend
Out[1]: FileSystemStoreBackend(location="/tmp/test/joblib")
```

```python
In [2]: from joblib._store_backends import FileSystemStoreBackend
   ...: backend = FileSystemStoreBackend()
   ...: backend
   ...: 
Out[2]: FileSystemStoreBackend(location="None")
```
