### PR TITLE
Upgrade to cloudpickle 0.8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Pierre Glaser
 
    Upgrade to cloudpickle 0.8.0
 
+   Add a non-regression test related to joblib issues #836 and #833, reporting
+   that cloudpickle versions between 0.5.4 and 0.7 introduced a bug where
+   global variables changes in a parent process between two calls to
+   joblib.Parallel would not be propagated into the workers
+
 
 Release 0.13.1
 --------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Latest changes
 ===============
 
+Release 0.13.2
+--------------
+
+Pierre Glaser
+
+   Upgrade to cloudpickle 0.8.0
+
+
 Release 0.13.1
 --------------
 

--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -106,7 +106,7 @@ Main features
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.13.1'
+__version__ = '0.13.2.dev0'
 
 
 from .memory import Memory, MemorizedResult, register_store_backend

--- a/joblib/externals/cloudpickle/__init__.py
+++ b/joblib/externals/cloudpickle/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .cloudpickle import *
 
-__version__ = '0.6.1'
+__version__ = '0.8.0'


### PR DESCRIPTION
This PR upgrades the vendored cloudpickle to version 0.8.0.

Consequenlty, it solves the issues  #833  and #836, reporting that changes of global variables in the environment of a `joblib.Parallel` process would not be propagated in the workers.

A non-regression test is also added to make sure this bug is solved.