### PR TITLE
FIX python-lz4 version comparison

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 
 import pytest
 from _pytest.doctest import DoctestItem
@@ -21,7 +21,7 @@ def pytest_collection_modifyitems(config, items):
             # numpy changed the str/repr formatting of numpy arrays in 1.14.
             # We want to run doctests only for numpy >= 1.14.
             import numpy as np
-            if LooseVersion(np.__version__) >= LooseVersion('1.14'):
+            if parse_version(np.__version__) >= parse_version('1.14'):
                 skip_doctests = False
         except ImportError:
             pass

--- a/joblib/backports.py
+++ b/joblib/backports.py
@@ -6,7 +6,7 @@ import time
 import ctypes
 import sys
 
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 
 try:
     import numpy as np
@@ -21,7 +21,7 @@ try:
         """
         mm = np.memmap(filename, dtype=dtype, mode=mode, offset=offset,
                        shape=shape, order=order)
-        if LooseVersion(np.__version__) < '1.13':
+        if parse_version(np.__version__) < '1.13':
             mm.offset = offset
         return mm
 except ImportError:

--- a/joblib/compressor.py
+++ b/joblib/compressor.py
@@ -3,7 +3,7 @@
 import sys
 import io
 import zlib
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 
 from ._compat import _basestring, PY3_OR_LATER
 
@@ -226,7 +226,7 @@ class LZ4CompressorWrapper(CompressorWrapper):
             raise ValueError('lz4 compression is only available with '
                              'python3+.')
 
-        if lz4 is None or LooseVersion(lz4.__version__) < LooseVersion('0.19'):
+        if lz4 is None or parse_version(lz4.__version__) < parse_version('0.19'):
             raise ValueError(LZ4_NOT_INSTALLED_ERROR)
 
     def compressor_file(self, fileobj, compresslevel=None):


### PR DESCRIPTION
The python-lz4 package has its version string prefixed with "v".
As a result on nixos a test fails.

This commit changes to pkg_resources.parse_version which normalizes
the two schemas correctly and seems to be the recommended way to
compare versions in python at the moment.

Nixos build log https://hydra.nixos.org/build/88820470/nixlog/2.