### PR TITLE
Raises a more explicit exception when a corrupted MemorizedResult is loaded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ master
 
 Maxime Weyl
 
+    Raises a more explicit exception when a corrupted MemorizedResult is loaded.
+
+Maxime Weyl
+
     Loading a corrupted cached file with mmap mode enabled would
     recompute the results and return them without memmory mapping.
 

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -247,8 +247,18 @@ class MemorizedResult(Logger):
                                    metadata=self.metadata)
         else:
             msg = None
-        return self.store_backend.load_item(
-            [self.func_id, self.args_id], msg=msg, verbose=self.verbose)
+
+        try:
+            return self.store_backend.load_item(
+                [self.func_id, self.args_id], msg=msg, verbose=self.verbose)
+        except ValueError:
+            raise ValueError(
+                "Error while trying to load a MemorizedResult's value. "
+                "It seems that this folder is corrupted : {}".format(
+                    os.path.join(
+                        self.store_backend.location, self.func_id,
+                        self.args_id)
+                ))
 
     def clear(self):
         """Clear value from cache"""

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -251,8 +251,8 @@ class MemorizedResult(Logger):
         try:
             return self.store_backend.load_item(
                 [self.func_id, self.args_id], msg=msg, verbose=self.verbose)
-        except ValueError:
-            raise ValueError(
+        except (ValueError, KeyError):
+            raise KeyError(
                 "Error while trying to load a MemorizedResult's value. "
                 "It seems that this folder is corrupted : {}".format(
                     os.path.join(

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -915,7 +915,7 @@ def test_memory_recomputes_after_an_error_while_loading_results(
             "It normally not possible to load a corrupted"
             " MemorizedResult"
         )
-    except ValueError as e:
+    except KeyError as e:
         message = "is corrupted"
         assert message in str(e.args)
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -339,7 +339,7 @@ def test_memory_numpy_check_mmap_mode(tmpdir, monkeypatch):
     assert len(recorded_warnings) == 1
     exception_msg = 'Exception while loading results'
     assert exception_msg in recorded_warnings[0]
-    # Asserts that the recomputation returns a mmmap
+    # Asserts that the recomputation returns a mmap
     assert isinstance(d, np.memmap)
     assert d.mode == 'r'
 
@@ -873,8 +873,8 @@ def test_cached_function_race_condition_when_persisting_output_2(tmpdir,
     assert exception_msg not in stderr
 
 
-def test_memory_recomputes_after_an_error_while_loading_results(tmpdir,
-                                                              monkeypatch):
+def test_memory_recomputes_after_an_error_while_loading_results(
+        tmpdir, monkeypatch):
     memory = Memory(location=tmpdir.strpath)
 
     def func(arg):
@@ -904,6 +904,20 @@ def test_memory_recomputes_after_an_error_while_loading_results(tmpdir,
     assert exception_msg in recorded_warnings[0]
     assert recomputed_arg == arg
     assert recomputed_timestamp > timestamp
+
+    # Corrupting output.pkl to make sure that an error happens when
+    # loading the cached result
+    corrupt_single_cache_item(memory)
+    reference = cached_func.call_and_shelve(arg)
+    try:
+        reference.get()
+        raise AssertionError(
+            "It normally not possible to load a corrupted"
+            " MemorizedResult"
+        )
+    except ValueError as e:
+        message = "is corrupted"
+        assert message in str(e.args)
 
 
 def test_deprecated_cachedir_behaviour(tmpdir):


### PR DESCRIPTION
When getting a reference with call_and_shelve, it's still possible that the underlying data gets corrupted (it raises an exception while trying to unpickle it). 

This PR just wraps the .get method of MemorizedResult into a try/except, and adds an explicit message to the finally raised Exception. 
I have found that pickle actually raises two kinds of Exceptions while unpickling. During my tests, it depended on the version of python that was used (KeyError for python 2.7 and ValueError for python 3).

Some existing tests were waiting for KeyError, so I used this one.
It would also be possible to use another one, like ValueError or a custom joblib exception, but it would require to change some tests, and could broke some users code..
I could also maybe just intercept the exception and add the explicit message, and reraise it again : in this way every user code that was expecting ValueError, or a KeyError could still catch it. It could still break code depending on what the user do with that exc.args (because we would have added an explicit message to it).

