### PR TITLE
Add encoding parameter in ZipNumpyUnpickler

### DIFF
--- a/joblib/numpy_pickle_compat.py
+++ b/joblib/numpy_pickle_compat.py
@@ -159,13 +159,13 @@ class ZipNumpyUnpickler(Unpickler):
 
     dispatch = Unpickler.dispatch.copy()
 
-    def __init__(self, filename, file_handle, mmap_mode=None):
+    def __init__(self, filename, file_handle, mmap_mode=None, encoding="ASCII"):
         """Constructor."""
         self._filename = os.path.basename(filename)
         self._dirname = os.path.dirname(filename)
         self.mmap_mode = mmap_mode
         self.file_handle = self._open_pickle(file_handle)
-        Unpickler.__init__(self, self.file_handle)
+        Unpickler.__init__(self, self.file_handle, encoding=encoding)
         try:
             import numpy as np
         except ImportError:


### PR DESCRIPTION
# What this PR does:
Add parameter `encoding` to `ZipNumpyUnpickler.__init__`

# Why it's important
Currently, I'm migrating from Python2.7 to 3.7 and when I open old files with pickel + encoding='latin1' works fine.
The problem is, default value of pickel is ASCII, and I cannot change that when I use joblib
This PR solves the problem

## Extra
I'm not sure of it is the best solution
Please let me know :heart: