### PR TITLE
Add a missing classifier for Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ if __name__ == '__main__':
               'Programming Language :: Python :: 3.4',
               'Programming Language :: Python :: 3.5',
               'Programming Language :: Python :: 3.6',
+              'Programming Language :: Python :: 3.7',
               'Topic :: Scientific/Engineering',
               'Topic :: Utilities',
               'Topic :: Software Development :: Libraries',


### PR DESCRIPTION
Hello,

As far as I can see on CI, Python 3.7 is already supported, but it's not declared in the `classifiers` list at `setup.py`.

Best regards!