### PR TITLE
Caching func_code on cache hit as well

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -655,6 +655,7 @@ class MemorizedFunc(Logger):
             old_func_code, old_first_line =\
                 extract_first_line(
                     self.store_backend.get_cached_func_code([func_id]))
+            self._write_func_code(old_func_code, old_first_line)
         except (IOError, OSError):  # some backend can also raise OSError
                 self._write_func_code(func_code, first_line)
                 return False


### PR DESCRIPTION
For smaller results _check_previous_func_code dominates the call times because "if self.func in _FUNCTION_HASHES:" is always false, a lot of performance can be gained if the func_code is cached.