### PR TITLE
[MRG] Improve error when using dask parallel backend and dask is not installed.

### DIFF
--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -108,6 +108,12 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
 
     def __init__(self, scheduler_host=None, scatter=None,
                  client=None, loop=None, **submit_kwargs):
+        if distributed is None:
+            msg = ("You are trying to use 'dask' as a joblib parallel backend "
+                   "but dask is not installed. Please install dask "
+                   "to fix this error.")
+            raise ValueError(msg)
+
         if client is None:
             if scheduler_host:
                 client = Client(scheduler_host, loop=loop,

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -59,6 +59,11 @@ try:
 except ImportError:
     parallel_sum = None
 
+try:
+    import distributed
+except ImportError:
+    distributed = None
+
 from joblib._parallel_backends import SequentialBackend
 from joblib._parallel_backends import ThreadingBackend
 from joblib._parallel_backends import MultiprocessingBackend
@@ -1453,8 +1458,8 @@ def test_nested_parallelism_limit(backend):
 
 
 @with_numpy
+@skipif(distributed is None, reason='This test requires dask')
 def test_nested_parallelism_with_dask():
-    distributed = pytest.importorskip('distributed')
     client = distributed.Client(n_workers=2, threads_per_worker=2)  # noqa
 
     # 10 MB of data as argument to trigger implicit scattering
@@ -1506,3 +1511,10 @@ def test_parallel_thread_limit(backend):
     for value in res[0][0].values():
         assert value == '1'
     assert all([r[1] == 1 for r in res])
+
+
+@skipif(distributed is not None,
+        reason='This test requires dask NOT installed')
+def test_dask_backend_when_dask_not_installed():
+    with raises(ValueError, match='Please install dask'):
+        parallel_backend('dask')


### PR DESCRIPTION
```python
import joblib
joblib.parallel_backend('dask')   
```

Stack-trace:
```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-1-9a48dc1ad7ba> in <module>
      1 import joblib
----> 2 joblib.parallel_backend('dask')

/home/local/lesteve/dev/joblib/joblib/parallel.py in __init__(self, backend, n_jobs, **backend_params)
    171                 register()
    172 
--> 173             backend = BACKENDS[backend](**backend_params)
    174 
    175         self.old_backend_and_jobs = getattr(_backend, 'backend_and_jobs', None)

/home/local/lesteve/dev/joblib/joblib/_dask.py in __init__(self, scheduler_host, scatter, client, loop, **submit_kwargs)
    115             else:
    116                 try:
--> 117                     client = get_client()
    118                 except ValueError:
    119                     msg = ("To use Joblib with Dask first create a Dask Client"

NameError: name 'get_client' is not defined
```

A few comments, let me know if you strongly disagree with these changes:
* I added a test in `test/test_parallel.py` because it was simpler (less code changes). All the tests in `test/test_dask.py` requires `distributed` to be installed through an importorskip.
* I changed `importorskip` to use `skipif` in `test_nested_parallelism_with_dask`, I have to say that I find it easier to have all the skip reasons in the same place (in this case `whith_numpy` was before the function but `importorskip` was inside the function body). It took me quite some time to understand why this test was skipped when I did not have distributed installed.