### PR TITLE
Random PermissionError on windows when using automatic memory mapping caused by reference cycles

### DIFF
--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -7,3 +7,5 @@ codecov
 distributed
 lz4
 threadpoolctl; python_version >= '3.5'
+scikit-learn
+pandas

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1741,3 +1741,56 @@ def test_threadpool_limitation_in_child_context_error(backend):
 
     with raises(AssertionError, match=r"does not acc.*inner_max_num_threads"):
         parallel_backend(backend, inner_max_num_threads=1)
+
+
+@with_numpy
+@parametrize("trial", range(10))
+def test_non_regression_memmap_permission_error_pandas(trial):
+    # Smoke test to serve as a non regression test for:
+    # https://github.com/joblib/joblib/issues/806
+    #
+    # The issue happens when trying to delete a memory mapped file that has
+    # not yet been closed by one of the worker processes.
+    ensemble = pytest.importorskip("sklearn.ensemble")
+    model_selection = pytest.importorskip("sklearn.model_selection")
+    pd = pytest.importorskip("pandas")
+
+    # Several iterations are needed to have a significant chance to trigger
+    # the bug. Generate a different dataset that are big enough to trigger
+    # joblib memory mapping
+    X_train = np.random.rand(int(2e6)).reshape((int(1e6), 2))
+    y_train = np.random.randint(0, 2, int(1e6))
+    X_train = pd.DataFrame(X_train)  # necessary to trigger the issue
+    clf = ensemble.RandomForestClassifier(n_estimators=5)
+    gs = model_selection.RandomizedSearchCV(
+        clf,
+        param_distributions={"n_estimators": [1],
+                                "max_depth": [2]},
+        n_iter=1,
+        cv=2,
+        scoring="accuracy",
+        n_jobs=2
+    )
+    gs.fit(X_train, y_train)
+
+
+@with_numpy
+@parametrize("trial", range(10))
+def test_non_regression_memmap_permission_error_minimal(trial):
+    # Smoke test to serve as a non regression test for:
+    # https://github.com/joblib/joblib/issues/806
+    #
+    # The issue happens when trying to delete a memory mapped file that has
+    # not yet been closed by one of the worker processes.
+    data = np.random.rand(int(2e6)).reshape((int(1e6), 2))
+
+    # Build a complex cyclic reference that is likely to delay garbage
+    # collection of the memmapped array in the worker processes.
+    first_list = current_list = [data]
+    for i in range(10):
+        current_list = [current_list]
+    first_list.append(current_list)
+
+    results = Parallel(n_jobs=2)(
+        delayed(len)(current_list) for i in range(10))
+    assert results == [1] * 10

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1744,8 +1744,8 @@ def test_threadpool_limitation_in_child_context_error(backend):
 
 
 @with_numpy
-@parametrize("trial", range(10))
-def test_non_regression_memmap_permission_error_minimal(trial):
+@parametrize("trial", range(3))
+def test_non_regression_memmap_permission_error(trial):
     # Smoke test to serve as a non regression test for:
     # https://github.com/joblib/joblib/issues/806
     #
@@ -1763,34 +1763,3 @@ def test_non_regression_memmap_permission_error_minimal(trial):
     results = Parallel(n_jobs=2)(
         delayed(len)(current_list) for i in range(10))
     assert results == [1] * 10
-
-
-@with_numpy
-@parametrize("trial", range(10))
-def test_non_regression_memmap_permission_error_pandas(trial):
-    # Smoke test to serve as a non regression test for:
-    # https://github.com/joblib/joblib/issues/806
-    #
-    # The issue happens when trying to delete a memory mapped file that has
-    # not yet been closed by one of the worker processes.
-    ensemble = pytest.importorskip("sklearn.ensemble")
-    model_selection = pytest.importorskip("sklearn.model_selection")
-    pd = pytest.importorskip("pandas")
-
-    # Several iterations are needed to have a significant chance to trigger
-    # the bug. Generate a different dataset that are big enough to trigger
-    # joblib memory mapping
-    X_train = np.random.rand(int(2e6)).reshape((int(1e6), 2))
-    y_train = np.random.randint(0, 2, int(1e6))
-    X_train = pd.DataFrame(X_train)  # necessary to trigger the issue
-    clf = ensemble.RandomForestClassifier(n_estimators=5)
-    gs = model_selection.RandomizedSearchCV(
-        clf,
-        param_distributions={"n_estimators": [1],
-                             "max_depth": [2]},
-        n_iter=1,
-        cv=2,
-        scoring="accuracy",
-        n_jobs=2
-    )
-    gs.fit(X_train, y_train)


### PR DESCRIPTION
For now this PR is trying to reproduce #806 on the Windows CI with a bunch of tests.