### PR TITLE
ENH Improve load-balancing between workers for large batch sizes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,10 @@ Latest changes
 Release 0.14.0
 --------------
 
-- Improve the load balancing between joblib's workers, which yielded a
-  performance increase for an extensive set of use-cases (including running
-  tasks with varying running time, and combined usage of ``joblib.Memory`` and
-  ``joblib.Parallel``)
+- Improved the load balancing between workers to avoid stranglers caused by an
+  excessively large batch size when the task duration is varying significantly
+  (because of the combined use of ``joblib.Parallel`` and ``joblib.Memory``
+  with a partially warmed cache for instance).
   https://github.com/joblib/joblib/pull/899
 
 - Add official support for Python 3.8: fixed protocol number in `Hasher`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Latest changes
 Release 0.14.0
 --------------
 
+- Improve the load balancing between joblib's workers, which yielded a
+  performance increase for an extensive set of use-cases (including running
+  tasks with varying running time, and combined usage of ``joblib.Memory`` and
+  ``joblib.Parallel``)
+  https://github.com/joblib/joblib/pull/899
+
 - Add official support for Python 3.8: fixed protocol number in `Hasher`
   and updated tests.
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -810,7 +810,6 @@ class Parallel(Logger):
                                          self._backend.get_nested_backend(),
                                          self._pickle_cache)
                     self._ready_batches.put(tasks)
-                    i += final_batch_size
 
                 # finally, get one task.
                 tasks = self._ready_batches.get(block=False)

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -803,9 +803,9 @@ class Parallel(Logger):
                     final_batch_size = max(1, len(islice) // (10 * n_jobs))
                 else:
                     final_batch_size = max(1, len(islice) // n_jobs)
-                i = 0
+
                 # enqueue n_jobs batches in a local queue
-                while i < len(islice):
+                for i in range(0, len(islice), final_batch_size):
                     tasks = BatchedCalls(islice[i:i + final_batch_size],
                                          self._backend.get_nested_backend(),
                                          self._pickle_cache)

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -794,10 +794,13 @@ class Parallel(Logger):
                 islice = list(itertools.islice(iterator, big_batch_size))
                 if len(islice) == 0:
                     return False
-                elif len(islice) < big_batch_size:
-                    # we reached the end of the iterator. In this case,
-                    # decrease the batch size to account for potential variance
-                    # in the batches running time.
+                elif (iterator is self._original_iterator
+                      and len(islice) < big_batch_size):
+                    # We reached the end of the original iterator (unless
+                    # iterator is the ``pre_dispatch``-long initial slice of
+                    # the original iterator) -- decrease the batch size to
+                    # account for potential variance in the batches running
+                    # time.
                     final_batch_size = max(1, len(islice) // (10 * n_jobs))
                 else:
                     final_batch_size = max(1, len(islice) // n_jobs)
@@ -965,7 +968,7 @@ class Parallel(Logger):
             # callbacks upon task completions.
 
             # TODO: this iterator should be batch_size * n_jobs
-            iterator = itertools.islice(iterator, n_jobs)
+            iterator = itertools.islice(iterator, self._pre_dispatch_amount)
 
         self._start_time = time.time()
         self.n_dispatched_batches = 0

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -17,7 +17,6 @@ import itertools
 from numbers import Integral
 import warnings
 import queue
-from functools import partial
 
 from ._multiprocessing_helpers import mp
 
@@ -790,13 +789,12 @@ class Parallel(Logger):
                 # accordingly to distribute evenly the last items between all
                 # workers.
                 n_jobs = self._cached_effective_n_jobs
-                BIG_BATCH_SIZE = batch_size * n_jobs
-                # raise ValueError(BIG_BATCH_SIZE)
+                big_batch_size = batch_size * n_jobs
 
-                islice = list(itertools.islice(iterator, BIG_BATCH_SIZE))
+                islice = list(itertools.islice(iterator, big_batch_size))
                 if len(islice) == 0:
                     return False
-                elif len(islice) < BIG_BATCH_SIZE:
+                elif len(islice) < big_batch_size:
                     # we reached the end of the iterator. In this case,
                     # decrease the batch size to account for potential variance
                     # in the batches running time.

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -16,7 +16,6 @@ import threading
 import itertools
 from numbers import Integral
 import warnings
-import queue
 
 from ._multiprocessing_helpers import mp
 


### PR DESCRIPTION
This PR tries to improve load-balancing between workers in joblib, mostly in two ways, creating balanced batches both in terms of number of tasks, and in terms of total batch running time.

### Ensuring a balanced number of tasks per batches
Previously, the tasks iterator consumed by joblib was sliced `batch_size` tasks at a time. This can lead to unbalanced batches when we reach the end of the iterator.
   
I propose to slice the tasks iterator `batch_size * n_jobs` tasks at a time instead. The resulting `n_jobs` batches are not dispatched immediately, but stored in a local queue that the further callback-triggered `dispatch_one_batch` calls will try to access before re-slicing the iterator. If the queue is empty, then the batch-size is re-computed, the iterator is re-sliced, and the queue is re-populated.

### Reducing running-time variance between batches
The higher the running-time variance between batches, the more we risk to create stranglers, that will decrease joblib speedup compared to the serial case. Reducing the variance can be done by reducing the batch size. Thus, I propose to be more conservative when increasing the batch size.


This plot summarizes the speedups for a set of benchmarks defined in the [joblib_benchmarks](https://github.com/pierreglaser/joblib_benchmarks/blob/add-joblib-batching-benchmark/benchmarks/bench_auto_batching.py) repository: Each point (x, y) is a benchmark result. 
x = total running time using joblib master 
y = total running time using this PR

Any point above the y=x line is an performance regression, any point below the y=x line is a performance improvement.

![image](https://user-images.githubusercontent.com/18555600/60255905-e3901180-98d0-11e9-903e-20b929d7788e.png)