### PR TITLE
ENH update loky 2.4.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,6 +49,7 @@ sphinx_gallery_conf = {
     'default_thumb_file': '_static/joblib_logo_examples.png',
     'doc_module': 'joblib',
     'filename_pattern': '',
+    'ignore_pattern': 'utils.py',
     'backreferences_dir': os.path.join('generated'),
     'reference_url': {
         'joblib': None}

--- a/examples/parallel_random_state.py
+++ b/examples/parallel_random_state.py
@@ -15,6 +15,14 @@ import numpy as np
 from joblib import Parallel, delayed
 
 
+# The followings are hacks to allow sphinx-gallery to run the example.
+import os
+import sys
+sys.path.insert(0, os.getcwd())
+main_dir = os.path.basename(sys.modules['__main__'].__file__)
+IS_RUN_WITH_SPHINX_GALLERY = main_dir != os.getcwd()
+
+
 ###############################################################################
 # A utility function for the example
 def print_vector(vector, backend):
@@ -68,6 +76,12 @@ print_vector(random_vector, backend)
 # do not require more care. However, this is not the case regarding the
 # multiprocessing backend.
 
+if IS_RUN_WITH_SPHINX_GALLERY:
+    # When this example is run with sphinx gallery, it breaks the pickling
+    # capacity for multiprocessing backend so we have to modify the way we
+    # define our functions. This has nothing to do with the example.
+    from utils import stochastic_function
+
 backend = 'multiprocessing'
 random_vector = Parallel(n_jobs=2, backend=backend)(delayed(
     stochastic_function)(10) for _ in range(n_vectors))
@@ -87,6 +101,13 @@ print_vector(random_vector, backend)
 def stochastic_function_seeded(max_value, random_state):
     rng = np.random.RandomState(random_state)
     return rng.randint(max_value, size=5)
+
+
+if IS_RUN_WITH_SPHINX_GALLERY:
+    # When this example is run with sphinx gallery, it breaks the pickling
+    # capacity for multiprocessing backend so we have to modify the way we
+    # define our functions. This has nothing to do with the example.
+    from utils import stochastic_function_seeded  # noqa: F811
 
 
 ###############################################################################

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,0 +1,12 @@
+# Module to import functions from in examples for multiprocessing backend
+import numpy as np
+
+
+def stochastic_function_seeded(max_value, random_state):
+    rng = np.random.RandomState(random_state)
+    return rng.randint(max_value, size=5)
+
+
+def stochastic_function(max_value):
+    """Randomly generate integer up to a maximum value."""
+    return np.random.randint(max_value, size=5)

--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -123,8 +123,12 @@ from .parallel import register_parallel_backend
 from .parallel import parallel_backend
 from .parallel import effective_n_jobs
 
+from .externals.loky import set_loky_pickler
+from .externals.loky import wrap_non_picklable_objects
+
 
 __all__ = ['Memory', 'MemorizedResult', 'PrintTime', 'Logger', 'hash', 'dump',
            'load', 'Parallel', 'delayed', 'cpu_count', 'effective_n_jobs',
            'register_parallel_backend', 'parallel_backend',
-           'register_store_backend', 'register_compressor']
+           'register_store_backend', 'register_compressor',
+           'set_loky_pickler', 'wrap_non_picklable_objects']

--- a/joblib/externals/loky/__init__.py
+++ b/joblib/externals/loky/__init__.py
@@ -22,4 +22,4 @@ __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "wrap_non_picklable_objects", "set_loky_pickler"]
 
 
-__version__ = '2.4.0'
+__version__ = '2.4.1dev0'

--- a/joblib/externals/loky/__init__.py
+++ b/joblib/externals/loky/__init__.py
@@ -22,4 +22,4 @@ __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "wrap_non_picklable_objects", "set_loky_pickler"]
 
 
-__version__ = '2.4.1dev0'
+__version__ = '2.4.1'

--- a/joblib/externals/loky/__init__.py
+++ b/joblib/externals/loky/__init__.py
@@ -9,14 +9,17 @@ from ._base import TimeoutError, CancelledError
 from ._base import ALL_COMPLETED, FIRST_COMPLETED, FIRST_EXCEPTION
 
 from .backend.context import cpu_count
+from .backend.reduction import set_loky_pickler
 from .reusable_executor import get_reusable_executor
+from .cloudpickle_wrapper import wrap_non_picklable_objects
 from .process_executor import BrokenProcessPool, ProcessPoolExecutor
 
 
 __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "Future", "Executor", "ProcessPoolExecutor",
            "BrokenProcessPool", "CancelledError", "TimeoutError",
-           "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED", ]
+           "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED",
+           "wrap_non_picklable_objects", "set_loky_pickler"]
 
 
-__version__ = '2.3.1'
+__version__ = '2.4.0'

--- a/joblib/externals/loky/backend/__init__.py
+++ b/joblib/externals/loky/backend/__init__.py
@@ -3,8 +3,6 @@ import sys
 
 from .context import get_context
 
-LOKY_PICKLER = os.environ.get("LOKY_PICKLER")
-
 if sys.version_info > (3, 4):
 
     def _make_name():

--- a/joblib/externals/loky/backend/compat.py
+++ b/joblib/externals/loky/backend/compat.py
@@ -31,9 +31,9 @@ def set_cause(exc, cause):
     if not PY3:
         # Preformat message here.
         if exc.__cause__ is not None:
-            exc.args = ("{}\n\nThis was caused directly by {}"
-                        .format(exc.args if len(exc.args) > 1 else exc.args[0],
-                                str(exc.__cause__)),)
+            exc.args = ("{}\n\nThis was caused directly by {}".format(
+                exc.args if len(exc.args) != 1 else exc.args[0],
+                str(exc.__cause__)),)
 
     return exc
 

--- a/joblib/externals/loky/backend/compat.py
+++ b/joblib/externals/loky/backend/compat.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 ###############################################################################
 # Compat file to import the correct modules for each platform and python
 # version.
@@ -7,12 +6,12 @@
 #
 import sys
 
-if sys.version_info[:2] >= (3, 3):
+PY3 = sys.version_info[:2] >= (3, 3)
+
+if PY3:
     import queue
 else:
     import Queue as queue
-
-from pickle import PicklingError
 
 if sys.version_info >= (3, 4):
     from multiprocessing.process import BaseProcess
@@ -21,6 +20,22 @@ else:
 
 # Platform specific compat
 if sys.platform == "win32":
-    from .compat_win32 import *
+    from .compat_win32 import wait
 else:
-    from .compat_posix import *
+    from .compat_posix import wait
+
+
+def set_cause(exc, cause):
+    exc.__cause__ = cause
+
+    if not PY3:
+        # Preformat message here.
+        if exc.__cause__ is not None:
+            exc.args = ("{}\n\nThis was caused directly by {}"
+                        .format(exc.args if len(exc.args) > 1 else exc.args[0],
+                                str(exc.__cause__)),)
+
+    return exc
+
+
+__all__ = ["queue", "BaseProcess", "set_cause", "wait"]

--- a/joblib/externals/loky/backend/queues.py
+++ b/joblib/externals/loky/backend/queues.py
@@ -22,7 +22,7 @@ from multiprocessing.queues import Full
 from multiprocessing.queues import _sentinel, Queue as mp_Queue
 from multiprocessing.queues import SimpleQueue as mp_SimpleQueue
 
-from .reduction import CustomizableLokyPickler
+from .reduction import loads, dumps
 from .context import assert_spawning, get_context
 
 
@@ -147,8 +147,7 @@ class Queue(mp_Queue):
                             return
 
                         # serialize the data before acquiring the lock
-                        obj_ = CustomizableLokyPickler.dumps(
-                            obj, reducers=reducers)
+                        obj_ = dumps(obj, reducers=reducers)
                         if wacquire is None:
                             send_bytes(obj_)
                         else:
@@ -227,12 +226,12 @@ class SimpleQueue(mp_SimpleQueue):
             with self._rlock:
                 res = self._reader.recv_bytes()
             # unserialize the data after having released the lock
-            return CustomizableLokyPickler.loads(res)
+            return loads(res)
 
     # Overload put to use our customizable reducer
     def put(self, obj):
         # serialize the data before acquiring the lock
-        obj = CustomizableLokyPickler.dumps(obj, reducers=self._reducers)
+        obj = dumps(obj, reducers=self._reducers)
         if self._wlock is None:
             # writes to a message oriented win32 pipe are atomic
             self._writer.send_bytes(obj)

--- a/joblib/externals/loky/backend/reduction.py
+++ b/joblib/externals/loky/backend/reduction.py
@@ -9,16 +9,19 @@
 #    on the fly.
 #
 import io
+import os
 import sys
 import functools
-import warnings
 from multiprocessing import util
 try:
     # Python 2 compat
-    from cPickle import loads
+    from cPickle import loads as pickle_loads
 except ImportError:
-    from pickle import loads
+    from pickle import loads as pickle_loads
     import copyreg
+
+from pickle import HIGHEST_PROTOCOL
+
 
 if sys.platform == "win32":
     if sys.version_info[:2] > (3, 3):
@@ -26,48 +29,16 @@ if sys.platform == "win32":
     else:
         from multiprocessing.forking import duplicate
 
-from pickle import HIGHEST_PROTOCOL
-from . import LOKY_PICKLER
-
-Pickler = None
-try:
-    if LOKY_PICKLER is None or LOKY_PICKLER == "":
-        from pickle import Pickler
-    elif LOKY_PICKLER == "cloudpickle":
-        from cloudpickle import CloudPickler as Pickler
-    elif LOKY_PICKLER == "dill":
-        from dill import Pickler
-    elif LOKY_PICKLER != "pickle":
-        from importlib import import_module
-        mpickle = import_module(LOKY_PICKLER)
-        Pickler = mpickle.Pickler
-    util.debug("Using default backend {} for pickling."
-               .format(LOKY_PICKLER if LOKY_PICKLER is not None
-                       else "pickle"))
-except ImportError:
-    warnings.warn("Failed to import {} as asked in LOKY_PICKLER. Make sure"
-                  " it is correctly installed on your system. Falling back"
-                  " to default builtin pickle.".format(LOKY_PICKLER))
-except AttributeError:  # pragma: no cover
-    warnings.warn("Failed to find Pickler object in module {}. The module "
-                  "specified in LOKY_PICKLER should implement a Pickler "
-                  "object. Falling back to default builtin pickle."
-                  .format(LOKY_PICKLER))
-
-
-if Pickler is None:
-    from pickle import Pickler
-
 
 ###############################################################################
 # Enable custom pickling in Loky.
 # To allow instance customization of the pickling process, we use 2 classes.
-# _LokyPickler gives module level customization and CustomizablePickler permits
-# to use instance base custom reducers.  Only CustomizablePickler should be
-# used.
+# _ReducerRegistry gives module level customization and CustomizablePickler
+# permits to use instance base custom reducers. Only CustomizablePickler
+# should be used.
 
-class _LokyPickler(Pickler):
-    """Pickler that uses custom reducers.
+class _ReducerRegistry(object):
+    """Registry for custom reducers.
 
     HIGHEST_PROTOCOL is selected by default as this pickler is used
     to pickle ephemeral datastructures for interprocess communication
@@ -81,83 +52,26 @@ class _LokyPickler(Pickler):
     # feature from http://bugs.python.org/issue14166 that makes it possible
     # to use the C implementation of the Pickler which is faster.
 
-    if hasattr(Pickler, 'dispatch'):
-        # Make the dispatch registry an instance level attribute instead of
-        # a reference to the class dictionary under Python 2
-        dispatch = Pickler.dispatch.copy()
-    else:
-        # Under Python 3 initialize the dispatch table with a copy of the
-        # default registry
-        dispatch_table = copyreg.dispatch_table.copy()
+    dispatch_table = {}
 
     @classmethod
     def register(cls, type, reduce_func):
         """Attach a reducer function to a given type in the dispatch table."""
-        if hasattr(Pickler, 'dispatch'):
+        if sys.version_info < (3,):
             # Python 2 pickler dispatching is not explicitly customizable.
             # Let us use a closure to workaround this limitation.
             def dispatcher(cls, obj):
                 reduced = reduce_func(obj)
                 cls.save_reduce(obj=obj, *reduced)
-            cls.dispatch[type] = dispatcher
+            cls.dispatch_table[type] = dispatcher
         else:
             cls.dispatch_table[type] = reduce_func
-
-
-class CustomizableLokyPickler(Pickler):
-    def __init__(self, writer, reducers=None, protocol=HIGHEST_PROTOCOL):
-        Pickler.__init__(self, writer, protocol=protocol)
-        if reducers is None:
-            reducers = {}
-        if hasattr(Pickler, 'dispatch'):
-            # Make the dispatch registry an instance level attribute instead of
-            # a reference to the class dictionary under Python 2
-            self.dispatch = _LokyPickler.dispatch.copy()
-        else:
-            # Under Python 3 initialize the dispatch table with a copy of the
-            # default registry
-            self.dispatch_table = _LokyPickler.dispatch_table.copy()
-        for type, reduce_func in reducers.items():
-            self.register(type, reduce_func)
-
-    def register(self, type, reduce_func):
-        """Attach a reducer function to a given type in the dispatch table."""
-        if hasattr(Pickler, 'dispatch'):
-            # Python 2 pickler dispatching is not explicitly customizable.
-            # Let us use a closure to workaround this limitation.
-            def dispatcher(self, obj):
-                reduced = reduce_func(obj)
-                self.save_reduce(obj=obj, *reduced)
-            self.dispatch[type] = dispatcher
-        else:
-            self.dispatch_table[type] = reduce_func
-
-    @classmethod
-    def loads(self, buf):
-        if sys.version_info < (3, 3) and isinstance(buf, io.BytesIO):
-            buf = buf.getvalue()
-        return loads(buf)
-
-    @classmethod
-    def dumps(cls, obj, reducers=None, protocol=None):
-        buf = io.BytesIO()
-        p = cls(buf, reducers=reducers, protocol=protocol)
-        p.dump(obj)
-        if sys.version_info < (3, 3):
-            return buf.getvalue()
-        return buf.getbuffer()
-
-
-def dump(obj, file, reducers=None, protocol=None):
-    '''Replacement for pickle.dump() using LokyPickler.'''
-    CustomizableLokyPickler(file, reducers=reducers,
-                            protocol=protocol).dump(obj)
 
 
 ###############################################################################
 # Registers extra pickling routines to improve picklization  for loky
 
-register = _LokyPickler.register
+register = _ReducerRegistry.register
 
 
 # make methods picklable
@@ -205,3 +119,120 @@ if sys.platform != "win32":
     from ._posix_reduction import _mk_inheritable  # noqa: F401
 else:
     from . import _win_reduction  # noqa: F401
+
+# global variable to change the pickler behavior
+try:
+    from joblib.externals import cloudpickle  # noqa: F401
+    DEFAULT_ENV = "cloudpickle"
+except ImportError:
+    # If cloudpickle is not present, fallback to pickle
+    DEFAULT_ENV = "pickle"
+
+ENV_LOKY_PICKLER = os.environ.get("LOKY_PICKLER", DEFAULT_ENV)
+_LokyPickler = ENV_LOKY_PICKLER
+
+
+def set_loky_pickler(loky_pickler=None):
+    global _LokyPickler
+
+    if loky_pickler is None:
+        loky_pickler = ENV_LOKY_PICKLER
+
+    loky_pickler_cls = None
+
+    if loky_pickler in ["cloudpickle", "", None]:
+        from joblib.externals.cloudpickle import CloudPickler as loky_pickler_cls
+    else:
+        try:
+            from importlib import import_module
+            module_pickle = import_module(loky_pickler)
+            loky_pickler_cls = module_pickle.Pickler
+        except (ImportError, AttributeError) as e:
+            extra_info = ("\nThis error occurred while setting loky_pickler to"
+                          " '{}', as required by the env variable LOKY_PICKLER"
+                          " or the function set_loky_pickler."
+                          .format(loky_pickler))
+            e.args = (e.args[0] + extra_info,) + e.args[1:]
+            e.msg = e.args[0]
+            raise e
+
+    util.debug("Using '{}' for serialization."
+               .format(loky_pickler if loky_pickler else "cloudpickle"))
+
+    class CustomizablePickler(loky_pickler_cls):
+        _loky_pickler_cls = loky_pickler_cls
+
+        if sys.version_info < (3,):
+            # Make the dispatch registry an instance level attribute instead of
+            # a reference to the class dictionary under Python 2
+            _dispatch = loky_pickler_cls.dispatch.copy()
+            _dispatch.update(_ReducerRegistry.dispatch_table)
+        else:
+            # Under Python 3 initialize the dispatch table with a copy of the
+            # default registry
+            _dispatch_table = copyreg.dispatch_table.copy()
+            _dispatch_table.update(_ReducerRegistry.dispatch_table)
+
+        def __init__(self, writer, reducers=None, protocol=HIGHEST_PROTOCOL):
+            loky_pickler_cls.__init__(self, writer, protocol=protocol)
+            if reducers is None:
+                reducers = {}
+            if sys.version_info < (3,):
+                self.dispatch = self._dispatch.copy()
+            else:
+                self.dispatch_table = self._dispatch_table.copy()
+            for type, reduce_func in reducers.items():
+                self.register(type, reduce_func)
+
+        def register(self, type, reduce_func):
+            """Attach a reducer function to a given type in the dispatch table.
+            """
+            if sys.version_info < (3,):
+                # Python 2 pickler dispatching is not explicitly customizable.
+                # Let us use a closure to workaround this limitation.
+                    def dispatcher(self, obj):
+                        reduced = reduce_func(obj)
+                        self.save_reduce(obj=obj, *reduced)
+                    self.dispatch[type] = dispatcher
+            else:
+                self.dispatch_table[type] = reduce_func
+
+    _LokyPickler = CustomizablePickler
+
+
+def get_loky_pickler():
+    global _LokyPickler
+    return _LokyPickler._loky_pickler_cls.__name__
+
+
+# Set it to its default value
+set_loky_pickler()
+
+
+def loads(buf):
+    # Compat for python2.7 version
+    if sys.version_info < (3, 3) and isinstance(buf, io.BytesIO):
+        buf = buf.getvalue()
+    return pickle_loads(buf)
+
+
+def dump(obj, file, reducers=None, protocol=None):
+    '''Replacement for pickle.dump() using _LokyPickler.'''
+    global _LokyPickler
+    _LokyPickler(file, reducers=reducers, protocol=protocol).dump(obj)
+
+
+def dumps(obj, reducers=None, protocol=None):
+    global _LokyPickler
+
+    buf = io.BytesIO()
+    dump(obj, buf, reducers=reducers, protocol=protocol)
+    if sys.version_info < (3, 3):
+        return buf.getvalue()
+    return buf.getbuffer()
+
+
+__all__ = ["dump", "dumps", "loads", "register", "set_loky_pickler"]
+
+if sys.platform == "win32":
+    __all__ += ["duplicate"]

--- a/joblib/externals/loky/backend/utils.py
+++ b/joblib/externals/loky/backend/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 import errno
 import signal
 import warnings
@@ -9,6 +10,9 @@ try:
     import psutil
 except ImportError:
     psutil = None
+
+
+WIN32 = sys.platform == "win32"
 
 
 def _flag_current_thread_clean_exit():
@@ -110,3 +114,59 @@ def _recursive_terminate(pid):
             # level function raise a warning and retry to kill the process.
             if e.errno != errno.ESRCH:
                 raise
+
+
+def get_exitcodes_terminated_worker(processes):
+    """Return a formated string with the exitcodes of terminated workers.
+
+    If necessary, wait (up to .25s) for the system to correctly set the
+    exitcode of one terminated worker.
+    """
+    patience = 5
+
+    # Catch the exitcode of the terminated workers. There should at least be
+    # one. If not, wait a bit for the system to correctly set the exitcode of
+    # the terminated worker.
+    exitcodes = [p.exitcode for p in processes.values()
+                 if p.exitcode is not None]
+    while len(exitcodes) == 0 and patience > 0:
+        patience -= 1
+        exitcodes = [p.exitcode for p in processes.values()
+                     if p.exitcode is not None]
+        time.sleep(.05)
+
+    return _format_exitcodes(exitcodes)
+
+
+def _format_exitcodes(exitcodes):
+    """Format a list of exit code with names of the signals if possible"""
+    str_exitcodes = ["{}({})".format(_get_exitcode_name(e), e)
+                     for e in exitcodes if e is not None]
+    return "{" + ", ".join(str_exitcodes) + "}"
+
+
+def _get_exitcode_name(exitcode):
+    if sys.platform == "win32":
+        # The exitcode are unreliable  on windows (see bpo-31863).
+        # For this case, return UNKNOWN
+        return "UNKNOWN"
+
+    if exitcode < 0:
+        try:
+            import signal
+            if sys.version_info > (3, 5):
+                return signal.Signals(-exitcode).name
+
+            # construct an inverse lookup table
+            for v, k in signal.__dict__.items():
+                if (v.startswith('SIG') and not v.startswith('SIG_') and
+                        k == -exitcode):
+                        return v
+        except ValueError:
+            return "UNKNOWN"
+    elif exitcode != 255:
+        # The exitcode are unreliable on forkserver were 255 is always returned
+        # (see bpo-30589). For this case, return UNKNOWN
+        return "EXIT"
+
+    return "UNKNOWN"

--- a/joblib/externals/loky/cloudpickle_wrapper.py
+++ b/joblib/externals/loky/cloudpickle_wrapper.py
@@ -1,53 +1,113 @@
-import os
 import inspect
 from functools import partial
 
-from .backend import LOKY_PICKLER
-
 try:
-    from cloudpickle import dumps, loads
+    from joblib.externals.cloudpickle import dumps, loads
     cloudpickle = True
 except ImportError:
     cloudpickle = False
 
-if not LOKY_PICKLER and cloudpickle:
-    wrap_cache = dict()
 
-    class CloudpickledObjectWrapper(object):
-        def __init__(self, obj):
-            self.pickled_obj = dumps(obj)
+WRAP_CACHE = dict()
 
-        def __reduce__(self):
-            return loads, (self.pickled_obj,)
 
-    def _wrap_non_picklable_objects(obj):
-        need_wrap = "__main__" in getattr(obj, "__module__", "")
-        if isinstance(obj, partial):
-            return partial(
-                _wrap_non_picklable_objects(obj.func),
-                *[_wrap_non_picklable_objects(a) for a in obj.args],
-                **{k: _wrap_non_picklable_objects(v)
-                   for k, v in obj.keywords.items()}
-            )
-        if callable(obj):
-            # Need wrap if the object is a function defined in a local scope of
-            # another function.
-            func_code = getattr(obj, "__code__", "")
-            need_wrap |= getattr(func_code, "co_flags", 0) & inspect.CO_NESTED
+class CloudpickledObjectWrapper(object):
+    def __init__(self, obj, keep_wrapper=False):
+        self._obj = obj
+        self._keep_wrapper = keep_wrapper
 
-            # Need wrap if the obj is a lambda expression
-            func_name = getattr(obj, "__name__", "")
-            need_wrap |= "<lambda>" in func_name
+    def __reduce__(self):
+        _pickled_object = dumps(self._obj)
+        if not self._keep_wrapper:
+            return loads, (_pickled_object,)
 
-        if not need_wrap:
-            return obj
+        return _reconstruct_wrapper, (_pickled_object, self._keep_wrapper)
 
-        wrapped_obj = wrap_cache.get(obj)
-        if wrapped_obj is None:
-            wrapped_obj = CloudpickledObjectWrapper(obj)
-            wrap_cache[obj] = wrapped_obj
-        return wrapped_obj
+    def __getattr__(self, attr):
+        # Ensure that the wrapped object can be used seemlessly as the
+        # previous object.
+        if attr not in ['_obj', '_keep_wrapper']:
+            return getattr(self._obj, attr)
+        return getattr(self, attr)
 
-else:
-    def _wrap_non_picklable_objects(obj):
+
+# Make sure the wrapped object conserves the callable property
+class CallableObjectWrapper(CloudpickledObjectWrapper):
+
+    def __call__(self, *args, **kwargs):
+        return self._obj(*args, **kwargs)
+
+
+def _wrap_non_picklable_objects(obj, keep_wrapper):
+    if callable(obj):
+        return CallableObjectWrapper(obj, keep_wrapper=keep_wrapper)
+    return CloudpickledObjectWrapper(obj, keep_wrapper=keep_wrapper)
+
+
+def _reconstruct_wrapper(_pickled_object, keep_wrapper):
+    obj = loads(_pickled_object)
+    return _wrap_non_picklable_objects(obj, keep_wrapper)
+
+
+def _wrap_objects_when_needed(obj):
+    # Function to introspect an object and decide if it should be wrapped or
+    # not.
+    if not cloudpickle:
         return obj
+
+    need_wrap = "__main__" in getattr(obj, "__module__", "")
+    if isinstance(obj, partial):
+        return partial(
+            _wrap_objects_when_needed(obj.func),
+            *[_wrap_objects_when_needed(a) for a in obj.args],
+            **{k: _wrap_objects_when_needed(v)
+                for k, v in obj.keywords.items()}
+        )
+    if callable(obj):
+        # Need wrap if the object is a function defined in a local scope of
+        # another function.
+        func_code = getattr(obj, "__code__", "")
+        need_wrap |= getattr(func_code, "co_flags", 0) & inspect.CO_NESTED
+
+        # Need wrap if the obj is a lambda expression
+        func_name = getattr(obj, "__name__", "")
+        need_wrap |= "<lambda>" in func_name
+
+    if not need_wrap:
+        return obj
+
+    wrapped_obj = WRAP_CACHE.get(obj)
+    if wrapped_obj is None:
+        wrapped_obj = _wrap_non_picklable_objects(obj, keep_wrapper=False)
+        WRAP_CACHE[obj] = wrapped_obj
+    return wrapped_obj
+
+
+def wrap_non_picklable_objects(obj, keep_wrapper=True):
+    """Wrapper for non-picklable object to use cloudpickle to serialize them.
+
+    Note that this wrapper tends to slow down the serialization process as it
+    is done with cloudpickle which is typically slower compared to pickle. The
+    proper way to solve serialization issues is to avoid defining functions and
+    objects in the main scripts and to implement __reduce__ functions for
+    complex classes.
+    """
+    if not cloudpickle:
+        raise ImportError("could not from joblib.externals import cloudpickle. Please install "
+                          "cloudpickle to allow extended serialization. "
+                          "(`pip install cloudpickle`).")
+
+    # If obj is a  class, create a CloudpickledClassWrapper which instantiates
+    # the object internally and wrap it directly in a CloudpickledObjectWrapper
+    if inspect.isclass(obj):
+        class CloudpickledClassWrapper(CloudpickledObjectWrapper):
+            def __init__(self, *args, **kwargs):
+                self._obj = obj(*args, **kwargs)
+                self._keep_wrapper = keep_wrapper
+
+        CloudpickledClassWrapper.__name__ = obj.__name__
+        return CloudpickledClassWrapper
+
+    # If obj is an instance of a class, just wrap it in a regular
+    # CloudpickledObjectWrapper
+    return _wrap_non_picklable_objects(obj, keep_wrapper=keep_wrapper)

--- a/joblib/externals/loky/process_executor.py
+++ b/joblib/externals/loky/process_executor.py
@@ -77,10 +77,10 @@ from . import _base
 from .backend import get_context
 from .backend.compat import queue
 from .backend.compat import wait
+from .backend.compat import set_cause
 from .backend.context import cpu_count
 from .backend.queues import Queue, SimpleQueue, Full
-from .backend.utils import recursive_terminate
-from .cloudpickle_wrapper import _wrap_non_picklable_objects
+from .backend.utils import recursive_terminate, get_exitcodes_terminated_worker
 
 try:
     from concurrent.futures.process import BrokenProcessPool as _BPPException
@@ -218,7 +218,8 @@ class _RemoteTraceback(Exception):
 
 class _ExceptionWithTraceback(BaseException):
 
-    def __init__(self, exc, tb=None):
+    def __init__(self, exc):
+        tb = getattr(exc, "__traceback__", None)
         if tb is None:
             _, _, tb = sys.exc_info()
         tb = traceback.format_exception(type(exc), exc, tb)
@@ -231,7 +232,7 @@ class _ExceptionWithTraceback(BaseException):
 
 
 def _rebuild_exc(exc, tb):
-    exc.__cause__ = _RemoteTraceback(tb)
+    exc = set_cause(exc, _RemoteTraceback(tb))
     return exc
 
 
@@ -266,17 +267,6 @@ class _CallItem(object):
         return "CallItem({}, {}, {}, {})".format(
             self.work_id, self.fn, self.args, self.kwargs)
 
-    def __getstate__(self):
-        return (
-            self.work_id,
-            _wrap_non_picklable_objects(self.fn),
-            [_wrap_non_picklable_objects(a) for a in self.args],
-            {k: _wrap_non_picklable_objects(a) for k, a in self.kwargs.items()}
-        )
-
-    def __setstate__(self, state):
-        self.work_id, self.fn, self.args, self.kwargs = state
-
 
 class _SafeQueue(Queue):
     """Safe Queue set exception to the future object linked to a job"""
@@ -299,8 +289,8 @@ class _SafeQueue(Queue):
                     "Could not pickle the task to send it to the workers.")
             tb = traceback.format_exception(
                 type(e), e, getattr(e, "__traceback__", None))
-            raised_error.__cause__ = _RemoteTraceback(
-                '\n"""\n{}"""'.format(''.join(tb)))
+            raised_error = set_cause(raised_error, _RemoteTraceback(
+                                     '\n"""\n{}"""'.format(''.join(tb))))
             work_item = self.pending_work_items.pop(obj.work_id, None)
             self.running_work_items.remove(obj.work_id)
             # work_item can be None if another process terminated. In this
@@ -311,11 +301,11 @@ class _SafeQueue(Queue):
                 del work_item
             self.thread_wakeup.wakeup()
         else:
-            super()._on_queue_feeder_error(e, obj)
+            super(_SafeQueue, self)._on_queue_feeder_error(e, obj)
 
 
 def _get_chunks(chunksize, *iterables):
-    """ Iterates over zip()ed iterables in chunks. """
+    """Iterates over zip()ed iterables in chunks. """
     if sys.version_info < (3, 3):
         it = itertools.izip(*iterables)
     else:
@@ -328,7 +318,7 @@ def _get_chunks(chunksize, *iterables):
 
 
 def _process_chunk(fn, chunk):
-    """ Processes a chunk of an iterable passed to map.
+    """Processes a chunk of an iterable passed to map.
 
     Runs the function passed to map() on a chunk of the
     iterable passed to map.
@@ -345,7 +335,7 @@ def _sendback_result(result_queue, work_id, result=None, exception=None):
         result_queue.put(_ResultItem(work_id, result=result,
                                      exception=exception))
     except BaseException as e:
-        exc = _ExceptionWithTraceback(e, getattr(e, "__traceback__", None))
+        exc = _ExceptionWithTraceback(e)
         result_queue.put(_ResultItem(work_id, exception=exc))
 
 
@@ -419,7 +409,7 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
         try:
             r = call_item.fn(*call_item.args, **call_item.kwargs)
         except BaseException as e:
-            exc = _ExceptionWithTraceback(e, getattr(e, "__traceback__", None))
+            exc = _ExceptionWithTraceback(e)
             result_queue.put(_ResultItem(call_item.work_id, exception=exc))
         else:
             _sendback_result(result_queue, call_item.work_id, result=r)
@@ -645,10 +635,18 @@ def _queue_management_worker(executor_reference,
         thread_wakeup.clear()
         if broken is not None:
             msg, cause_tb, exc_type = broken
+            if (issubclass(exc_type, TerminatedWorkerError) and
+                    (sys.platform != "win32")):
+                # In Windows, introspecting terminated workers exitcodes seems
+                # unstable, therefore they are not appended in the exception
+                # message.
+                msg += " The exit codes of the workers are {}".format(
+                    get_exitcodes_terminated_worker(processes))
+
             bpe = exc_type(msg)
             if cause_tb is not None:
-                bpe.__cause__ = _RemoteTraceback(
-                    "\n'''\n{}'''".format(''.join(cause_tb)))
+                bpe = set_cause(bpe, _RemoteTraceback(
+                          "\n'''\n{}'''".format(''.join(cause_tb))))
             # Mark the process pool broken so that submits fail right now.
             executor_flags.flag_as_broken(bpe)
 
@@ -884,8 +882,8 @@ class ProcessPoolExecutor(_base.Executor):
 
         if initializer is not None and not callable(initializer):
             raise TypeError("initializer must be a callable")
-        self._initializer = _wrap_non_picklable_objects(initializer)
-        self._initargs = [_wrap_non_picklable_objects(a) for a in initargs]
+        self._initializer = initializer
+        self._initargs = initargs
 
         _check_max_depth(self._context)
 

--- a/joblib/externals/vendor_loky.sh
+++ b/joblib/externals/vendor_loky.sh
@@ -21,4 +21,10 @@ rm -rf $INSTALL_FOLDER
 find loky -name "*.py" | xargs sed -i.bak "s/from loky/from joblib.externals.loky/"
 find loky -name "*.bak" | xargs rm
 
+for f in $(git grep -l "cloudpickle" loky); do
+	echo $f;
+	sed -ie 's/import cloudpickle/from joblib.externals import cloudpickle/' $f
+	sed -ie 's/from cloudpickle import/from joblib.externals.cloudpickle import/' $f
+done
+
 sed -i "s/loky.backend.popen_loky/joblib.externals.loky.backend.popen_loky/" loky/backend/popen_loky_posix.py

--- a/joblib/externals/vendor_loky.sh
+++ b/joblib/externals/vendor_loky.sh
@@ -23,8 +23,8 @@ find loky -name "*.bak" | xargs rm
 
 for f in $(git grep -l "cloudpickle" loky); do
 	echo $f;
-	sed -ie 's/import cloudpickle/from joblib.externals import cloudpickle/' $f
-	sed -ie 's/from cloudpickle import/from joblib.externals.cloudpickle import/' $f
+	sed -i 's/import cloudpickle/from joblib.externals import cloudpickle/' $f
+	sed -i 's/from cloudpickle import/from joblib.externals.cloudpickle import/' $f
 done
 
 sed -i "s/loky.backend.popen_loky/joblib.externals.loky.backend.popen_loky/" loky/backend/popen_loky_posix.py

--- a/joblib/externals/vendor_loky.sh
+++ b/joblib/externals/vendor_loky.sh
@@ -22,9 +22,9 @@ find loky -name "*.py" | xargs sed -i.bak "s/from loky/from joblib.externals.lok
 find loky -name "*.bak" | xargs rm
 
 for f in $(git grep -l "cloudpickle" loky); do
-	echo $f;
-	sed -i 's/import cloudpickle/from joblib.externals import cloudpickle/' $f
-	sed -i 's/from cloudpickle import/from joblib.externals.cloudpickle import/' $f
+    echo $f;
+    sed -i 's/import cloudpickle/from joblib.externals import cloudpickle/' $f
+    sed -i 's/from cloudpickle import/from joblib.externals.cloudpickle import/' $f
 done
 
 sed -i "s/loky.backend.popen_loky/joblib.externals.loky.backend.popen_loky/" loky/backend/popen_loky_posix.py

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -924,6 +924,9 @@ print(Parallel(n_jobs=2, backend=backend)(
 def test_parallel_with_interactively_defined_functions(backend):
     # When using the "-c" flag, interactive functions defined in __main__
     # should work with any backend.
+    if backend == "multiprocessing" and sys.platform == "win32":
+        pytest.skip("Require fork start method to use interactively defined "
+                    "functions with multiprocessing.")
     code = UNPICKLABLE_CALLABLE_SCRIPT_TEMPLATE_NO_MAIN.format(backend)
     check_subprocess_call(
         [sys.executable, '-c', code], timeout=10,

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -494,7 +494,6 @@ def test_exception_dispatch():
             delayed(exception_raiser)(i) for i in range(30))
 
 
-
 def nested_function_inner(i):
     Parallel(n_jobs=2)(
         delayed(exception_raiser)(j) for j in range(30))
@@ -987,8 +986,9 @@ square = lambda x: x ** 2
 @parametrize('callable_position', ['delayed', 'args', 'kwargs'])
 def test_parallel_with_unpicklable_functions_in_args(
         backend, define_func, callable_position, tmpdir):
-    if define_func != SQUARE_MAIN and backend in ['multiprocessing', 'spawn']:
-        pytest.skip("Not pickleble with pickle")
+    if backend in ['multiprocessing', 'spawn'] and (
+            define_func != SQUARE_MAIN or sys.platform == "win32"):
+        pytest.skip("Not picklable with pickle")
     code = UNPICKLABLE_CALLABLE_SCRIPT_TEMPLATE_MAIN.format(
         define_func=define_func, backend=backend,
         callable_position=callable_position,


### PR DESCRIPTION
Bump the version of `loky` to 2.4.0.

This update changes the default behavior of `joblib`: `cloudpickle` is used by default to serialize the tasks. Note that this might cause some performance drop in particular for large python objects.