### PR TITLE
DOC emphasize security sensitivity of joblib.load

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Latest changes
 ===============
 
+Release 0.14.0
+--------------
+
+- Warn users that they should never use `joblib.load` with files from
+  untrusted sources. Fix security related API change introduced in numpy
+  1.6.3 that would prevent using joblib with recent numpy versions.
+  https://github.com/joblib/joblib/pull/879
+
+
 Release 0.13.2
 --------------
 

--- a/doc/persistence.rst
+++ b/doc/persistence.rst
@@ -13,6 +13,26 @@ Use case
 pickle to work efficiently on arbitrary Python objects containing large data,
 in particular large numpy arrays.
 
+.. warning::
+
+  :func:`joblib.dump` and :func:`joblib.load` are based on the Python pickle
+  serialization model, which means that arbitrary Python code can be executed
+  when loading a serialized object with :func:`joblib.load`.
+
+  :func:`joblib.load` should therefore never be used to load objects from an
+  untrusted source or otherwise you will introduce a security vulnerability in
+  your program.
+
+.. note::
+
+  As of Python 3.8 and numpy 1.16, pickle protocol 5 introduced in
+  `PEP 574 <https://www.python.org/dev/peps/pep-0574/>`_ supports efficient
+  serialization and de-serialization for large data buffers natively using
+  the standard library::
+
+      pickle.dump(large_object, fileobj, protocol=5)
+
+
 A simple example
 ================
 

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -550,6 +550,10 @@ def load(filename, mmap_mode=None):
 
     Read more in the :ref:`User Guide <persistence>`.
 
+    WARNING: joblib.load relies on the pickle module and can therefore
+    execute arbitrary Python code. It should therefore never be used
+    to load files from untrusted sources.
+
     Parameters
     -----------
     filename: str, pathlib.Path, or file object.


### PR DESCRIPTION
Update the documentation to make it explicit that joblib.load should never be used to load files from an untrusted source.

Also add compat for numpy 1.16.3 and later.