### PR TITLE
CLN directly use concurrent.futures TimeoutError

### DIFF
--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -20,7 +20,7 @@ if mp is not None:
 
     # Compat between concurrent.futures and multiprocessing TimeoutError
     from multiprocessing import TimeoutError
-    from .externals.loky._base import TimeoutError as LokyTimeoutError
+    from concurrent.futures._base import TimeoutError as CfTimeoutError
     from .externals.loky import process_executor, cpu_count
 
 
@@ -557,7 +557,7 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
         AsyncResults.get from multiprocessing."""
         try:
             return future.result(timeout=timeout)
-        except LokyTimeoutError:
+        except CfTimeoutError:
             raise TimeoutError()
 
     def terminate(self):


### PR DESCRIPTION
Here is a more subtle `Python 2` leftover:
Now that `joblib` is `Python 3` only, it can directly rely on `concurrent.futures._base.TimeoutError`
instead of `loky._base.TimeoutError`, which are the same objects in `Python 3.3+`
This need to be merged to make `joblib` compatible with the `Python 3`-only `loky` in joblib/loky#227.