### PR TITLE
"NoneType has no attribute 'write'" exception in Parallel._print

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -763,6 +763,8 @@ class Parallel(Logger):
         """Display the message on stout or stderr depending on verbosity"""
         # XXX: Not using the logger framework: need to
         # learn to use logger better.
+        if sys.stdout is None or sys.stderr is None:
+            return
         if not self.verbose:
             return
         if self.verbose < 50:


### PR DESCRIPTION
sys.stdout and sys.stderr can be None, causing exception:  "NoneType has no attribute 'write'".
https://docs.python.org/3/library/sys.html#sys.__stdout__