### PR TITLE
FIX avoid spawning resource trackers on import

### DIFF
--- a/joblib/_compat.py
+++ b/joblib/_compat.py
@@ -17,3 +17,11 @@ except NameError:
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
     return meta("NewBase", bases, {})
+
+
+# python2.7 error compatibility
+if PY27:
+    class _FileExistsError(OSError):
+        pass
+else:
+    CompatFileExistsError = FileExistsError

--- a/joblib/_compat.py
+++ b/joblib/_compat.py
@@ -21,7 +21,7 @@ def with_metaclass(meta, *bases):
 
 # python2.7 error compatibility
 if PY27:
-    class _FileExistsError(OSError):
+    class CompatFileExistsError(OSError):
         pass
 else:
     CompatFileExistsError = FileExistsError

--- a/joblib/_multiprocessing_helpers.py
+++ b/joblib/_multiprocessing_helpers.py
@@ -36,19 +36,21 @@ if mp is not None:
                 Semaphore = ctx.Semaphore
             _sem = Semaphore()
         else:
-                from joblib.externals.loky.backend.semlock import SemLock
-                for i in range(100):
-                    try:
-                        _sem = SemLock(0, 1, None, name=SemLock._make_name(),
-                                       unlink_now=True)
-                    except CompatFileExistsError:  # pragma: no cover
-                        pass
-                    else:
-                        break
-                else:  # pragma: no cover
-                    raise CompatFileExistsError(
-                        'cannot find name for semaphore')
-                del _sem  # cleanup
+            # try to create a named semaphore using
+            from joblib.externals.loky.backend.semlock import SemLock
+            for i in range(100):
+                try:
+                    name = '/loky-{}-{}' .format(
+                        os.getpid(), next(SemLock._rand))
+                    _sem = SemLock(0, 1, None, name=name, unlink_now=True)
+                except CompatFileExistsError:  # pragma: no cover
+                    pass
+                else:
+                    break
+            else:  # pragma: no cover
+                raise CompatFileExistsError(
+                    'cannot find name for semaphore')
+            del _sem  # cleanup
     except (AttributeError, CompatFileExistsError, ImportError, OSError) as e:
         mp = None
         warnings.warn('%s.  joblib will operate in serial mode' % (e,))

--- a/joblib/_multiprocessing_helpers.py
+++ b/joblib/_multiprocessing_helpers.py
@@ -4,10 +4,9 @@ We use a distinct module to simplify import statements and avoid introducing
 circular dependencies (for instance for the assert_spawning name).
 """
 import os
-import sys
 import warnings
 
-from ._compat import PY27, CompatFileExistsError
+from ._compat import CompatFileExistsError
 
 
 # Obtain possible configuration from the environment, assuming 1 (on)
@@ -24,34 +23,25 @@ if mp:
 #            issue a warning if not
 if mp is not None:
     try:
-        if sys.platform == "win32":
-            # Use the spawn context
-            if PY27:
-                Semaphore = mp.Semaphore
-            else:
-                # Using mp.Semaphore has a border effect and set the default
-                # backend for multiprocessing. To avoid that, we use the
-                # 'spawn' context which is available on all supported platforms
-                ctx = mp.get_context('spawn')
-                Semaphore = ctx.Semaphore
-            _sem = Semaphore()
-        else:
-            # try to create a named semaphore using
-            from joblib.externals.loky.backend.semlock import SemLock
-            for i in range(100):
-                try:
-                    name = '/loky-{}-{}' .format(
-                        os.getpid(), next(SemLock._rand))
-                    _sem = SemLock(0, 1, None, name=name, unlink_now=True)
-                except CompatFileExistsError:  # pragma: no cover
-                    pass
-                else:
-                    break
-            else:  # pragma: no cover
-                raise CompatFileExistsError(
-                    'cannot find name for semaphore')
-            del _sem  # cleanup
-    except (AttributeError, CompatFileExistsError, ImportError, OSError) as e:
+        # try to create a named semaphore using SemLock to make sure they are
+        # available on this platform. We use the low level object
+        # _multiprocessing.SemLock to avoid spawning a resource tracker on
+        # Unix system or changing the default backend.
+        import tempfile
+        from _multiprocessing import SemLock
+        _rand = tempfile._RandomNameSequence()
+        for i in range(100):
+            try:
+                name = '/joblib-{}-{}' .format(
+                    os.getpid(), next(SemLock._rand))
+                _sem = SemLock(0, 1, None, name=name, unlink_now=True)
+                del _sem  # cleanup
+                break
+            except CompatFileExistsError:  # pragma: no cover
+                if i >= 99:
+                    raise CompatFileExistsError(
+                        'cannot find name for semaphore')
+    except (CompatFileExistsError, AttributeError, ImportError, OSError) as e:
         mp = None
         warnings.warn('%s.  joblib will operate in serial mode' % (e,))
 

--- a/joblib/_multiprocessing_helpers.py
+++ b/joblib/_multiprocessing_helpers.py
@@ -4,6 +4,7 @@ We use a distinct module to simplify import statements and avoid introducing
 circular dependencies (for instance for the assert_spawning name).
 """
 import os
+import sys
 import warnings
 
 from ._compat import CompatFileExistsError
@@ -29,6 +30,12 @@ if mp is not None:
         # Unix system or changing the default backend.
         import tempfile
         from _multiprocessing import SemLock
+        if sys.version_info < (3,):
+            _SemLock = SemLock
+
+            def SemLock(kind, value, maxvalue, name, unlink):
+                return _SemLock(kind, value, maxvalue)
+
         _rand = tempfile._RandomNameSequence()
         for i in range(100):
             try:

--- a/joblib/_multiprocessing_helpers.py
+++ b/joblib/_multiprocessing_helpers.py
@@ -4,8 +4,9 @@ We use a distinct module to simplify import statements and avoid introducing
 circular dependencies (for instance for the assert_spawning name).
 """
 import os
-import sys
 import warnings
+
+from ._compat import CompatFileExistsError
 
 
 # Obtain possible configuration from the environment, assuming 1 (on)
@@ -22,18 +23,19 @@ if mp:
 #            issue a warning if not
 if mp is not None:
     try:
-        # Use the spawn context
-        if sys.version_info < (3, 3):
-            Semaphore = mp.Semaphore
-        else:
-            # Using mp.Semaphore has a border effect and set the default
-            # backend for multiprocessing. To avoid that, we use the 'spawn'
-            # context which is available on all supported platforms.
-            ctx = mp.get_context('spawn')
-            Semaphore = ctx.Semaphore
-        _sem = Semaphore()
+        from joblib.externals.loky.backend.semlock import SemLock
+        for i in range(100):
+            try:
+                _sem = SemLock(0, 1, None, name=SemLock._make_name(),
+                               unlink_now=True)
+            except CompatFileExistsError:  # pragma: no cover
+                pass
+            else:
+                break
+        else:  # pragma: no cover
+            raise CompatFileExistsError('cannot find name for semaphore')
         del _sem  # cleanup
-    except (ImportError, OSError) as e:
+    except (AttributeError, CompatFileExistsError) as e:
         mp = None
         warnings.warn('%s.  joblib will operate in serial mode' % (e,))
 

--- a/joblib/_multiprocessing_helpers.py
+++ b/joblib/_multiprocessing_helpers.py
@@ -33,8 +33,8 @@ if mp is not None:
         for i in range(100):
             try:
                 name = '/joblib-{}-{}' .format(
-                    os.getpid(), next(SemLock._rand))
-                _sem = SemLock(0, 1, None, name=name, unlink_now=True)
+                    os.getpid(), next(_rand))
+                _sem = SemLock(0, 0, 1, name=name, unlink=True)
                 del _sem  # cleanup
                 break
             except CompatFileExistsError:  # pragma: no cover

--- a/joblib/test/test_module.py
+++ b/joblib/test/test_module.py
@@ -1,6 +1,7 @@
 import sys
 import joblib
 import pytest
+from joblib._compat import PY27
 from joblib.testing import check_subprocess_call
 
 
@@ -9,7 +10,7 @@ def test_version():
         "There are no __version__ argument on the joblib module")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 3), reason="Need python3.3+")
+@pytest.mark.skipif(PY27, reason="Need python3.3+")
 def test_no_start_method_side_effect_on_import():
     # check that importing joblib does not implicitly set the global
     # start_method for multiprocessing.
@@ -19,5 +20,32 @@ def test_no_start_method_side_effect_on_import():
         # The following line would raise RuntimeError if the
         # start_method is already set.
         mp.set_start_method("loky")
+    """
+    check_subprocess_call([sys.executable, '-c', code])
+
+
+@pytest.mark.skipif(PY27, reason="Need python3.3+")
+def test_no_semaphore_tracker_on_import():
+    # check that importing joblib does not implicitly spawn a ressource tracker
+    # or a semaphore tracker
+    code = """if True:
+        import joblib
+        from multiprocessing import semaphore_tracker
+        # The following line would raise RuntimeError if the
+        # start_method is already set.
+        msg = "multiprocessing.semaphore_tracker has been spawned on import"
+        assert semaphore_tracker._semaphore_tracker._fd is None, msg"""
+    check_subprocess_call([sys.executable, '-c', code])
+
+
+@pytest.mark.skipif(PY27, reason="Need python3.3+")
+def test_no_ressource_tracker_on_import():
+    code = """if True:
+        import joblib
+        from joblib.externals.loky.backend import resource_tracker
+        # The following line would raise RuntimeError if the
+        # start_method is already set.
+        msg = "loky.resource_tracker has been spawned on import"
+        assert resource_tracker._resource_tracker._fd is None, msg
     """
     check_subprocess_call([sys.executable, '-c', code])

--- a/joblib/test/test_module.py
+++ b/joblib/test/test_module.py
@@ -38,7 +38,6 @@ def test_no_semaphore_tracker_on_import():
     check_subprocess_call([sys.executable, '-c', code])
 
 
-@pytest.mark.skipif(PY27, reason="Need python3.3+")
 def test_no_ressource_tracker_on_import():
     code = """if True:
         import joblib


### PR DESCRIPTION
Change the way we check for semaphore availability to avoid spawning resource trackers on `joblib` import.

I rely directly on `SemLock` for unix and did not change the bahavior on windows as there is no semaphore tracker in this case.

closes #841