### PR TITLE
FIX: convert text element to vector path in svg logo

### DIFF
--- a/doc/_static/joblib_logo.svg
+++ b/doc/_static/joblib_logo.svg
@@ -11,7 +11,7 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   inkscape:version="0.91 r13725"
    width="862.47913"
    height="794.92072"
    sodipodi:docname="joblib_logo.svg">
@@ -28,16 +28,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs6">
-    <style
-       type="text/css"
-       id="style851">
-      @import url('https://fonts.googleapis.com/css?family=Ubuntu+Mono');
-      text {
-        font-family: "Ubuntu Mono";
-      }
-    </style>
-  </defs>
+     id="defs6"/>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -47,14 +38,14 @@
      guidetolerance="10"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1028"
+     inkscape:window-width="1375"
+     inkscape:window-height="876"
      id="namedview4"
      showgrid="false"
      inkscape:zoom="0.40606399"
-     inkscape:cx="-244.80539"
+     inkscape:cx="283.18477"
      inkscape:cy="221.99429"
-     inkscape:window-x="1600"
+     inkscape:window-x="65"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="g4547"
@@ -74,25 +65,37 @@
      inkscape:connector-curvature="0" />
   <g
      id="g4547">
-    <text
-       id="text4523"
-       y="782.04944"
-       x="345.62256"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:175px;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1"
-         y="782.04944"
-         x="345.62256"
-         id="tspan4521"
-         sodipodi:role="line">Job</tspan></text>
-    <text
-       id="text4523-0"
-       y="782.24146"
-       x="605.22913"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:175px;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#e15617;fill-opacity:1"
-         y="782.24146"
-         x="605.22913"
-         id="tspan4521-1"
-         sodipodi:role="line">lib</tspan></text>
+    <g
+       style="font-family:'Ubuntu Mono'"
+       id="text4523">
+      <path
+         d="m 422.27256,745.82444 q 0,7.875 -2.1,14.875 -1.925,7 -6.65,12.25 -4.55,5.25 -11.9,8.4 -7.35,2.975 -17.85,2.975 -11.025,0 -18.375,-2.8 -7.35,-2.8 -12.425,-6.825 l 8.225,-17.15 q 4.375,2.8 9.625,5.425 5.425,2.625 11.025,2.625 8.4,0 13.475,-4.375 5.25,-4.55 5.25,-16.625 l 0,-53.025 -36.225,0 0,-17.85 57.925,0 0,72.1 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:175px;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1"
+         id="path3422" />
+      <path
+         d="m 515.72256,740.74944 q 0,9.8 -2.8,17.85 -2.8,7.875 -7.875,13.65 -5.075,5.775 -12.25,8.925 -7,3.15 -15.75,3.15 -8.75,0 -15.925,-3.15 -7,-3.15 -12.25,-8.925 -5.075,-5.775 -7.875,-13.65 -2.8,-8.05 -2.8,-17.85 0,-9.625 2.8,-17.5 2.975,-8.05 8.05,-13.65 5.25,-5.775 12.425,-8.75 7.175,-3.15 15.575,-3.15 8.575,0 15.575,3.15 7.175,2.975 12.25,8.75 5.25,5.6 8.05,13.65 2.8,7.875 2.8,17.5 z m -55.65,0.175 q 0,11.025 3.85,17.85 4.025,6.825 12.775,6.825 8.4,0 12.6,-6.825 4.375,-6.825 4.375,-17.85 0,-11.025 -4.025,-17.675 -3.85,-6.825 -12.6,-6.825 -8.4,0 -12.775,6.825 -4.2,6.65 -4.2,17.675 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:175px;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1"
+         id="path3424" />
+      <path
+         d="m 580.99756,740.39944 q 0,-11.55 -3.85,-17.675 -3.675,-6.125 -11.375,-6.125 -3.5,0 -7,1.05 -3.325,0.875 -5.775,2.275 l 0,44.625 q 2.45,0.525 5.075,0.7 2.8,0.175 4.725,0.175 8.4,0 13.3,-5.6 4.9,-5.775 4.9,-19.425 z m 21.875,0.525 q 0,9.8 -2.625,17.85 -2.625,7.875 -7.7,13.475 -5.075,5.6 -12.425,8.75 -7.35,2.975 -16.8,2.975 -8.4,0 -17.15,-1.225 -8.75,-1.225 -14.7,-3.15 l 0,-115.325 21.525,-3.675 0,41.125 q 4.55,-2.1 8.75,-2.8 4.2,-0.875 8.4,-0.875 8.05,0 14.175,3.15 6.125,2.975 10.15,8.75 4.2,5.6 6.3,13.475 2.1,7.875 2.1,17.5 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:175px;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1"
+         id="path3426" />
+    </g>
+    <g
+       style="font-family:'Ubuntu Mono'"
+       id="text4523-0">
+      <path
+         d="m 686.95413,778.74146 q -0.525,0.35 -2.45,1.225 -1.75,0.875 -4.725,1.925 -2.975,0.875 -7.35,1.575 -4.2,0.7 -9.625,0.7 -14.875,0 -21.7,-8.75 -6.825,-8.925 -6.825,-25.9 l 0,-69.825 -22.75,0 0,-17.85 44.275,0 0,89.25 q 0,8.4 3.325,11.375 3.325,2.975 8.4,2.975 6.475,0 10.85,-1.75 4.375,-1.75 5.775,-2.275 l 2.8,17.325 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:175px;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#e15617;fill-opacity:1"
+         id="path3415" />
+      <path
+         d="m 742.42913,676.36646 q 0,6.3 -4.025,9.975 -4.025,3.675 -9.625,3.675 -5.6,0 -9.625,-3.675 -3.85,-3.675 -3.85,-9.975 0,-6.475 3.85,-10.15 4.025,-3.675 9.625,-3.675 5.6,0 9.625,3.675 4.025,3.675 4.025,10.15 z m 32.025,102.375 q -6.65,3.15 -12.6,4.2 -5.775,1.225 -10.675,1.225 -8.4,0 -14.175,-2.45 -5.6,-2.45 -9.1,-7 -3.325,-4.725 -4.725,-11.375 -1.4,-6.65 -1.4,-15.225 l 0,-30.275 -22.75,0 0,-17.85 44.275,0 0,50.925 q 0,7.35 2.625,11.025 2.8,3.5 9.1,3.5 2.975,0 7.175,-0.7 4.2,-0.875 9.45,-3.325 l 2.8,17.325 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:175px;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#e15617;fill-opacity:1"
+         id="path3417" />
+      <path
+         d="m 840.60413,740.59146 q 0,-11.55 -3.85,-17.675 -3.675,-6.125 -11.375,-6.125 -3.5,0 -7,1.05 -3.325,0.875 -5.775,2.275 l 0,44.625 q 2.45,0.525 5.075,0.7 2.8,0.175 4.725,0.175 8.4,0 13.3,-5.6 4.9,-5.775 4.9,-19.425 z m 21.875,0.525 q 0,9.8 -2.625,17.85 -2.625,7.875 -7.7,13.475 -5.075,5.6 -12.425,8.75 -7.35,2.975 -16.8,2.975 -8.4,0 -17.15,-1.225 -8.75,-1.225 -14.7,-3.15 l 0,-115.325 21.525,-3.675 0,41.125 q 4.55,-2.1 8.75,-2.8 4.2,-0.875 8.4,-0.875 8.05,0 14.175,3.15 6.125,2.975 10.15,8.75 4.2,5.6 6.3,13.475 2.1,7.875 2.1,17.5 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:175px;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#e15617;fill-opacity:1"
+         id="path3419" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
Second attempt to fix #770.

This time the text elements are converted to path vectors. If this is merged, the text will not be editable directly via Inkscape but I think this is not important.
