### PR TITLE
catch new TimeoutError thrown by distributed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     # multiprocesssing disabled via the JOBLIB_MULTIPROCESSING environment variable
     - PYTHON_VERSION="3.6" NUMPY_VERSION="1.14" JOBLIB_MULTIPROCESSING=0 COVERAGE="true"
     # Make sure we do not depend on lz4 to run joblib.
-    - PYTHON_VERSION="3.6" NUMPY_VERSION="1.14" COVERAGE="true" NO_LZ4="true" CYTHON="true" DISTRIBUTED_VERSION="1.22"
+    - PYTHON_VERSION="3.6" NUMPY_VERSION="1.14" COVERAGE="true" NO_LZ4="true" CYTHON="true" DISTRIBUTED_VERSION="2.10"
     - PYTHON_VERSION="3.7" NUMPY_VERSION="1.15" CYTHON="true" DISTRIBUTED_VERSION="1.23"
     # flake8 linting on diff wrt common ancestor with upstream/master
     - SKIP_TESTS="true" FLAKE8_VERSION="3.5" PYTHON_VERSION="3.6"

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -20,6 +20,12 @@ if distributed is not None:
     from distributed.worker import thread_state
     from distributed.sizeof import sizeof
 
+    try:
+        # asyncio.TimeoutError, Python3-only error thrown by recent versions of
+        # distributed
+        from distributed.utils import TimeoutError as _TimeoutError
+    except ImportError:
+        from tornado.gen import TimeoutError as _TimeoutError
 
 def is_weakrefable(obj):
     try:
@@ -35,13 +41,6 @@ except NameError:
     # Python 2 backward compat
     class TimeoutError(OSError):
         pass
-
-try:
-    # asyncio.TimeoutError, Python3-only error thrown by recent versions of
-    # distributed
-    from distributed.utils import TimeoutError as _TimeoutError
-except ImportError:
-    from tornado.gen import TimeoutError as _TimeoutError
 
 
 class _WeakKeyDictionary:


### PR DESCRIPTION
`distributed` 2.10 throws a new type of `TimeoutError`, so the dask backend of `joblib` needs to be updated to except new such exceptions.