### PR TITLE
FIX explicit error when effective_n_jobs is 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,17 @@ Pierre Glaser
    Also, a warning is raised if the returned backend is None while
    ``location`` is not None.
 
+Olivier Grisel
+
+   Make ``Parallel`` raise an informative RuntimeError when the active
+   parallel has zero worker.
+
+   Make the ``DaskDistributedBackend`` wait for workers before trying to
+   schedule work. This is useful in particular when the workers are
+   provisionned dynamically but provisionning is not immediate (for
+   instance using Kubernetes, Yarn or an HPC job queue).
+
+
 Release 0.13.0
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,8 @@ Pierre Glaser
 
 Olivier Grisel
 
-   Make ``Parallel`` raise an informative RuntimeError when the active
-   parallel has zero worker.
+   Make ``Parallel`` raise an informative ``RuntimeError`` when the
+   active parallel backend has zero worker.
 
    Make the ``DaskDistributedBackend`` wait for workers before trying to
    schedule work. This is useful in particular when the workers are

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -185,8 +185,15 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             self.client.submit(_joblib_probe_task).result(
                 timeout=self.wait_for_workers_timeout)
         except gen.TimeoutError:
-            raise TimeoutError("DaskDistributedBackend has no worker after %s"
-                               " seconds." % self.wait_for_workers_timeout)
+            error_msg = (
+                "DaskDistributedBackend has no worker after {} seconds. "
+                "Make sure that workers are started and can properly connect "
+                "to the scheduler and increase the joblib/dask connection "
+                "timeout with:\n\n"
+                "parallel_backend('dask', wait_for_workers_timeout={})"
+            ).format(self.wait_for_workers_timeout,
+                     max(10, 2 * self.wait_for_workers_timeout))
+            raise TimeoutError(error_msg)
         return sum(self.client.ncores().values())
 
     def _to_func_args(self, func):

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -34,7 +34,7 @@ try:
     TimeoutError = TimeoutError
 except NameError:
     # Python 2 backward compat
-    class TimeoutError(Exception):
+    class TimeoutError(OSError):
         pass
 
 
@@ -110,6 +110,11 @@ class Batch(object):
         return Batch, (self.tasks,)
 
 
+def _joblib_probe_task():
+    # Noop used by the joblib connector to probe when workers are ready.
+    pass
+
+
 class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
     MIN_IDEAL_BATCH_DURATION = 0.2
     MAX_IDEAL_BATCH_DURATION = 1.0
@@ -177,7 +182,7 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
         # to come up and be available. If the dask cluster is in adaptive mode
         # task might cause the cluster to provision some workers.
         try:
-            self.client.submit(lambda: None).result(
+            self.client.submit(_joblib_probe_task).result(
                 timeout=self.wait_for_workers_timeout)
         except gen.TimeoutError:
             raise TimeoutError("DaskDistributedBackend has no worker after %s"

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -30,6 +30,14 @@ def is_weakrefable(obj):
         return False
 
 
+try:
+    TimeoutError
+except NameError:
+    # Python 2 backward compat
+    class TimeoutError(Exception):
+        pass
+
+
 class _WeakKeyDictionary:
     """A variant of weakref.WeakKeyDictionary for unhashable objects.
 

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -31,7 +31,7 @@ def is_weakrefable(obj):
 
 
 try:
-    TimeoutError
+    TimeoutError = TimeoutError
 except NameError:
     # Python 2 backward compat
     class TimeoutError(Exception):

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -876,8 +876,7 @@ class Parallel(Logger):
             n_jobs = self._effective_n_jobs()
         backend_name = self._backend.__class__.__name__
         if n_jobs == 0:
-            raise RuntimeError("Parallel backend %s has no active worker."
-                               % backend_name)
+            raise RuntimeError("%s has no active worker." % backend_name)
 
         self._print("Using backend %s with %d concurrent workers.",
                     (backend_name, n_jobs))

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -874,8 +874,13 @@ class Parallel(Logger):
             n_jobs = self._initialize_backend()
         else:
             n_jobs = self._effective_n_jobs()
+        backend_name = self._backend.__class__.__name__
+        if n_jobs == 0:
+            raise RuntimeError("Parallel backend %s has no active worker."
+                               % backend_name)
+
         self._print("Using backend %s with %d concurrent workers.",
-                    (self._backend.__class__.__name__, n_jobs))
+                    (backend_name, n_jobs))
         if hasattr(self._backend, 'start_call'):
             self._backend.start_call()
         iterator = iter(iterable)

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -7,7 +7,7 @@ from time import sleep
 
 from .. import Parallel, delayed, parallel_backend
 from ..parallel import ThreadingBackend
-from .._dask import DaskDistributedBackend
+from .._dask import DaskDistributedBackend, TimeoutError
 
 distributed = pytest.importorskip('distributed')
 from distributed import Client, LocalCluster

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1506,3 +1506,21 @@ def test_parallel_thread_limit(backend):
     for value in res[0][0].values():
         assert value == '1'
     assert all([r[1] == 1 for r in res])
+
+
+def test_zero_worker_backend():
+    # joblib.Parallel should reject parallel backends
+    class ZeroWorkerBackend(ThreadingBackend):
+        def configure(self, *args, **kwargs):
+            return 0
+
+        def apply_async(self, func, callback=None):
+            raise TimeoutError("No worker available")
+
+        def effective_n_jobs(self, n_jobs):
+            return 0
+
+    expected_msg = "Parallel backend ZeroWorkerBackend has no active worker"
+    with parallel_backend(ZeroWorkerBackend()):
+        with pytest.raises(RuntimeError, match=expected_msg):
+            Parallel(n_jobs=2)(delayed(id)(i) for i in range(2))

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1509,18 +1509,19 @@ def test_parallel_thread_limit(backend):
 
 
 def test_zero_worker_backend():
-    # joblib.Parallel should reject parallel backends
+    # joblib.Parallel should reject with an explicit error message parallel
+    # backends that have no worker.
     class ZeroWorkerBackend(ThreadingBackend):
         def configure(self, *args, **kwargs):
             return 0
 
-        def apply_async(self, func, callback=None):
+        def apply_async(self, func, callback=None):   # pragma: no cover
             raise TimeoutError("No worker available")
 
-        def effective_n_jobs(self, n_jobs):
+        def effective_n_jobs(self, n_jobs):   # pragma: no cover
             return 0
 
-    expected_msg = "Parallel backend ZeroWorkerBackend has no active worker"
+    expected_msg = "ZeroWorkerBackend has no active worker"
     with parallel_backend(ZeroWorkerBackend()):
         with pytest.raises(RuntimeError, match=expected_msg):
             Parallel(n_jobs=2)(delayed(id)(i) for i in range(2))


### PR DESCRIPTION
This is a fix for #828.

<del>I still need to change the dask backend to add an option to wait for workers coming up (with a timeout) in the dask backend itself.</del>

It consists in two parts:

- first joblib will now throw a RuntimeError for any backend that return n_jobs=0 in its configuration step;
- second, the `DaskDistributedBackend` will now wait a configurable amount of time for workers to come up by scheduling a small probe task if the client sees 0 workers at configuration time.