### PR TITLE
Fix a minor typo in a test name

### DIFF
--- a/joblib/test/test_module.py
+++ b/joblib/test/test_module.py
@@ -41,7 +41,7 @@ def test_no_semaphore_tracker_on_import():
     check_subprocess_call([sys.executable, '-c', code])
 
 
-def test_no_ressource_tracker_on_import():
+def test_no_resource_tracker_on_import():
     code = """if True:
         import joblib
         from joblib.externals.loky.backend import resource_tracker


### PR DESCRIPTION
Janek beat me to fix the typo in docs in 427e7c6a8937acdd24d07e04910c794e767cff59, but I found it manifested in the test name! ;)