### PR TITLE
MAINT use macos-10.14 on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,14 +84,14 @@ jobs:
         EXTRA_CONDA_PACKAGES: "numpy=1.16"
 
       macos_py38:
-        imageName: "macos-10.13"
+        imageName: "macos-10.14"
         PYTHON_VERSION: "3.8"
         EXTRA_CONDA_PACKAGES: "numpy=1.18"
       macos_py35_no_numpy:
-        imageName: "macos-10.13"
+        imageName: "macos-10.14"
         PYTHON_VERSION: "3.5"
       macos_py27:
-        imageName: "macos-10.13"
+        imageName: "macos-10.14"
         PYTHON_VERSION: "2.7"
         EXTRA_CONDA_PACKAGES: "numpy=1.16"
 


### PR DESCRIPTION
macos-10.13 is being removed:

https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/