### PR TITLE
hashing: Add optional protocol to support large objects (≥4gb)

### DIFF
--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -473,3 +473,11 @@ def test_wrong_hash_name():
     with raises(ValueError, match=msg):
         data = {'foo': 'bar'}
         hash(data, hash_name='invalid')
+
+
+def test_large_objects_succeed_with_protocol_ge_4():
+    # Assert that hash() doesn't fail on large values
+    #   - Requires protocol >= 4
+    #   - And assert the hashed value while we're at it
+    bytes_4gb = b'a' * (4 * 1024**3)
+    assert hash(bytes_4gb, protocol=4) == '2252e9bd4b770db8384325f812a88b3b'


### PR DESCRIPTION
- Pickle protocols ≥4 have been added to support objects larger than 4gb
  - https://docs.python.org/3/library/pickle.html#data-stream-format
- This PR adds an optional `protocol` so the user can opt into protocols 4/5 if they want large object support
- Doing this will break compatibility with old `joblib.hash()` values from protocols 2/3, but if the user is stuck with an error like the below, then that's probably an acceptable cost
- This also adds a test that an example large value (4gb of bytes) succeeds when `protocol=4` is specified, instead of raising the below error, which happens with the default `protocol=3` (default on py3)

```
Traceback (most recent call last):
  File "<ipython-input-6-404e1c2b7deb>", line 2, in <module>
    joblib.hash(bytes_4gb)
  File ".../joblib/hashing.py", line 291, in hash
    return hasher.hash(obj)
  File ".../joblib/hashing.py", line 93, in hash
    self.dump(obj)
  File ".../python/python3.7.3/lib/python3.7/pickle.py", line 437, in dump
    self.save(obj)
  File ".../joblib/hashing.py", line 266, in save
    Hasher.save(self, obj)
  File ".../joblib/hashing.py", line 118, in save
    Pickler.save(self, obj)
  File ".../python/python3.7.3/lib/python3.7/pickle.py", line 504, in save
    f(self, obj) # Call unbound method with explicit self
  File ".../python/python3.7.3/lib/python3.7/pickle.py", line 732, in save_bytes
    self._write_large_bytes(BINBYTES + pack("<I", n), obj)
error: 'I' format requires 0 <= number <= 4294967295
```