### PR TITLE
Multiprocessing: change default inner n_threads to cpu_count // n_jobs

### DIFF
--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -163,13 +163,13 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
             if n_jobs is None:
                 raise ValueError('At least one of n_threads, n_jobs must be '
                                  'not None')
-            elif n_jobs == -1:
-                n_threads = 1
-            elif n_jobs >= 1:
+            elif isinstance(n_jobs, int) and n_jobs != 0:
+                if n_jobs < 0:
+                    n_jobs = cpu_count() - n_jobs + 1
                 n_threads = max(cpu_count() // n_jobs, 1)
             else:
-                raise ValueError('n_jobs={} must be larger than 1 or equal to '
-                                 '-1.'.format(n_jobs))
+                raise ValueError('n_jobs={} must be a non zero int.'
+                                 .format(n_jobs))
 
         for var in cls.SUPPORTED_CLIB_VARS:
             var_value = os.environ.get(var, None)


### PR DESCRIPTION
Following discussion in https://github.com/scikit-learn/scikit-learn/issues/14265#issuecomment-510234472 this aims to change the default value of inner `n_threads` (set via `OMP_NUM_THREADS` etc) during process creation in multiprocessing and loky backends from `n_threads=1` to `max(cpu_count() // n_jobs, 1)`.

This helps to better use CPU resources when `n_jobs<cpu_count()`

Documentation would also probably need updating, I just wanted to get some feedback first.