### PR TITLE
joblib now logs to joblib namespace and no longer adds a stream handler to the root logger.

### DIFF
--- a/joblib/logger.py
+++ b/joblib/logger.py
@@ -74,14 +74,14 @@ class Logger(object):
                 The namespace to log to. If None, defaults to joblib.
         """
         self.depth = depth
-        self._logger = logging.getLogger(name if name else 'joblib')
+        self._name = name if name else 'joblib'
 
     def warn(self, msg):
-        self._logger.warning("[%s]: %s" % (self, msg))
+        logging.getLogger(self._name).warning("[%s]: %s" % (self, msg))
 
     def debug(self, msg):
         # XXX: This conflicts with the debug flag used in children class
-        self._logger.debug("[%s]: %s" % (self, msg))
+        logging.getLogger(self._name).debug("[%s]: %s" % (self, msg))
 
     def format(self, obj, indent=0):
         """Return the formatted representation of the object."""


### PR DESCRIPTION
```python3
#!/usr/bin/env python3

import logging
from joblib import Memory

ROOT_LOGGER = logging.getLogger()

mem = Memory('/tmp/', verbose=100)


@mem.cache
def foo(x):
    print('running foo')
    return x + 1


print('pre-function-call', ROOT_LOGGER.handlers)
x = foo(0)

print('post-function-call', ROOT_LOGGER.handlers)
ROOT_LOGGER.removeHandler(ROOT_LOGGER.handlers[0])
print('post-remove', ROOT_LOGGER.handlers)
x = foo(1)
print('post-second-function-call', ROOT_LOGGER.handlers)
ROOT_LOGGER.removeHandler(ROOT_LOGGER.handlers[0])
x = foo(1)
print('post-memoized-function-call', ROOT_LOGGER.handlers)
```

produces the following output:

```
pre-function-call []
WARNING:root:[MemorizedFunc(func=<function foo at 0x7ff7da2e6e60>, location=/tmp/joblib)]: Computing func foo, argument hash eafd7cd8280c6ace8622a25cf1f54934 in location /tmp/joblib/__main__--home-ubuntu-scratch-tmp/foo
________________________________________________________________________________
[Memory] Calling __main__--home-ubuntu-scratch-tmp.foo...
foo(0)
running foo
Persisting in /tmp/joblib/__main__--home-ubuntu-scratch-tmp/foo/eafd7cd8280c6ace8622a25cf1f54934
______________________________________________________________foo - 0.0s, 0.0min
post-function-call [<StreamHandler <stderr> (NOTSET)>]
post-remove []
WARNING:root:[MemorizedFunc(func=<function foo at 0x7ff7da2e6e60>, location=/tmp/joblib)]: Computing func foo, argument hash d3ffa92536e9b2aeb96c6d0e11ccd857 in location /tmp/joblib/__main__--home-ubuntu-scratch-tmp/foo
________________________________________________________________________________
[Memory] Calling __main__--home-ubuntu-scratch-tmp.foo...
foo(1)
running foo
Persisting in /tmp/joblib/__main__--home-ubuntu-scratch-tmp/foo/d3ffa92536e9b2aeb96c6d0e11ccd857
______________________________________________________________foo - 0.0s, 0.0min
post-second-function-call [<StreamHandler <stderr> (NOTSET)>]
[Memory]0.0s, 0.0min    : Loading foo from /tmp/joblib/__main__--home-ubuntu-scratch-tmp/foo/d3ffa92536e9b2aeb96c6d0e11ccd857
_________________________________________________foo cache loaded - 0.0s, 0.0min
post-memoized-function-call []
```

The culprit was that the `Logger` class was using the bare `logging.warning` functions instead of instantiating a logger and then using that logger's logging functions as it should have. Furthermore, it should be logging to a joblib namespace.