### PR TITLE
memory: add test for call_and_shelve performance

### DIFF
--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -514,6 +514,32 @@ def test_call_and_shelve_argument_hash(tmpdir):
         in str(w[-1].message)
 
 
+def test_call_and_shelve_performance(tmpdir):
+    """Check call_and_shelve only load stored data if needed."""
+    memory = Memory(location=tmpdir.strpath, verbose=0)
+    func = memory.cache(f)
+    func_id, argument_hash = func._get_output_identifiers(2)
+    result_path = os.path.join(memory.store_backend.location,
+                               func_id, argument_hash, 'output.pkl')
+    assert func(2) == 5
+    first_access = os.stat(result_path).st_atime
+    time.sleep(1)
+
+    # Should not access the stored data
+    result = func.call_and_shelve(2)
+    assert isinstance(result, MemorizedResult)
+    assert os.stat(result_path).st_atime == first_access
+    time.sleep(1)
+
+    # Should not access the stored data
+    func.call_and_shelve(2)
+    assert os.stat(result_path).st_atime == first_access
+
+    # Read the stored data => last access time is greater than first_access
+    assert result.get() == 5
+    assert os.stat(result_path).st_atime > first_access
+
+
 def test_memorized_pickling(tmpdir):
     for func in (MemorizedFunc(f, tmpdir.strpath), NotMemorizedFunc(f)):
         filename = tmpdir.join('pickling_test.dat').strpath

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -514,7 +514,7 @@ def test_call_and_shelve_argument_hash(tmpdir):
         in str(w[-1].message)
 
 
-def test_call_and_shelve_performance(tmpdir):
+def test_call_and_shelve_lazily_load_stored_result(tmpdir):
     """Check call_and_shelve only load stored data if needed."""
     test_access_time_file = tmpdir.join('test_access')
     test_access_time_file.write('test_access')
@@ -527,7 +527,8 @@ def test_call_and_shelve_performance(tmpdir):
     if test_access_time == os.stat(test_access_time_file.strpath).st_atime:
         # Skip this test when access time cannot be retrieved with enough
         # precision from the file system (e.g. NTFS on windows).
-        return
+        pytest.skip("filesystem does not support fine-grained access time "
+                    "attribute")
 
     memory = Memory(location=tmpdir.strpath, verbose=0)
     func = memory.cache(f)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -522,22 +522,22 @@ def test_call_and_shelve_performance(tmpdir):
     result_path = os.path.join(memory.store_backend.location,
                                func_id, argument_hash, 'output.pkl')
     assert func(2) == 5
-    first_access = os.stat(result_path).st_atime
+    first_access = os.path.getatime(result_path)
     time.sleep(1)
 
     # Should not access the stored data
     result = func.call_and_shelve(2)
     assert isinstance(result, MemorizedResult)
-    assert os.stat(result_path).st_atime == first_access
+    assert os.path.getatime(result_path) == first_access
     time.sleep(1)
 
     # Should not access the stored data
     func.call_and_shelve(2)
-    assert os.stat(result_path).st_atime == first_access
+    assert os.path.getatime(result_path) == first_access
 
     # Read the stored data => last access time is greater than first_access
     assert result.get() == 5
-    assert os.stat(result_path).st_atime > first_access
+    assert os.path.getatime(result_path) > first_access
 
 
 def test_memorized_pickling(tmpdir):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -519,7 +519,9 @@ def test_call_and_shelve_performance(tmpdir):
     test_access_time_file = tmpdir.join('test_access')
     test_access_time_file.write('test_access')
     test_access_time = os.stat(test_access_time_file.strpath).st_atime
-    time.sleep(1)
+    # check file system access time stats resolution is lower than test wait
+    # timings.
+    time.sleep(0.5)
     assert test_access_time_file.read() == 'test_access'
 
     if test_access_time == os.stat(test_access_time_file.strpath).st_atime:

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -27,7 +27,7 @@ from joblib.parallel import Parallel, delayed
 from joblib._store_backends import StoreBackendBase, FileSystemStoreBackend
 from joblib.test.common import with_numpy, np
 from joblib.test.common import with_multiprocessing
-from joblib.testing import parametrize, raises, warns, skipif
+from joblib.testing import parametrize, raises, warns
 from joblib._compat import PY3_OR_LATER
 from joblib.hashing import hash
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -534,6 +534,7 @@ def test_call_and_shelve_performance(tmpdir):
     # Should not access the stored data
     func.call_and_shelve(2)
     assert os.path.getatime(result_path) == first_access
+    time.sleep(1)
 
     # Read the stored data => last access time is greater than first_access
     assert result.get() == 5


### PR DESCRIPTION
This test verifies that the `call_and_shelve` function doesn't perform a load of cached data every time it is used.

The idea is to verify that the access time of the file containing the cached file. It should remain untouched after each calls. And getting result using `MemorizedResult.get` will change the access time since the data must be read.

See #757