### PR TITLE
import setup from setuptools rather than distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 import sys
 
 import joblib


### PR DESCRIPTION
Change setup.py to import setup from setuptools which supports the --single-version-externally-managed option needed for OpenBSD ports. Otherwise functions the same.