### PR TITLE
Fix use of mmap arrays (when not using np.memmap)

### DIFF
--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -299,7 +299,7 @@ class ArrayMemmapReducer(object):
 
     def __call__(self, a):
         m = _get_backing_memmap(a)
-        if m is not None:
+        if m is not None and isinstance(m, np.memmap):
             # a is already backed by a memmap file, let's reuse it directly
             return _reduce_memmap_backed(a, m)
 

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -646,13 +646,16 @@ def test_direct_mmap(tmpdir):
             mm = mmap.mmap(fd.fileno(), 0, access=mmap.ACCESS_READ, offset=0)
         return np.ndarray((10,), dtype=np.uint8, buffer=mm, offset=0)
 
+    def func(x):
+        return x**2
+
     arr = _read_array()
 
     # this is expected to work and gives the reference
-    ref = Parallel(n_jobs=2)(delayed(np.sqrt)(x) for x in [a])
+    ref = Parallel(n_jobs=2)(delayed(func)(x) for x in [a])
 
     # now test that it work with the mmap array
-    results = Parallel(n_jobs=2)(delayed(np.sqrt)(x) for x in [arr])
+    results = Parallel(n_jobs=2)(delayed(func)(x) for x in [arr])
     np.testing.assert_array_equal(results, ref)
 
     # also test with a mmap array read in the subprocess

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -634,6 +634,8 @@ def test_weak_array_key_map_no_pickling():
         pickle.dumps(m)
 
 
+@with_numpy
+@with_multiprocessing
 def test_direct_mmap(tmpdir):
     testfile = str(tmpdir.join('arr.dat'))
     a = np.arange(10, dtype='uint8')

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -639,8 +639,7 @@ def test_weak_array_key_map_no_pickling():
 def test_direct_mmap(tmpdir):
     testfile = str(tmpdir.join('arr.dat'))
     a = np.arange(10, dtype='uint8')
-    with open(testfile, mode='wb') as f:
-        f.write(a.tobytes())
+    a.tofile(testfile)
 
     def _read_array():
         with open(testfile) as fd:


### PR DESCRIPTION
Fix #839: when a Numpy array is created directly with Python's mmap, joblib was crashing because it assumes that all mmap arrays use np.memmap. The latter has more attributes (offset, filename) that are used by joblib to recreate the memmap array instead of pickling the data, which is a nice feature, but it cannot be done with pure mmap arrays.