### PR TITLE
BUG fix reported number of jobs in effective_n_jobs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Latest changes
 ==============
 
+Release 0.14.2
+--------------
+
+- Fix the number of jobs reported by ``effective_n_jobs`` when ``n_jobs=None``
+  called in a parallel backend context.
+  https://github.com/joblib/joblib/blob/master/CHANGES.rst
+
 Release 0.14.1
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Release 0.14.2
 
 - Fix the number of jobs reported by ``effective_n_jobs`` when ``n_jobs=None``
   called in a parallel backend context.
-  https://github.com/joblib/joblib/blob/master/CHANGES.rst
+  https://github.com/joblib/joblib/pull/985
 
 Release 0.14.1
 --------------

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -91,7 +91,9 @@ if [ -n "$NUMPY_VERSION" ]; then
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then
-    PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES pytest-cov codecov"
+    # Pin the version of coverage < 0.5
+    # TODO: unpin when https://github.com/nedbat/coveragepy/issues/883 is fixed
+    PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES pytest-cov codecov coverage==4.5.4"
 fi
 
 if [[ "2.7 3.4 pypy3" != *"$PYTHON_VERSION"* ]]; then

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -387,7 +387,7 @@ def effective_n_jobs(n_jobs=-1):
     """
     backend, backend_n_jobs = get_active_backend()
     if n_jobs is None:
-        return backend.effective_n_jobs(n_jobs=backend_n_jobs)
+        n_jobs = backend_n_jobs
     return backend.effective_n_jobs(n_jobs=n_jobs)
 
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -387,7 +387,7 @@ def effective_n_jobs(n_jobs=-1):
     """
     backend, backend_n_jobs = get_active_backend()
     if n_jobs is None:
-        return backend_n_jobs
+        return backend.effective_n_jobs(n_jobs=backend_n_jobs)
     return backend.effective_n_jobs(n_jobs=n_jobs)
 
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -385,7 +385,9 @@ def effective_n_jobs(n_jobs=-1):
     .. versionadded:: 0.10
 
     """
-    backend, _ = get_active_backend()
+    backend, backend_n_jobs = get_active_backend()
+    if n_jobs is None:
+        return backend_n_jobs
     return backend.effective_n_jobs(n_jobs=n_jobs)
 
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -154,7 +154,7 @@ def test_effective_n_jobs():
 
 @pytest.mark.parametrize(
     "backend_n_jobs, expected_n_jobs",
-    [(3, 3), (-1, cpu_count()), (None, 1)],
+    [(3, 3), (-1, effective_n_jobs(n_jobs=-1)), (None, 1)],
     ids=["positive-int", "negative-int", "None"]
 )
 @with_multiprocessing

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -152,6 +152,18 @@ def test_effective_n_jobs():
     assert effective_n_jobs() > 0
 
 
+def test_effective_n_jobs_None():
+    # check the number of effective jobs when `n_jobs=None`
+    # non-regression test for https://github.com/joblib/joblib/issues/984
+    backend_n_jobs = 3
+    with parallel_backend("threading", n_jobs=backend_n_jobs):
+        # when using a backend, the default of number jobs will be the one set
+        # in the backend
+        assert effective_n_jobs(n_jobs=None) == backend_n_jobs
+    # without any backend, None will default to a single job
+    assert effective_n_jobs(n_jobs=None) == 1
+
+
 ###############################################################################
 # Test parallel
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -157,6 +157,7 @@ def test_effective_n_jobs():
     [(3, 3), (-1, effective_n_jobs(n_jobs=-1)), (None, 1)],
     ids=["positive-int", "negative-int", "None"]
 )
+@with_multiprocessing
 def test_effective_n_jobs_None(backend_n_jobs, expected_n_jobs):
     # check the number of effective jobs when `n_jobs=None`
     # non-regression test for https://github.com/joblib/joblib/issues/984

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -152,14 +152,18 @@ def test_effective_n_jobs():
     assert effective_n_jobs() > 0
 
 
-def test_effective_n_jobs_None():
+@pytest.mark.parametrize(
+    "backend_n_jobs, expected_n_jobs",
+    [(3, 3), (-1, effective_n_jobs(n_jobs=-1)), (None, 1)],
+    ids=["positive-int", "negative-int", "None"]
+)
+def test_effective_n_jobs_None(backend_n_jobs, expected_n_jobs):
     # check the number of effective jobs when `n_jobs=None`
     # non-regression test for https://github.com/joblib/joblib/issues/984
-    backend_n_jobs = 3
     with parallel_backend("threading", n_jobs=backend_n_jobs):
         # when using a backend, the default of number jobs will be the one set
         # in the backend
-        assert effective_n_jobs(n_jobs=None) == backend_n_jobs
+        assert effective_n_jobs(n_jobs=None) == expected_n_jobs
     # without any backend, None will default to a single job
     assert effective_n_jobs(n_jobs=None) == 1
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -154,7 +154,7 @@ def test_effective_n_jobs():
 
 @pytest.mark.parametrize(
     "backend_n_jobs, expected_n_jobs",
-    [(3, 3), (-1, effective_n_jobs(n_jobs=-1)), (None, 1)],
+    [(3, 3), (-1, cpu_count()), (None, 1)],
     ids=["positive-int", "negative-int", "None"]
 )
 @with_multiprocessing


### PR DESCRIPTION
closes #984 

When `n_jobs=None` is passed to `effective_n_jobs`, the number of reported jobs should be equal to either 1 or the default in the current backend.