### PR TITLE
Replace path with with its hash, fixes #482

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -12,6 +12,7 @@ import warnings
 import re
 import os
 import collections
+import hashlib
 
 from ._compat import _basestring
 from .logger import pformat
@@ -159,7 +160,7 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
         # Stupid windows can't encode certain characters in filenames
         name = _clean_win_chars(name)
         module = [_clean_win_chars(s) for s in module]
-    return module, name
+    return [hashlib.sha1(m.encode('utf-8')).hexdigest() for m in module], name
 
 
 def getfullargspec(func):


### PR DESCRIPTION
Fast fix for https://github.com/joblib/joblib/issues/482
Long file names used as cache identifiers are not supported on all
filesystems. This caused silent errors, and broken Memory.cache
functionality.