### PR TITLE
Setup faulthandler.dump_traceback_later after pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -50,3 +50,19 @@ def pytest_configure(config):
         log = mp.util.log_to_stderr(logging.DEBUG)
         log.handlers[0].setFormatter(logging.Formatter(
             '[%(levelname)s:%(processName)s:%(threadName)s] %(message)s'))
+
+
+def pytest_unconfigure(config):
+    try:
+        # Setup a global traceback printer callback to debug deadlocks that
+        # would happen once pytest has completed: for instance in atexit
+        # finalizers. At this point the stdout/stderr capture of pytest
+        # should be disabled.
+
+        # Note that we also use a shorter timeout for the per-test callback
+        # configured via the pytest-timeout extension.
+        import faulthandler
+        faulthandler.dump_traceback_later(60, exit=True)
+    except ImportError:
+        # Python 2 backward compat.
+        pass


### PR DESCRIPTION
This should help tracking the cause of the problem reported in #974.