### PR TITLE
Remove `check_pickle` argument in `delayed`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Latest changes
 In development
 --------------
 
+- Remove deprecated `check_pickle` argument in `delayed`.
+  https://github.com/joblib/joblib/pull/903
+
 Release 0.17.0
 --------------
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -299,15 +299,8 @@ def _verbosity_filter(index, verbose):
 
 
 ###############################################################################
-def delayed(function, check_pickle=None):
+def delayed(function):
     """Decorator used to capture the arguments of a function."""
-    if check_pickle is not None:
-        warnings.warn('check_pickle is deprecated in joblib 0.12 and will be'
-                      ' removed in 0.13', DeprecationWarning)
-    # Try to pickle the input function, to catch the problems early when
-    # using with multiprocessing:
-    if check_pickle:
-        dumps(function)
 
     def delayed_function(*args, **kwargs):
         return function, args, kwargs

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -808,7 +808,7 @@ def test_retrieval_context():
 
     with parallel_backend("retrieval") as (ba, _):
         Parallel(n_jobs=2)(
-            delayed(nested_call, check_pickle=False)(i)
+            delayed(nested_call)(i)
             for i in range(5)
         )
         assert ba.i == 1

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1213,33 +1213,6 @@ def test_lambda_expression(backend):
     assert results == [i ** 2 for i in range(10)]
 
 
-def test_delayed_check_pickle_deprecated():
-    class UnpicklableCallable(object):
-
-        def __call__(self, *args, **kwargs):
-            return 42
-
-        def __reduce__(self):
-            raise ValueError()
-
-    with warns(DeprecationWarning):
-        f, args, kwargs = delayed(lambda x: 42, check_pickle=False)('a')
-    assert f('a') == 42
-    assert args == ('a',)
-    assert kwargs == dict()
-
-    with warns(DeprecationWarning):
-        f, args, kwargs = delayed(UnpicklableCallable(),
-                                  check_pickle=False)('a', option='b')
-        assert f('a', option='b') == 42
-        assert args == ('a',)
-        assert kwargs == dict(option='b')
-
-    with warns(DeprecationWarning):
-        with raises(ValueError):
-            delayed(UnpicklableCallable(), check_pickle=True)
-
-
 @with_multiprocessing
 @parametrize('backend', PROCESS_BACKENDS)
 def test_backend_batch_statistics_reset(backend):


### PR DESCRIPTION
**Context**: `check_pickle` should have been removed in 0.13.0 as indicated in the `DeprecationWarning`.

**Changes**: This PR removes this argument, behavior, and the associated test.

**Associated Issue:**  #900