### PR TITLE
Returning a view when memory mapping is used raises Permission error on windows

### DIFF
--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1300,7 +1300,6 @@ def test_view_on_memmap(backend, tmpdir):
         np.testing.assert_array_equal(array[1:2], view)
         assert isinstance(view, np.memmap)
 
-
     # Make sure that the shared memory is cleaned at the end of a call
     p = Parallel(n_jobs=2, max_nbytes=1, backend=backend)
     views = p(delayed(view_on_memmap)(a, start=1, stop=2) for a in arrays)


### PR DESCRIPTION
Following [#942 (comment)](https://github.com/joblib/joblib/pull/942#issuecomment-537917125) I added a non regression test for when a view of a memory mapped object is returned.
This raises a Permission error on windows (to be confirmed by CI). However I am not sure about the expected behavior in this case. In a way it makes sense to have an error but I don't think it is the case with macOS or linux.

Related to issue #806.