### PR TITLE
Fix sklearn's CI entry

### DIFF
--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -4,6 +4,9 @@ pytest
 pytest-cov
 pytest-timeout
 codecov
+# msgpack 1.0 is not compatible with Python 2
+# (https://github.com/msgpack/msgpack-python/issues/413)
+msgpack<1; python_version >= '3'
 distributed
 lz4
 threadpoolctl; python_version >= '3.5'

--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -6,7 +6,7 @@ pytest-timeout
 codecov
 # msgpack 1.0 is not compatible with Python 2
 # (https://github.com/msgpack/msgpack-python/issues/413)
-msgpack<1; python_version >= '3'
+msgpack<1; python_version <= '3'
 distributed
 lz4
 threadpoolctl; python_version >= '3.5'

--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -6,7 +6,7 @@ pytest-timeout
 codecov
 # msgpack 1.0 is not compatible with Python 2
 # (https://github.com/msgpack/msgpack-python/issues/413)
-msgpack<1; python_version <= '3'
+msgpack<1; python_version < '3'
 distributed
 lz4
 threadpoolctl; python_version >= '3.5'

--- a/continuous_integration/travis/test_script.sh
+++ b/continuous_integration/travis/test_script.sh
@@ -26,12 +26,6 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
     conda install -y -c conda-forge cython pillow scikit-learn
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
 
-    # Hack to workaround shadowing of public function by compat modules:
-    # https://github.com/scikit-learn/scikit-learn/issues/15842
-    SKLEARN_ROOT=`python -c "import sklearn; print(sklearn.__path__[0])"`
-    rm -rf "$SKLEARN_ROOT/decomposition/dict_learning.py"
-    rm -rf "$SKLEARN_ROOT/inspection/partial_dependence.py"
-
     # Move to a dedicated folder to avoid being polluted by joblib specific conftest.py
     # and disable the doctest plugin to avoid issues with doctests in scikit-learn
     # docstrings that require setting print_changed_only=True temporarily.


### PR DESCRIPTION
Fixes #1014 

Now that the scikit-learn/scikit-learn#5846 is present in `scikit-learn` latest release, we can remove the related workarounds that were introduced in joblib before this fix.