### PR TITLE
Add a retry mechanism to the resource_tracker when unlinking memmaps

### DIFF
--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -77,7 +77,7 @@ def add_maybe_unlink_finalizer(memmap):
 def unlink_file(filename):
     """Wrapper around os.unlink with a retry mechanism.
 
-    The retry mechanism as been primarily implemented to overcome a race
+    The retry mechanism has been implemented primarily to overcome a race
     condition happening during the finalizer of a memmap: when a process
     holding the last reference to a mmap-backed np.array is about to delete
     this array (and close the reference), it sends a maybe_unlink request to

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -78,12 +78,12 @@ def unlink_file(filename):
     """Wrapper around os.unlink with a retry mechanism.
 
     The retry mechanism has been implemented primarily to overcome a race
-    condition happening during the finalizer of a memmap: when a process
-    holding the last reference to a mmap-backed np.array is about to delete
-    this array (and close the reference), it sends a maybe_unlink request to
-    the resource_tracker. This request can be processed faster than it takes
-    for the last reference of the memmap to be closed, yielding (on windows) a
-    PermissionError in the resource_tracker loop.
+    condition happening during the finalizer of a np.memmap: when a process
+    holding the last reference to a mmap-backed np.memmap/np.array is about to
+    delete this array (and close the reference), it sends a maybe_unlink
+    request to the resource_tracker. This request can be processed faster than
+    it takes for the last reference of the memmap to be closed, yielding (on
+    Windows) a PermissionError in the resource_tracker loop.
     """
     NUM_RETRIES = 10
     for retry_no in range(1, NUM_RETRIES + 1):

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -91,6 +91,10 @@ def unlink_file(filename):
             os.unlink(filename)
             break
         except PermissionError:
+            util.debug(
+                '[ResourceTracker] tried to unlink {}, got '
+                'PermissionError'.format(filename)
+            )
             if retry_no == NUM_RETRIES:
                 raise
             else:

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -144,6 +144,52 @@ def test_memmap_based_array_reducing(tmpdir):
     assert not has_shareable_memory(b3_reconstructed)
     assert_array_equal(b3_reconstructed, b3)
 
+@skipif(sys.platform != "win32",
+        reason="PermissionError only easily triggerable on Windows")
+def test_resource_tracker_retries_when_permissionerror(tmpdir):
+    # Test that the resource_tracker retry mechanism unlinking memmaps.  See
+    # more thorough information in the ``unlink_file`` documentation of joblib.
+    filename = tmpdir.join('test.mmap').strpath
+    cmd = """if 1:
+    import os
+    import numpy as np
+    import time
+    from joblib.externals.loky.backend import resource_tracker
+    resource_tracker.VERBOSE = 1
+
+    # Start the resource tracker
+    resource_tracker.ensure_running()
+    time.sleep(1)
+
+    # Create a file containing numpy data
+    memmap = np.memmap(r"{filename}", dtype=np.float64, shape=10, mode='w+')
+    memmap[:] = np.arange(10).astype(np.int8).data
+    memmap.flush()
+    assert os.path.exists(r"{filename}")
+    del memmap
+
+    # Create a np.memmap backed by this file
+    memmap = np.memmap(r"{filename}", dtype=np.float64, shape=10, mode='w+')
+    resource_tracker.register(r"{filename}", "file")
+
+    # Ask the resource_tracker to delete the file backing the np.memmap , this
+    # should raise PermissionError that the resource_tracker will log.
+    # catched by the resource_tracker
+    resource_tracker.maybe_unlink(r"{filename}", "file")
+
+    # wait for the resource_tracker to process the message before cleaning up
+    # the memmap
+    time.sleep(2)
+    """.format(filename=filename)
+    p = subprocess.Popen([sys.executable, '-c', cmd], stderr=subprocess.PIPE,
+                         stdout=subprocess.PIPE)
+    p.wait()
+    out, err = p.communicate()
+    assert p.returncode == 0
+    assert out == b''
+    msg = 'tried to unlink {}, got PermissionError'.format(filename)
+    assert msg in err.decode()
+
 
 @with_numpy
 @with_multiprocessing

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -144,11 +144,12 @@ def test_memmap_based_array_reducing(tmpdir):
     assert not has_shareable_memory(b3_reconstructed)
     assert_array_equal(b3_reconstructed, b3)
 
+
 @skipif(sys.platform != "win32",
         reason="PermissionError only easily triggerable on Windows")
 def test_resource_tracker_retries_when_permissionerror(tmpdir):
-    # Test that the resource_tracker retry mechanism unlinking memmaps.  See
-    # more thorough information in the ``unlink_file`` documentation of joblib.
+    # Test resource_tracker retry mechanism when unlinking memmaps.  See more
+    # thorough information in the ``unlink_file`` documentation of joblib.
     filename = tmpdir.join('test.mmap').strpath
     cmd = """if 1:
     import os
@@ -174,11 +175,10 @@ def test_resource_tracker_retries_when_permissionerror(tmpdir):
 
     # Ask the resource_tracker to delete the file backing the np.memmap , this
     # should raise PermissionError that the resource_tracker will log.
-    # catched by the resource_tracker
     resource_tracker.maybe_unlink(r"{filename}", "file")
 
-    # wait for the resource_tracker to process the message before cleaning up
-    # the memmap
+    # Wait for the resource_tracker to process the maybe_unlink before cleaning
+    # up the memmap
     time.sleep(2)
     """.format(filename=filename)
     p = subprocess.Popen([sys.executable, '-c', cmd], stderr=subprocess.PIPE,


### PR DESCRIPTION
In response to https://github.com/joblib/joblib/pull/966#issuecomment-619035841