### PR TITLE
Fix dask scatter deadlock

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Release 0.14.0
 - Add official support for Python 3.8: fixed protocol number in `Hasher`
   and updated tests.
 
+- Fix a deadlock when using the dask backend (when scattering large numpy
+  arrays).
+  https://github.com/joblib/joblib/pull/914
+
 - Warn users that they should never use `joblib.load` with files from
   untrusted sources. Fix security related API change introduced in numpy
   1.6.3 that would prevent using joblib with recent numpy versions.

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -115,7 +115,9 @@ def test_manual_scatter(loop):
 
 def test_auto_scatter(loop):
     np = pytest.importorskip('numpy')
-    data = np.ones(int(1e7), dtype=np.uint8)
+    data1 = np.ones(int(1e4), dtype=np.uint8)
+    data2 = np.ones(int(1e4), dtype=np.uint8)
+    data_to_process = ([data1] * 4) + ([data2] * 4)
 
     def count_events(event_name, client):
         worker_events = client.run(lambda dask_worker: dask_worker.log)
@@ -131,7 +133,7 @@ def test_auto_scatter(loop):
                 # Passing the same data as arg and kwarg triggers a single
                 # scatter operation whose result is reused.
                 Parallel()(delayed(noop)(data, data, i, opt=data)
-                           for i in range(5))
+                           for i, data in enumerate(data_to_process))
             # By default large array are automatically scattered with
             # broadcast=1 which means that one worker must directly receive
             # the data from the scatter operation once.

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -138,7 +138,7 @@ def test_auto_scatter(loop):
             # broadcast=1 which means that one worker must directly receive
             # the data from the scatter operation once.
             counts = count_events('receive-from-scatter', client)
-            assert counts[a['address']] + counts[b['address']] == 1
+            assert counts[a['address']] + counts[b['address']] == 2
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -143,7 +143,7 @@ def test_auto_scatter(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:
             with parallel_backend('dask') as (ba, _):
-                Parallel()(delayed(noop)(data[:3], i) for i in range(5))
+                Parallel()(delayed(noop)(data1[:3], i) for i in range(5))
             # Small arrays are passed within the task definition without going
             # through a scatter operation.
             counts = count_events('receive-from-scatter', client)


### PR DESCRIPTION
Builds on top of #910 
Fixes #852 

(I'm still not 100% sure of whats going on here). This PR ensures the synchronous execution of distributed `scatter` operations by not running joblib's callbacks directly into `distributed` client event loop. In this situation, the operations can safely be made blocking.

I tried running the sklearn example in #852 and it runs fine. Hopefully the results are correct also.
@ogrisel 