### PR TITLE
FIX nested backend not changed by SequentialBackend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Latest changes
 master
 ------
 
+Thomas Moreau
+
+   Fix nested backend in SequentialBackend to avoid changing the default
+   backend to Sequential. (#792)
+
 Thomas Moreau, Olivier Grisel
 
     Fix nested_backend behavior to avoid setting the default number of

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -185,8 +185,10 @@ class SequentialBackend(ParallelBackendBase):
         return result
 
     def get_nested_backend(self):
-        nested_level = getattr(self, 'nesting_level', 0) + 1
-        return SequentialBackend(nesting_level=nested_level), None
+        # SequentialBackend should neither change the nesting level, the
+        # default backend or the number of jobs. Just return the current one.
+        from .parallel import get_active_backend
+        return get_active_backend()
 
 
 class PoolManagerMixin(object):

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -185,9 +185,11 @@ class SequentialBackend(ParallelBackendBase):
         return result
 
     def get_nested_backend(self):
+        # import is not top level to avoid cyclic import errors.
+        from .parallel import get_active_backend
+
         # SequentialBackend should neither change the nesting level, the
         # default backend or the number of jobs. Just return the current one.
-        from .parallel import get_active_backend
         return get_active_backend()
 
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -745,9 +745,8 @@ def test_nested_backend_in_sequential(backend, n_jobs):
     # ThreadingBackend
 
     def check_nested_backend(expected_backend_type, expected_n_job):
-        # Assert that the sequential backend at top level, does not change
-        if expected_backend_type is None:
-            expected_backend_type = 'loky'
+        # Assert that the sequential backend at top level, does not change the
+        # backend for nested calls.
         assert _active_backend_type() == BACKENDS[expected_backend_type]
 
         # Assert that the nested backend in SequentialBackend does not change

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -709,7 +709,8 @@ def test_direct_parameterized_backend_context_manager():
 
 
 @with_multiprocessing
-def test_nested_backend_context_manager():
+@pytest.mark.parametrize('backend', ['threading', 'loky', 'multiprocessing'])
+def test_nested_backend_context_manager(backend):
     # Check that by default, nested parallel calls will always use the
     # ThreadingBackend
 
@@ -727,14 +728,43 @@ def test_nested_backend_context_manager():
         return Parallel(n_jobs=2)(delayed(sleep_and_return_pid)()
                                   for _ in range(2))
 
-    for backend in ['threading', 'loky', 'multiprocessing']:
-        with parallel_backend(backend):
-            pid_groups = Parallel(n_jobs=2)(
-                delayed(get_nested_pids)()
-                for _ in range(10)
-            )
-            for pid_group in pid_groups:
-                assert len(set(pid_group)) == 1
+    with parallel_backend(backend):
+        pid_groups = Parallel(n_jobs=2)(
+            delayed(get_nested_pids)()
+            for _ in range(10)
+        )
+        for pid_group in pid_groups:
+            assert len(set(pid_group)) == 1
+
+
+@with_multiprocessing
+@pytest.mark.parametrize('n_jobs', [2, -1, None])
+@pytest.mark.parametrize('backend', PARALLEL_BACKENDS)
+def test_nested_backend_in_sequential(backend, n_jobs):
+    # Check that by default, nested parallel calls will always use the
+    # ThreadingBackend
+
+    def check_nested_backend(expected_backend_type, expected_n_job):
+        # Assert that the sequential backend at top level, does not change
+        if expected_backend_type is None:
+            expected_backend_type = 'loky'
+        assert _active_backend_type() == BACKENDS[expected_backend_type]
+
+        # Assert that the nested backend in SequentialBackend does not change
+        # the default number of jobs used in Parallel
+        expected_n_job = effective_n_jobs(expected_n_job)
+        assert Parallel()._effective_n_jobs() == expected_n_job
+
+    Parallel(n_jobs=1)(
+        delayed(check_nested_backend)('loky', 1)
+        for _ in range(10)
+    )
+
+    with parallel_backend(backend, n_jobs=n_jobs):
+        Parallel(n_jobs=1)(
+            delayed(check_nested_backend)(backend, n_jobs)
+            for _ in range(10)
+        )
 
 
 @with_multiprocessing
@@ -1201,7 +1231,7 @@ def test_delayed_check_pickle_deprecated():
 
 
 @with_multiprocessing
-@parametrize('backend', ['multiprocessing', 'loky'])
+@parametrize('backend', PROCESS_BACKENDS)
 def test_backend_batch_statistics_reset(backend):
     """Test that a parallel backend correctly resets its batch statistics."""
     n_jobs = 2
@@ -1380,15 +1410,17 @@ def test_nested_parallelism_limit(backend):
 
     if cpu_count() == 1:
         second_level_backend_type = 'SequentialBackend'
+        max_level = 1
     else:
         second_level_backend_type = 'ThreadingBackend'
+        max_level = 2
 
     top_level_backend_type = backend.title() + 'Backend'
     expected_types_and_levels = [
         (top_level_backend_type, 0),
         (second_level_backend_type, 1),
-        ('SequentialBackend', 2),
-        ('SequentialBackend', 3)
+        ('SequentialBackend', max_level),
+        ('SequentialBackend', max_level)
     ]
     assert backend_types_and_levels == expected_types_and_levels
 


### PR DESCRIPTION
The nested backend in `SequentialBackend` should not be changed as we do not got deeper in the nesting. This causes issue for libraries that relies on `Parallel` even when `n_jobs=1`, with subsequent nested calls (see _eg_ scikit-learn/scikit-learn#12389  ).

This PR should fix this and test the behavior.