### PR TITLE
Unregister folder rtracker

### DIFF
--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -451,28 +451,7 @@ def get_memmapping_reducers(
     # self to ensure that this callback won't prevent garbage collection of
     # the pool instance and related file handler resources such as POSIX
     # semaphores and pipes
-    pool_module_name = whichmodule(delete_folder, 'delete_folder')
     resource_tracker.register(pool_folder, "folder")
-
-    def _cleanup():
-        # In some cases the Python runtime seems to set delete_folder to
-        # None just before exiting when accessing the delete_folder
-        # function from the closure namespace. So instead we reimport
-        # the delete_folder function explicitly.
-        # https://github.com/joblib/joblib/issues/328
-        # We cannot just use from 'joblib.pool import delete_folder'
-        # because joblib should only use relative imports to allow
-        # easy vendoring.
-        delete_folder = __import__(
-            pool_module_name, fromlist=['delete_folder']).delete_folder
-        try:
-            if delete_folder(pool_folder, allow_non_empty=True):
-                resource_tracker.unregister(pool_folder, "folder")
-        except OSError:
-            warnings.warn("Failed to clean temporary folder: {}"
-                          .format(pool_folder))
-
-    atexit.register(_cleanup)
 
     if np is not None:
         # Register smart numpy.ndarray reducers that detects memmap backed
@@ -521,8 +500,34 @@ class TemporaryResourcesManagerMixin(object):
             if delete_folder(self._temp_folder,
                              allow_non_empty=allow_non_empty):
                 resource_tracker.unregister(self._temp_folder, "folder")
+
         except OSError:
             # Temporary folder cannot be deleted right now. No need to
             # handle it though, as this folder will be cleaned up by an
             # atexit finalizer registered by the memmapping_reducer.
-            pass
+            pool_module_name = whichmodule(delete_folder, 'delete_folder')
+
+            def _cleanup():
+                # In some cases the Python runtime seems to set
+                # delete_folder to None just before exiting when accessing
+                # the delete_folder function from the closure namespace. So
+                # instead we reimport the delete_folder function
+                # explicitly.  https://github.com/joblib/joblib/issues/328
+                # We cannot just use from 'joblib.pool import
+                # delete_folder' because joblib should only use relative
+                # imports to allow easy vendoring.
+                delete_folder = __import__(
+                    pool_module_name,
+                    fromlist=['delete_folder']).delete_folder
+                try:
+                    if delete_folder(
+                            self._temp_folder, "folder",
+                            allow_non_empty=True):
+                        resource_tracker.unregister(self._temp_folder,
+                                                    "folder")
+                except OSError:
+                    warnings.warn(
+                        "Failed to clean temporary folder: {}".format(
+                            self._temp_folder))
+
+            atexit.register(_cleanup)

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -518,7 +518,8 @@ class TemporaryResourcesManagerMixin(object):
 
     def _try_delete_folder(self, allow_non_empty):
         try:
-            if delete_folder(self._temp_folder, allow_non_empty=allow_non_empty):
+            if delete_folder(self._temp_folder,
+                             allow_non_empty=allow_non_empty):
                 resource_tracker.unregister(self._temp_folder, "folder")
         except OSError:
             # Temporary folder cannot be deleted right now. No need to

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -466,8 +466,8 @@ def get_memmapping_reducers(
         delete_folder = __import__(
             pool_module_name, fromlist=['delete_folder']).delete_folder
         try:
-            delete_folder(pool_folder, allow_non_empty=True)
-            resource_tracker.unregister(pool_folder, "folder")
+            if delete_folder(pool_folder, allow_non_empty=True):
+                resource_tracker.unregister(pool_folder, "folder")
         except OSError:
             warnings.warn("Failed to clean temporary folder: {}"
                           .format(pool_folder))
@@ -518,7 +518,8 @@ class TemporaryResourcesManagerMixin(object):
 
     def _try_delete_folder(self, allow_non_empty):
         try:
-            delete_folder(self._temp_folder, allow_non_empty=allow_non_empty)
+            if delete_folder(self._temp_folder, allow_non_empty=allow_non_empty):
+                resource_tracker.unregister(self._temp_folder, "folder")
         except OSError:
             # Temporary folder cannot be deleted right now. No need to
             # handle it though, as this folder will be cleaned up by an

--- a/joblib/disk.py
+++ b/joblib/disk.py
@@ -103,10 +103,13 @@ def rm_subdirs(path, onerror=None):
 
 
 def delete_folder(folder_path, onerror=None, allow_non_empty=True):
-    """Utility function to cleanup a temporary folder if it still exists."""
+    """Utility function to cleanup a temporary folder if it still exists.
+
+    returns True if the folder was succesfully deleted"""
     if os.path.isdir(folder_path):
         if onerror is not None:
             shutil.rmtree(folder_path, False, onerror)
+            return True
         else:
             # allow the rmtree to fail once, wait and re-try.
             # if the error is raised again, fail
@@ -120,7 +123,7 @@ def delete_folder(folder_path, onerror=None, allow_non_empty=True):
                         )
                         util.debug(
                             "Sucessfully deleted {}".format(folder_path))
-                        break
+                        return True
                     else:
                         raise OSError(
                             "Expected empty folder {} but got {} "
@@ -134,3 +137,4 @@ def delete_folder(folder_path, onerror=None, allow_non_empty=True):
                         # yet.
                         raise
                 time.sleep(RM_SUBDIRS_RETRY_TIME)
+    return False

--- a/joblib/disk.py
+++ b/joblib/disk.py
@@ -105,7 +105,10 @@ def rm_subdirs(path, onerror=None):
 def delete_folder(folder_path, onerror=None, allow_non_empty=True):
     """Utility function to cleanup a temporary folder if it still exists.
 
-    returns True if the folder was succesfully deleted"""
+    Returns
+    - True if the folder was succesfully deleted
+    - False if the folder does not exist, or was not deleted
+    """
     if os.path.isdir(folder_path):
         if onerror is not None:
             shutil.rmtree(folder_path, False, onerror)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -257,8 +257,8 @@ def nested_loop(backend):
         delayed(square)(.01) for _ in range(2))
 
 
-@parametrize('child_backend', BACKENDS)
-@parametrize('parent_backend', BACKENDS)
+@parametrize('child_backend', ['loky'])
+@parametrize('parent_backend', ['multiprocessing'])
 def test_nested_loop(parent_backend, child_backend):
     Parallel(n_jobs=2, backend=parent_backend)(
         delayed(nested_loop)(child_backend) for _ in range(2))

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -257,8 +257,8 @@ def nested_loop(backend):
         delayed(square)(.01) for _ in range(2))
 
 
-@parametrize('child_backend', ['loky'])
-@parametrize('parent_backend', ['multiprocessing'])
+@parametrize('child_backend', BACKENDS)
+@parametrize('parent_backend', BACKENDS)
 def test_nested_loop(parent_backend, child_backend):
     Parallel(n_jobs=2, backend=parent_backend)(
         delayed(nested_loop)(child_backend) for _ in range(2))


### PR DESCRIPTION
 #966 was missing a few `resource_tracker.unregister` when folder deletion was sucessful, leading to `KeyError`/`FileNotFoundError` in the `resource_tracker`.
h/t @ogrisel for the pair debugging.