### PR TITLE
Adapt to windows new process launching mechanism

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,8 @@ install:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 
   # Install the build and runtime dependencies of the project.
+  - python -m venv ../python_venv
+  - ../python_venv/Scripts/activate.bat
   - pip install -r continuous_integration/appveyor/requirements.txt
   - python setup.py bdist_wheel
   - ps: ls dist

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,6 @@ environment:
   # platforms (universal wheel).
   # We run the tests on 2 different target platforms for testing purpose only.
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,10 @@ environment:
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "64"
+
 matrix:
     fast_finish: true
 


### PR DESCRIPTION
[bpo-34977](https://bugs.python.org/issue34977)   introduces a new way to launch processes in Windows (and MacOS). This change led to regressions in concurrent futures that also affect joblib ([bpo-35797](https://bugs.python.org/issue35797), #901, also related: [bpo-35872](https://bugs.python.org/issue35872)).
This PR first reproduces the bug by adding an entry for python3.7 in the Windows CI, and then will propose a fix.