### PR TITLE
ENH over-subscription mitigation + MTN vendor loky 2.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,9 +36,10 @@ Release 0.14.0
   in child before loading any module.
   https://github.com/joblib/joblib/pull/940
 
-- Fix the oversubscription protection for native libraries using threadpools.
+- Fix the oversubscription protection for native libraries using threadpools
+  (OpenBLAS, MKL, Blis and OpenMP runtimes).
   The maximal number of threads is can now be set in children using the
-  ``inner_max_num_threads`` in ``parallel_backend``. It default to
+  ``inner_max_num_threads`` in ``parallel_backend``. It defaults to
   ``cpu_count() // n_jobs``.
   https://github.com/joblib/joblib/pull/940
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,17 @@ Release 0.14.0
   Windows.
   https://github.com/joblib/joblib/pull/920
 
+- Upgrade to loky 2.6.1 that add supports for the setting environment variables
+  in child before loading any module.
+  https://github.com/joblib/joblib/pull/940
+
+- Fix the oversubscription protection for native libraries using threadpools.
+  The maximal number of threads is can now be set in children using the
+  ``inner_max_num_threads`` in ``parallel_backend``. It default to
+  ``cpu_count() // n_jobs``.
+  https://github.com/joblib/joblib/pull/940
+
+
 Release 0.13.2
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ Release 0.14.0
   Windows.
   https://github.com/joblib/joblib/pull/920
 
-- Upgrade to loky 2.6.1 that add supports for the setting environment variables
+- Upgrade to loky 2.6.0 that add supports for the setting environment variables
   in child before loading any module.
   https://github.com/joblib/joblib/pull/940
 

--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -6,4 +6,4 @@ pytest-timeout
 codecov
 distributed
 lz4
-threadpoolctl
+threadpoolctl; python_version >= '3.5'

--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -6,3 +6,4 @@ pytest-timeout
 codecov
 distributed
 lz4
+threadpoolctl

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -77,7 +77,7 @@ else
 fi
 
 # Install py.test timeout to fasten failure in deadlocking tests
-PIP_INSTALL_PACKAGES="pytest-timeout threadpoolctl"
+PIP_INSTALL_PACKAGES="pytest-timeout"
 
 if [ -n "$NUMPY_VERSION" ]; then
     # We want to ensure no memory copies are performed only when numpy is
@@ -92,6 +92,10 @@ fi
 
 if [[ "$COVERAGE" == "true" ]]; then
     PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES pytest-cov codecov"
+fi
+
+if [[ "2.7 3.4 pypy3" != *"$PYTHON_VERSION"* ]]; then
+    PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES threadpoolctl"
 fi
 
 pip install $PIP_INSTALL_PACKAGES

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -77,7 +77,7 @@ else
 fi
 
 # Install py.test timeout to fasten failure in deadlocking tests
-PIP_INSTALL_PACKAGES="pytest-timeout"
+PIP_INSTALL_PACKAGES="pytest-timeout threadpoolctl"
 
 if [ -n "$NUMPY_VERSION" ]; then
     # We want to ensure no memory copies are performed only when numpy is

--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -109,6 +109,7 @@ Main features
 __version__ = '0.13.2'
 
 
+import os
 from .memory import Memory, MemorizedResult, register_store_backend
 from .logger import PrintTime
 from .logger import Logger
@@ -131,3 +132,8 @@ __all__ = ['Memory', 'MemorizedResult', 'PrintTime', 'Logger', 'hash', 'dump',
            'register_parallel_backend', 'parallel_backend',
            'register_store_backend', 'register_compressor',
            'wrap_non_picklable_objects']
+
+
+# Workaround issue discovered in intel-openmp 2019.5:
+# https://github.com/ContinuumIO/anaconda-issues/issues/11294
+os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -31,7 +31,7 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
     """Helper abc which defines all methods a ParallelBackend must implement"""
 
     supports_timeout = False
-    support_inner_max_num_threads = False
+    supports_inner_max_num_threads = False
     nesting_level = None
 
     def __init__(self, nesting_level=None, inner_max_num_threads=None):
@@ -149,7 +149,7 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
         """
         yield
 
-    def get_max_num_threads_vars(self, n_threads=1):
+    def _get_max_num_threads_vars(self, n_threads=1):
         """Return environment variables limiting threadpools in external libs.
 
         This function return a dict containing environment variable to pass in
@@ -470,7 +470,7 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
     """Managing pool of workers with loky instead of multiprocessing."""
 
     supports_timeout = True
-    support_inner_max_num_threads = True
+    supports_inner_max_num_threads = True
 
     def configure(self, n_jobs=1, parallel=None, prefer=None, require=None,
                   idle_worker_timeout=300, **memmappingexecutor_args):
@@ -486,7 +486,7 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
 
         self._workers = get_memmapping_executor(
             n_jobs, timeout=idle_worker_timeout,
-            env=self.get_max_num_threads_vars(n_threads=n_threads),
+            env=self._get_max_num_threads_vars(n_threads=n_threads),
             **memmappingexecutor_args)
         self.parallel = parallel
         return n_jobs

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -31,6 +31,7 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
     """Helper abc which defines all methods a ParallelBackend must implement"""
 
     supports_timeout = False
+    nesting_level = None
 
     def __init__(self, nesting_level=None, max_inner_num_threads=None):
         self.nesting_level = nesting_level

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -40,7 +40,7 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
 
     MAX_NUM_THREADS_VARS = [
         'OMP_NUM_THREADS', 'OPENBLAS_NUM_THREADS', 'MKL_NUM_THREADS',
-        'VECLIB_MAXIMUM_THREADS', 'NUMEXPR_NUM_THREADS'
+        'BLIS_NUM_THREADS', 'VECLIB_MAXIMUM_THREADS', 'NUMEXPR_NUM_THREADS'
     ]
 
     @abstractmethod

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -31,6 +31,7 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
     """Helper abc which defines all methods a ParallelBackend must implement"""
 
     supports_timeout = False
+    support_inner_num_threads = False
     nesting_level = None
 
     def __init__(self, nesting_level=None, max_inner_num_threads=None):
@@ -483,6 +484,7 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
     """Managing pool of workers with loky instead of multiprocessing."""
 
     supports_timeout = True
+    support_inner_num_threads = True
 
     def configure(self, n_jobs=1, parallel=None, prefer=None, require=None,
                   idle_worker_timeout=300, **memmappingexecutor_args):

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -18,7 +18,7 @@ _backend_args = None
 
 
 def get_memmapping_executor(n_jobs, timeout=300, initializer=None, initargs=(),
-                            **backend_args):
+                            env=None, **backend_args):
     """Factory for ReusableExecutor with automatic memmapping for large numpy
     arrays.
     """
@@ -33,7 +33,7 @@ def get_memmapping_executor(n_jobs, timeout=300, initializer=None, initargs=(),
                                       result_reducers=result_reducers,
                                       reuse=reuse, timeout=timeout,
                                       initializer=initializer,
-                                      initargs=initargs)
+                                      initargs=initargs, env=env)
     # If executor doesn't have a _temp_folder, it means it is a new executor
     # and the reducers have been used. Else, the previous reducers are used
     # and we should not change this attibute.

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -24,6 +24,7 @@ def get_memmapping_executor(n_jobs, timeout=300, initializer=None, initargs=(),
     """
     global _backend_args
     reuse = _backend_args is None or _backend_args == backend_args
+    reuse = 'auto' if reuse else False
     _backend_args = backend_args
 
     id_executor = random.randint(0, int(1e10))

--- a/joblib/externals/loky/__init__.py
+++ b/joblib/externals/loky/__init__.py
@@ -22,4 +22,4 @@ __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "wrap_non_picklable_objects", "set_loky_pickler"]
 
 
-__version__ = '2.5.1'
+__version__ = '2.6.0'

--- a/joblib/externals/loky/backend/fork_exec.py
+++ b/joblib/externals/loky/backend/fork_exec.py
@@ -33,11 +33,16 @@ def close_fds(keep_fds):  # pragma: no cover
             pass
 
 
-def fork_exec(cmd, keep_fds):
+def fork_exec(cmd, keep_fds, env=None):
+
+    # copy the environment variables to set in the child process
+    env = {} if env is None else env
+    child_env = os.environ.copy()
+    child_env.update(env)
 
     pid = os.fork()
     if pid == 0:  # pragma: no cover
         close_fds(keep_fds)
-        os.execv(sys.executable, cmd)
+        os.execve(sys.executable, cmd, child_env)
     else:
         return pid

--- a/joblib/externals/loky/backend/popen_loky_posix.py
+++ b/joblib/externals/loky/backend/popen_loky_posix.py
@@ -68,7 +68,7 @@ if sys.platform != "win32":
                 while True:
                     try:
                         pid, sts = os.waitpid(self.pid, flag)
-                    except OSError as e:
+                    except OSError:
                         # Child process not yet created. See #1731717
                         # e.errno == errno.ECHILD == 10
                         return None
@@ -150,7 +150,7 @@ if sys.platform != "win32":
                 reduction._mk_inheritable(tracker_fd)
                 self._fds.extend([child_r, child_w, tracker_fd])
                 from .fork_exec import fork_exec
-                pid = fork_exec(cmd_python, self._fds)
+                pid = fork_exec(cmd_python, self._fds, env=process_obj.env)
                 util.debug("launched python with pid {} and cmd:\n{}"
                            .format(pid, cmd_python))
                 self.sentinel = parent_r
@@ -197,7 +197,7 @@ if __name__ == '__main__':
                 del process.current_process()._inheriting
 
         exitcode = process_obj._bootstrap()
-    except Exception as e:
+    except Exception:
         print('\n\n' + '-' * 80)
         print('{} failed with traceback: '.format(args.process_name))
         print('-' * 80)

--- a/joblib/externals/loky/backend/popen_loky_win32.py
+++ b/joblib/externals/loky/backend/popen_loky_win32.py
@@ -31,10 +31,18 @@ WINEXE = (sys.platform == 'win32' and getattr(sys, 'frozen', False))
 WINSERVICE = sys.executable.lower().endswith("pythonservice.exe")
 
 
+def _path_eq(p1, p2):
+    return p1 == p2 or os.path.normcase(p1) == os.path.normcase(p2)
+
+
+WINENV = (hasattr(sys, "_base_executable")
+          and not _path_eq(sys.executable, sys._base_executable))
+
 #
 # We define a Popen class similar to the one from subprocess, but
 # whose constructor takes a process object as its argument.
 #
+
 
 class Popen(_Popen):
     '''
@@ -55,6 +63,18 @@ class Popen(_Popen):
         cmd = get_command_line(parent_pid=os.getpid(), pipe_handle=rhandle)
         cmd = ' '.join('"%s"' % x for x in cmd)
 
+        python_exe = spawn.get_executable()
+
+        # copy the environment variables to set in the child process
+        child_env = os.environ.copy()
+        child_env.update(process_obj.env)
+
+        # bpo-35797: When running in a venv, we bypass the redirect
+        # executor and launch our base Python.
+        if WINENV and _path_eq(python_exe, sys.executable):
+            python_exe = sys._base_executable
+            child_env["__PYVENV_LAUNCHER__"] = sys.executable
+
         try:
             with open(wfd, 'wb') as to_child:
                 # start process
@@ -68,11 +88,11 @@ class Popen(_Popen):
                     # be used instead.
                     inherit = True
                     hp, ht, pid, tid = _winapi.CreateProcess(
-                        spawn.get_executable(), cmd,
+                        python_exe, cmd,
                         None, None, inherit, 0,
-                        None, None, None)
+                        child_env, None, None)
                     _winapi.CloseHandle(ht)
-                except BaseException as e:
+                except BaseException:
                     _winapi.CloseHandle(rhandle)
                     raise
 

--- a/joblib/externals/loky/backend/process.py
+++ b/joblib/externals/loky/backend/process.py
@@ -15,7 +15,8 @@ class LokyProcess(BaseProcess):
     _start_method = 'loky'
 
     def __init__(self, group=None, target=None, name=None, args=(),
-                 kwargs={}, daemon=None, init_main_module=False):
+                 kwargs={}, daemon=None, init_main_module=False,
+                 env=None):
         if sys.version_info < (3, 3):
             super(LokyProcess, self).__init__(
                 group=group, target=target, name=name, args=args,
@@ -25,6 +26,7 @@ class LokyProcess(BaseProcess):
             super(LokyProcess, self).__init__(
                 group=group, target=target, name=name, args=args,
                 kwargs=kwargs, daemon=daemon)
+        self.env = {} if env is None else env
         self.authkey = self.authkey
         self.init_main_module = init_main_module
 

--- a/joblib/externals/loky/process_executor.py
+++ b/joblib/externals/loky/process_executor.py
@@ -400,7 +400,7 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
             else:
                 mp.util.info("Could not acquire processes_management_lock")
                 continue
-        except BaseException as e:
+        except BaseException:
             previous_tb = traceback.format_exc()
             try:
                 result_queue.put(_RemoteTraceback(previous_tb))
@@ -853,7 +853,7 @@ class ProcessPoolExecutor(_base.Executor):
 
     def __init__(self, max_workers=None, job_reducers=None,
                  result_reducers=None, timeout=None, context=None,
-                 initializer=None, initargs=()):
+                 initializer=None, initargs=(), env=None):
         """Initializes a new ProcessPoolExecutor instance.
 
         Args:
@@ -874,6 +874,10 @@ class ProcessPoolExecutor(_base.Executor):
                 object should provide SimpleQueue, Queue and Process.
             initializer: An callable used to initialize worker processes.
             initargs: A tuple of arguments to pass to the initializer.
+            env: A dict of environment variable to overwrite in the child
+                process. The environment variables are set before any module is
+                loaded. Note that this only works with the loky context and it
+                is unreliable under windows with Python < 3.6.
         """
         _check_system_limits()
 
@@ -887,6 +891,7 @@ class ProcessPoolExecutor(_base.Executor):
         if context is None:
             context = get_context()
         self._context = context
+        self._env = env
 
         if initializer is not None and not callable(initializer):
             raise TypeError("initializer must be a callable")
@@ -992,17 +997,17 @@ class ProcessPoolExecutor(_base.Executor):
     def _adjust_process_count(self):
         for _ in range(len(self._processes), self._max_workers):
             worker_exit_lock = self._context.BoundedSemaphore(1)
+            args = (self._call_queue, self._result_queue, self._initializer,
+                    self._initargs, self._processes_management_lock,
+                    self._timeout, worker_exit_lock, _CURRENT_DEPTH + 1)
             worker_exit_lock.acquire()
-            p = self._context.Process(
-                target=_process_worker,
-                args=(self._call_queue,
-                      self._result_queue,
-                      self._initializer,
-                      self._initargs,
-                      self._processes_management_lock,
-                      self._timeout,
-                      worker_exit_lock,
-                      _CURRENT_DEPTH + 1))
+            try:
+                # Try to spawn the process with some environment variable to
+                # overwrite but it only works with the loky context for now.
+                p = self._context.Process(target=_process_worker, args=args,
+                                          env=self._env)
+            except TypeError:
+                p = self._context.Process(target=_process_worker, args=args)
             p._worker_exit_lock = worker_exit_lock
             p.start()
             self._processes[p.pid] = p

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -165,13 +165,13 @@ class parallel_backend(object):
     threads usable in some C-level library threadpools like openBLAS, MKL or
     OpenMP. The default limit in each worker is set to
     ``cpu_count() // effective_n_jobs`` but this limit can be overwritten with
-    the ``max_inner_num_threads`` argument which will be used to set this limit
+    the ``inner_max_num_threads`` argument which will be used to set this limit
     in the child processes.
 
     .. versionadded:: 0.10
 
     """
-    def __init__(self, backend, n_jobs=-1, max_inner_num_threads=None,
+    def __init__(self, backend, n_jobs=-1, inner_max_num_threads=None,
                  **backend_params):
         if isinstance(backend, _basestring):
             if backend not in BACKENDS and backend in EXTERNAL_BACKENDS:
@@ -180,11 +180,11 @@ class parallel_backend(object):
 
             backend = BACKENDS[backend](**backend_params)
 
-        if max_inner_num_threads is not None:
-            msg = ("max_inner_num_threads argument should only be used with "
+        if inner_max_num_threads is not None:
+            msg = ("inner_max_num_threads argument should only be used with "
                    "backend='loky'")
-            assert backend.support_inner_num_threads, msg
-            backend.max_inner_num_threads = max_inner_num_threads
+            assert backend.support_inner_max_num_threads, msg
+            backend.inner_max_num_threads = inner_max_num_threads
 
         # If the nesting_level of the backend is not set previously, use the
         # nesting level from the previous active_backend to set it

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -162,11 +162,11 @@ class parallel_backend(object):
     version of joblib.
 
     Joblib also tries to limit the oversubscription by limiting the number of
-    threads usable in some C-level library threadpools like openBLAS, MKL or
-    OpenMP. The default limit in each worker is set to
-    ``cpu_count() // effective_n_jobs`` but this limit can be overwritten with
-    the ``inner_max_num_threads`` argument which will be used to set this limit
-    in the child processes.
+    threads usable in some third-party library threadpools like OpenBLAS, MKL
+    or OpenMP. The default limit in each worker is set to
+    ``max(cpu_count() // effective_n_jobs, 1)`` but this limit can be
+    overwritten with the ``inner_max_num_threads`` argument which will be used
+    to set this limit in the child processes.
 
     .. versionadded:: 0.10
 
@@ -181,9 +181,9 @@ class parallel_backend(object):
             backend = BACKENDS[backend](**backend_params)
 
         if inner_max_num_threads is not None:
-            msg = ("inner_max_num_threads argument should only be used with "
-                   "backend='loky'")
-            assert backend.support_inner_max_num_threads, msg
+            msg = ("{} does not accept setting the inner_max_num_threads "
+                   "argument.".format(backend.__class__.__name__))
+            assert backend.supports_inner_max_num_threads, msg
             backend.inner_max_num_threads = inner_max_num_threads
 
         # If the nesting_level of the backend is not set previously, use the

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -161,16 +161,27 @@ class parallel_backend(object):
     Warning: this function is experimental and subject to change in a future
     version of joblib.
 
+    Joblib also tries to limit the oversubscription by limiting the number of
+    threads usable in some C-level library threadpools like openBLAS, MKL or
+    OpenMP. The default limit in each worker is set to
+    ``cpu_count() // effective_n_jobs`` but this limit can be overwritten with
+    the ``max_inner_num_threads`` argument which will be used to set this limit
+    in the child processes.
+
     .. versionadded:: 0.10
 
     """
-    def __init__(self, backend, n_jobs=-1, **backend_params):
+    def __init__(self, backend, n_jobs=-1, max_inner_num_threads=None,
+                 **backend_params):
         if isinstance(backend, _basestring):
             if backend not in BACKENDS and backend in EXTERNAL_BACKENDS:
                 register = EXTERNAL_BACKENDS[backend]
                 register()
 
             backend = BACKENDS[backend](**backend_params)
+
+        if max_inner_num_threads is not None:
+            backend.max_inner_num_threads = max_inner_num_threads
 
         # If the nesting_level of the backend is not set previously, use the
         # nesting level from the previous active_backend to set it

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -181,6 +181,9 @@ class parallel_backend(object):
             backend = BACKENDS[backend](**backend_params)
 
         if max_inner_num_threads is not None:
+            msg = ("max_inner_num_threads argument should only be used with "
+                   "backend='loky'")
+            assert backend.support_inner_num_threads, msg
             backend.max_inner_num_threads = max_inner_num_threads
 
         # If the nesting_level of the backend is not set previously, use the

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1613,7 +1613,7 @@ def test_globals_update_at_each_parallel_call():
 
 def _check_numpy_threadpool_limits():
     import numpy as np
-    a = np.random.randn(1000)
+    a = np.random.randn(100, 100)
     np.dot(a, a)
     from threadpoolctl import threadpool_info
     return threadpool_info()

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1694,6 +1694,7 @@ def test_threadpool_limitation_in_child_context(n_jobs, inner_max_num_threads):
     check_child_num_threads(workers_threadpool_infos, parent_info,
                             expected_child_num_threads)
 
+
 @parametrize('n_jobs', [2, 4, -2, -1])
 @parametrize('var_name', ["OPENBLAS_NUM_THREADS",
                           "MKL_NUM_THREADS",

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1608,7 +1608,7 @@ def test_globals_update_at_each_parallel_call():
 
 @with_numpy
 @with_multiprocessing
-@skipif(sys.version_info >= (3, 5),
+@skipif(sys.version_info < (3, 5),
         reason='threadpoolctl is a python3.5+ package')
 def test_threadpool_limitation_in_child():
     # Check that the protection against oversubscription in workers is working

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1613,6 +1613,9 @@ def test_globals_update_at_each_parallel_call():
 
 def _check_numpy_threadpool_limits():
     import numpy as np
+    # Let's call BLAS on a Matrix Matrix multiplication with dimensions large
+    # enough to ensure that the threadpool managed by the underlying BLAS
+    # implementation is actually used so as to force its initialization.
     a = np.random.randn(100, 100)
     np.dot(a, a)
     from threadpoolctl import threadpool_info

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1695,5 +1695,5 @@ def test_threadpool_limitation_in_child_context(n_jobs, inner_max_num_threads):
                          MultiprocessingBackend(), ThreadingBackend()])
 def test_threadpool_limitation_in_child_context_error(backend):
 
-    with raises(AssertionError, match=r"inner_max.*should only be used.*loky"):
+    with raises(AssertionError, match=r"does not acc.*inner_max_num_threads"):
         parallel_backend(backend, inner_max_num_threads=1)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1696,6 +1696,7 @@ def test_threadpool_limitation_in_child_context(n_jobs, inner_max_num_threads):
                             expected_child_num_threads)
 
 
+@with_multiprocessing
 @parametrize('n_jobs', [2, -1])
 @parametrize('var_name', ["OPENBLAS_NUM_THREADS",
                           "MKL_NUM_THREADS",

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1608,6 +1608,8 @@ def test_globals_update_at_each_parallel_call():
 
 @with_numpy
 @with_multiprocessing
+@skipif(sys.version_info >= (3, 5),
+        reason='threadpoolctl is a python3.5+ package')
 def test_threadpool_limitation_in_child():
     # Check that the protection against oversubscription in workers is working
     # using threadpoolctl functionalities.

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -417,11 +417,12 @@ def test_error_capture(backend):
 
     try:
         # JoblibException wrapping is disabled in sequential mode:
-        ex = JoblibException()
         Parallel(n_jobs=1)(
             delayed(division)(x, y) for x, y in zip((0, 1), (1, 0)))
     except Exception as ex:
         assert not isinstance(ex, JoblibException)
+    else:
+        raise ValueError("The excepted error has not been raised.")
 
 
 def consumer(queue, item):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1619,13 +1619,6 @@ def _check_threadpool_limits():
     return threadpool_info()
 
 
-def _get_num_threads(threadpool_info_list):
-    """Return a set containing the different num_threads"""
-    return set(module['num_threads']
-               for threadpool_info in threadpool_info_list
-               for module in threadpool_info)
-
-
 def get_max_num_threads(module, original_info):
     for original_module in original_info:
         if original_module['filepath'] == module['filepath']:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ testpaths = joblib
 # For PEP8 error codes see
 # https://pep8.readthedocs.org/en/latest/intro.html#error-codes
 # E402: module level import not at top of file
-ignore=E402
+ignore=E402,W504
 exclude=joblib/externals/*
 
 [metadata]


### PR DESCRIPTION
Vendor the version 2.6 of `loky` in joblib. This version introduce a way to set the environment variables in the child process before loading any module. This PR intend to use it to specify the maximal number of inner threads `max_inner_num_threads` in the child processes. This would fix #880 and #913 .