### PR TITLE
MAINT test against the latest stable scikit-learn version

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -111,4 +111,4 @@ if [[ "$CYTHON" == "true" ]]; then
     cd ../../..
 fi
 
-python setup.py install
+pip install -v .

--- a/continuous_integration/travis/test_script.sh
+++ b/continuous_integration/travis/test_script.sh
@@ -22,7 +22,7 @@ fi
 if [[ "$SKLEARN_TESTS" == "true" ]]; then
     # Install scikit-learn from conda and test against the installed
     # development version of joblib.
-    conda install --yes cython scikit-learn scipy==1.2.1
+    conda install --yes cython pillow scikit-learn scipy==1.2.1
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
     pytest -vl --pyargs sklearn
 fi

--- a/continuous_integration/travis/test_script.sh
+++ b/continuous_integration/travis/test_script.sh
@@ -22,7 +22,7 @@ fi
 if [[ "$SKLEARN_TESTS" == "true" ]]; then
     # Install scikit-learn from conda and test against the installed
     # development version of joblib.
-    conda install --yes scikit-learn scipy==1.2.1
+    conda install --yes cython scikit-learn scipy==1.2.1
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
     pytest -vl --pyargs sklearn
 fi

--- a/continuous_integration/travis/test_script.sh
+++ b/continuous_integration/travis/test_script.sh
@@ -24,5 +24,9 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
     # development version of joblib.
     conda install --yes cython pillow scikit-learn scipy==1.2.1
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
-    pytest -vl --pyargs sklearn
+    # Skip test_lars_cv_max_iter because of a warning that is (probably)
+    # not related to joblib. To be confirmed once the following PR is
+    # merged:
+    # https://github.com/scikit-learn/scikit-learn/pull/12597
+    pytest -vl -k "not test_lars_cv_max_iter" --pyargs sklearn
 fi

--- a/continuous_integration/travis/test_script.sh
+++ b/continuous_integration/travis/test_script.sh
@@ -20,13 +20,9 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
 fi
 
 if [[ "$SKLEARN_TESTS" == "true" ]]; then
-    # Install scikit-learn from conda, patch it to use this version of joblib
-    # and run the scikit-learn tests with pytest. The versions of scikit-learn
-    # and scipy are frozen to avoid instabilities in the API (see issue #684)
-    # that should not be tested here.
-    conda install --yes scikit-learn==0.20.3 scipy==1.2.1
-    export SKLEARN=`python -c "import sklearn; print(sklearn.__path__[0])"`
-    cp $TRAVIS_BUILD_DIR/continuous_integration/travis/copy_joblib.sh $SKLEARN/externals
-    (cd $SKLEARN/externals && bash copy_joblib.sh $TRAVIS_BUILD_DIR)
-    pytest -vl $SKLEARN
+    # Install scikit-learn from conda and test against the installed
+    # development version of joblib.
+    conda install --yes scikit-learn scipy==1.2.1
+    python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
+    pytest -vl --pyargs sklearn
 fi


### PR DESCRIPTION
Now that joblib is no longer vendored in scikit-learn, there is no longer any need to vendor 