### PR TITLE
[WIP] Refactor temporary folder handling

### DIFF
--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -451,28 +451,7 @@ def get_memmapping_reducers(
     # self to ensure that this callback won't prevent garbage collection of
     # the pool instance and related file handler resources such as POSIX
     # semaphores and pipes
-    pool_module_name = whichmodule(delete_folder, 'delete_folder')
     resource_tracker.register(pool_folder, "folder")
-
-    def _cleanup():
-        # In some cases the Python runtime seems to set delete_folder to
-        # None just before exiting when accessing the delete_folder
-        # function from the closure namespace. So instead we reimport
-        # the delete_folder function explicitly.
-        # https://github.com/joblib/joblib/issues/328
-        # We cannot just use from 'joblib.pool import delete_folder'
-        # because joblib should only use relative imports to allow
-        # easy vendoring.
-        delete_folder = __import__(
-            pool_module_name, fromlist=['delete_folder']).delete_folder
-        try:
-            if delete_folder(pool_folder, allow_non_empty=True):
-                resource_tracker.unregister(pool_folder, "folder")
-        except OSError:
-            warnings.warn("Failed to clean temporary folder: {}"
-                          .format(pool_folder))
-
-    atexit.register(_cleanup)
 
     if np is not None:
         # Register smart numpy.ndarray reducers that detects memmap backed
@@ -521,8 +500,34 @@ class TemporaryResourcesManagerMixin(object):
             if delete_folder(self._temp_folder,
                              allow_non_empty=allow_non_empty):
                 resource_tracker.unregister(self._temp_folder, "folder")
+
         except OSError:
             # Temporary folder cannot be deleted right now. No need to
             # handle it though, as this folder will be cleaned up by an
             # atexit finalizer registered by the memmapping_reducer.
-            pass
+            pool_module_name = whichmodule(delete_folder, 'delete_folder')
+
+            def _cleanup():
+                # In some cases the Python runtime seems to set
+                # delete_folder to None just before exiting when accessing
+                # the delete_folder function from the closure namespace. So
+                # instead we reimport the delete_folder function
+                # explicitly.  https://github.com/joblib/joblib/issues/328
+                # We cannot just use from 'joblib.pool import
+                # delete_folder' because joblib should only use relative
+                # imports to allow easy vendoring.
+                delete_folder = __import__(
+                    pool_module_name,
+                    fromlist=['delete_folder']).delete_folder
+                try:
+                    if delete_folder(
+                            self._temp_folder, "folder",
+                            allow_non_empty=True):
+                        resource_tracker.unregister(self._temp_folder,
+                                                    "folder")
+                except OSError:
+                    warnings.warn(
+                        "Failed to clean temporary folder: {}".format(
+                            self._temp_folder))
+
+            atexit.register(_cleanup)

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -518,7 +518,8 @@ class TemporaryResourcesManagerMixin(object):
 
     def _try_delete_folder(self, allow_non_empty):
         try:
-            if delete_folder(self._temp_folder, allow_non_empty=allow_non_empty):
+            if delete_folder(self._temp_folder,
+                             allow_non_empty=allow_non_empty):
                 resource_tracker.unregister(self._temp_folder, "folder")
         except OSError:
             # Temporary folder cannot be deleted right now. No need to

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -466,8 +466,8 @@ def get_memmapping_reducers(
         delete_folder = __import__(
             pool_module_name, fromlist=['delete_folder']).delete_folder
         try:
-            delete_folder(pool_folder, allow_non_empty=True)
-            resource_tracker.unregister(pool_folder, "folder")
+            if delete_folder(pool_folder, allow_non_empty=True):
+                resource_tracker.unregister(pool_folder, "folder")
         except OSError:
             warnings.warn("Failed to clean temporary folder: {}"
                           .format(pool_folder))
@@ -518,7 +518,8 @@ class TemporaryResourcesManagerMixin(object):
 
     def _try_delete_folder(self, allow_non_empty):
         try:
-            delete_folder(self._temp_folder, allow_non_empty=allow_non_empty)
+            if delete_folder(self._temp_folder, allow_non_empty=allow_non_empty):
+                resource_tracker.unregister(self._temp_folder, "folder")
         except OSError:
             # Temporary folder cannot be deleted right now. No need to
             # handle it though, as this folder will be cleaned up by an

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -445,7 +445,7 @@ def get_memmapping_reducers(
         if prewarm == "auto":
             prewarm = not use_shared_mem
         forward_reduce_ndarray = ArrayMemmapForwardReducer(
-            max_nbytes, pool_folder, mmap_mode, unlink_on_gc_collect, verbose,
+            max_nbytes, temp_folder, mmap_mode, unlink_on_gc_collect, verbose,
             prewarm=prewarm)
         forward_reducers[np.ndarray] = forward_reduce_ndarray
         forward_reducers[np.memmap] = forward_reduce_ndarray
@@ -457,7 +457,7 @@ def get_memmapping_reducers(
         backward_reducers[np.ndarray] = reduce_array_memmap_backward
         backward_reducers[np.memmap] = reduce_array_memmap_backward
 
-    return forward_reducers, backward_reducers, pool_folder
+    return forward_reducers, backward_reducers
 
 
 class TemporaryResourcesManagerMixin(object):
@@ -471,6 +471,7 @@ class TemporaryResourcesManagerMixin(object):
             os.getpid(), pool_id)
         pool_folder, use_shared_mem = _get_temp_dir(pool_folder_name,
                                                     temp_folder)
+        return pool_folder, use_shared_mem
 
     def _unlink_temporary_resources(self):
         """Unlink temporary resources created by a process-based pool"""

--- a/joblib/disk.py
+++ b/joblib/disk.py
@@ -103,10 +103,13 @@ def rm_subdirs(path, onerror=None):
 
 
 def delete_folder(folder_path, onerror=None, allow_non_empty=True):
-    """Utility function to cleanup a temporary folder if it still exists."""
+    """Utility function to cleanup a temporary folder if it still exists.
+
+    returns True if the folder was succesfully deleted"""
     if os.path.isdir(folder_path):
         if onerror is not None:
             shutil.rmtree(folder_path, False, onerror)
+            return True
         else:
             # allow the rmtree to fail once, wait and re-try.
             # if the error is raised again, fail
@@ -120,7 +123,7 @@ def delete_folder(folder_path, onerror=None, allow_non_empty=True):
                         )
                         util.debug(
                             "Sucessfully deleted {}".format(folder_path))
-                        break
+                        return True
                     else:
                         raise OSError(
                             "Expected empty folder {} but got {} "
@@ -134,3 +137,4 @@ def delete_folder(folder_path, onerror=None, allow_non_empty=True):
                         # yet.
                         raise
                 time.sleep(RM_SUBDIRS_RETRY_TIME)
+    return False

--- a/joblib/disk.py
+++ b/joblib/disk.py
@@ -105,7 +105,10 @@ def rm_subdirs(path, onerror=None):
 def delete_folder(folder_path, onerror=None, allow_non_empty=True):
     """Utility function to cleanup a temporary folder if it still exists.
 
-    returns True if the folder was succesfully deleted"""
+    Returns
+    - True if the folder was succesfully deleted
+    - False if the folder does not exist, or was not deleted
+    """
     if os.path.isdir(folder_path):
         if onerror is not None:
             shutil.rmtree(folder_path, False, onerror)

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -48,11 +48,11 @@ class MemmappingExecutor(
             # new executor has to be created
             id_executor = random.randint(0, int(1e10))
             temp_folder, use_shared_mem = cls.get_temp_dir(
-                executor_args.get('temp_folder'), id_executor
+                backend_args.pop('temp_folder', None), id_executor
             )
             job_reducers, result_reducers = get_memmapping_reducers(
-                id_executor, unlink_on_gc_collect=True,
-                temp_folder=temp_folder, **backend_args)
+                unlink_on_gc_collect=True, temp_folder=temp_folder,
+                **backend_args)
             _executor = super().get_reusable_executor(
                 n_jobs, job_reducers=job_reducers,
                 result_reducers=result_reducers, reuse=reuse, timeout=timeout,

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -33,8 +33,14 @@ def get_memmapping_executor(n_jobs, timeout=300, initializer=None, initargs=(),
     _executor_args = executor_args
 
     id_executor = random.randint(0, int(1e10))
-    job_reducers, result_reducers, temp_folder = get_memmapping_reducers(
-        id_executor, unlink_on_gc_collect=True, **backend_args)
+    temp_folder, use_shared_mem = TemporaryResourcesManagerMixin.get_temp_dir(
+        executor_args.get('temp_folder'), id_executor
+    )
+    job_reducers, result_reducers = get_memmapping_reducers(
+        id_executor, unlink_on_gc_collect=True,
+        temp_folder=temp_folder, use_shared_mem=use_shared_mem,
+        **backend_args
+    )
     _executor = get_reusable_executor(n_jobs, job_reducers=job_reducers,
                                       result_reducers=result_reducers,
                                       reuse=reuse, timeout=timeout,

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -58,14 +58,16 @@ class MemmappingExecutor(
                 result_reducers=result_reducers, reuse=reuse, timeout=timeout,
                 initializer=initializer, initargs=initargs, env=env
             )
-            # patch the executor with its temp folder. The whole temporary
-            # folder configuration would be less awkward if we
+            # The whole temporary folder configuration would be less awkward if
+            # we:
             # - first create the reducers without any info about the temp
             #   folder
             # - then create the executor
             # - then create a temp folder
             # - then "bind" the temp folder to the executor and the reducers.
-            _executor.temp_folder = temp_folder
+            _executor._setup_temp_dir_tracking(
+                temp_folder, delete_folder_upon_gc=True
+            )
             return _executor
 
 
@@ -85,7 +87,7 @@ class _TestingMemmappingExecutor(TemporaryResourcesManagerMixin):
 
     def terminate(self):
         self._executor.shutdown()
-        self._unlink_temporary_resources()
+        self._unlink_temporary_resources(delete_folder=True)
 
     def map(self, f, *args):
         res = self._executor.map(f, *args)

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -11,47 +11,54 @@ copy between the parent and child processes.
 import random
 from ._memmapping_reducer import get_memmapping_reducers
 from ._memmapping_reducer import TemporaryResourcesManagerMixin
-from .externals.loky.reusable_executor import get_reusable_executor
+from .externals.loky.reusable_executor import _ReusablePoolExecutor
 
 
 _executor_args = None
 
 
-def get_memmapping_executor(n_jobs, timeout=300, initializer=None, initargs=(),
-                            env=None, **backend_args):
-    """Factory for ReusableExecutor with automatic memmapping for large numpy
-    arrays.
-    """
-    global _executor_args
-    # Check if we can reuse the executor here instead of deferring the test to
-    # loky as the reducers are objects that changes at each call.
-    executor_args = backend_args.copy()
-    executor_args.update(env if env else {})
-    executor_args.update(dict(
-        timeout=timeout, initializer=initializer, initargs=initargs))
-    reuse = _executor_args is None or _executor_args == executor_args
-    _executor_args = executor_args
+def get_memmapping_executor(n_jobs, **kwargs):
+    return MemmappingExecutor.get_memmapping_executor(n_jobs, **kwargs)
 
-    id_executor = random.randint(0, int(1e10))
-    temp_folder, use_shared_mem = TemporaryResourcesManagerMixin.get_temp_dir(
-        executor_args.get('temp_folder'), id_executor
-    )
-    job_reducers, result_reducers = get_memmapping_reducers(
-        id_executor, unlink_on_gc_collect=True,
-        temp_folder=temp_folder, use_shared_mem=use_shared_mem,
-        **backend_args
-    )
-    _executor = get_reusable_executor(n_jobs, job_reducers=job_reducers,
-                                      result_reducers=result_reducers,
-                                      reuse=reuse, timeout=timeout,
-                                      initializer=initializer,
-                                      initargs=initargs, env=env)
-    # If executor doesn't have a _temp_folder, it means it is a new executor
-    # and the reducers have not been used. Else, the previous reducers are used
-    # and we should not change this attribute.
-    if not hasattr(_executor, "_temp_folder"):
-        _executor._temp_folder = temp_folder
-    return _executor
+
+class MemmappingExecutor(
+        _ReusablePoolExecutor, TemporaryResourcesManagerMixin
+):
+
+    @classmethod
+    def get_memmapping_executor(cls, n_jobs, timeout=300, initializer=None,
+                                initargs=(), env=None, **backend_args):
+        """Factory for ReusableExecutor with automatic memmapping for large numpy
+        arrays.
+        """
+        global _executor_args
+        executor_args = backend_args.copy()
+        executor_args.update(env if env else {})
+        executor_args.update(dict(
+            timeout=timeout, initializer=initializer, initargs=initargs))
+        reuse = _executor_args is None or _executor_args == executor_args
+        _executor_args = executor_args
+
+        id_executor = random.randint(0, int(1e10))
+        temp_folder, use_shared_mem = self.get_temp_dir(
+            executor_args.get('temp_folder'), id_executor
+        )
+        job_reducers, result_reducers = get_memmapping_reducers(
+            id_executor, unlink_on_gc_collect=True,
+            temp_folder=temp_folder, use_shared_mem=use_shared_mem,
+            **backend_args
+        )
+        _executor = super().get_reusable_executor(
+            n_jobs, job_reducers=job_reducers, result_reducers=result_reducers,
+            reuse=reuse, timeout=timeout, initializer=initializer,
+            initargs=initargs, env=env
+        )
+        # If executor doesn't have a _temp_folder, it means it is a new executor
+        # and the reducers have not been used. Else, the previous reducers are used
+        # and we should not change this attribute.
+        if not hasattr(_executor, "_temp_folder"):
+            _executor._temp_folder = temp_folder
+        return _executor
 
 
 class _TestingMemmappingExecutor(TemporaryResourcesManagerMixin):

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -36,7 +36,7 @@ class MemmappingExecutor(
         executor_args.update(env if env else {})
         executor_args.update(dict(
             timeout=timeout, initializer=initializer, initargs=initargs))
-        reuse = _executor_args is None or _executor_args == executor_args
+        reuse = _executor_args == executor_args
         _executor_args = executor_args
         if reuse:
             return super().get_reusable_executor(

--- a/joblib/externals/loky/__init__.py
+++ b/joblib/externals/loky/__init__.py
@@ -22,4 +22,4 @@ __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "wrap_non_picklable_objects", "set_loky_pickler"]
 
 
-__version__ = '2.7.0'
+__version__ = '3.0.0dev0'

--- a/joblib/externals/loky/reusable_executor.py
+++ b/joblib/externals/loky/reusable_executor.py
@@ -81,65 +81,12 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
     in the children before any module is loaded. This only works with with the
     ``loky`` context and it is unreliable on Windows with Python < 3.6.
     """
-    with _executor_lock:
-        global _executor, _executor_kwargs
-        executor = _executor
-
-        if max_workers is None:
-            if reuse is True and executor is not None:
-                max_workers = executor._max_workers
-            else:
-                max_workers = cpu_count()
-        elif max_workers <= 0:
-            raise ValueError(
-                "max_workers must be greater than 0, got {}."
-                .format(max_workers))
-
-        if isinstance(context, STRING_TYPE):
-            context = get_context(context)
-        if context is not None and context.get_start_method() == "fork":
-            raise ValueError("Cannot use reusable executor with the 'fork' "
-                             "context")
-
-        kwargs = dict(context=context, timeout=timeout,
-                      job_reducers=job_reducers,
-                      result_reducers=result_reducers,
-                      initializer=initializer, initargs=initargs,
-                      env=env)
-        if executor is None:
-            mp.util.debug("Create a executor with max_workers={}."
-                          .format(max_workers))
-            executor_id = _get_next_executor_id()
-            _executor_kwargs = kwargs
-            _executor = executor = _ReusablePoolExecutor(
-                _executor_lock, max_workers=max_workers,
-                executor_id=executor_id, **kwargs)
-        else:
-            if reuse == 'auto':
-                reuse = kwargs == _executor_kwargs
-            if (executor._flags.broken or executor._flags.shutdown
-                    or not reuse):
-                if executor._flags.broken:
-                    reason = "broken"
-                elif executor._flags.shutdown:
-                    reason = "shutdown"
-                else:
-                    reason = "arguments have changed"
-                mp.util.debug(
-                    "Creating a new executor with max_workers={} as the "
-                    "previous instance cannot be reused ({})."
-                    .format(max_workers, reason))
-                executor.shutdown(wait=True, kill_workers=kill_workers)
-                _executor = executor = _executor_kwargs = None
-                # Recursive call to build a new instance
-                return get_reusable_executor(max_workers=max_workers,
-                                             **kwargs)
-            else:
-                mp.util.debug("Reusing existing executor with max_workers={}."
-                              .format(executor._max_workers))
-                executor._resize(max_workers)
-
-    return executor
+    return _ReusablePoolExecutor.get_current_executor(
+        max_workers=max_workers, context=context, timeout=timeout,
+        kill_workers=kill_workers, reuse=reuse, job_reducers=job_reducers,
+        result_reducers=result_reducers, initializer=initializer,
+        initargs=initargs, env=env
+    )
 
 
 class _ReusablePoolExecutor(ProcessPoolExecutor):
@@ -153,6 +100,73 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
             initializer=initializer, initargs=initargs, env=env)
         self.executor_id = executor_id
         self._submit_resize_lock = submit_resize_lock
+
+    @classmethod
+    def get_current_executor(cls, max_workers=None, context=None, timeout=10,
+                             kill_workers=False, reuse="auto",
+                             job_reducers=None, result_reducers=None,
+                             initializer=None, initargs=(), env=None):
+        with _executor_lock:
+            global _executor, _executor_kwargs
+            executor = _executor
+
+            if max_workers is None:
+                if reuse is True and executor is not None:
+                    max_workers = executor._max_workers
+                else:
+                    max_workers = cpu_count()
+            elif max_workers <= 0:
+                raise ValueError(
+                    "max_workers must be greater than 0, got {}."
+                    .format(max_workers))
+
+            if isinstance(context, STRING_TYPE):
+                context = get_context(context)
+            if context is not None and context.get_start_method() == "fork":
+                raise ValueError("Cannot use reusable executor with the 'fork' "
+                                 "context")
+
+            kwargs = dict(context=context, timeout=timeout,
+                          job_reducers=job_reducers,
+                          result_reducers=result_reducers,
+                          initializer=initializer, initargs=initargs,
+                          env=env)
+            if executor is None:
+                mp.util.debug("Create a executor with max_workers={}."
+                              .format(max_workers))
+                executor_id = _get_next_executor_id()
+                _executor_kwargs = kwargs
+                _executor = executor = cls(
+                    _executor_lock, max_workers=max_workers,
+                    executor_id=executor_id, **kwargs)
+            else:
+                if reuse == 'auto':
+                    reuse = kwargs == _executor_kwargs
+                if (executor._flags.broken or executor._flags.shutdown
+                        or not reuse):
+                    if executor._flags.broken:
+                        reason = "broken"
+                    elif executor._flags.shutdown:
+                        reason = "shutdown"
+                    else:
+                        reason = "arguments have changed"
+                    mp.util.debug(
+                        "Creating a new executor with max_workers={} as the "
+                        "previous instance cannot be reused ({})."
+                        .format(max_workers, reason))
+                    executor.shutdown(wait=True, kill_workers=kill_workers)
+                    _executor = executor = _executor_kwargs = None
+                    # Recursive call to build a new instance
+                    return cls.get_current_executor(max_workers=max_workers,
+                                                    **kwargs)
+                else:
+                    mp.util.debug(
+                        "Reusing existing executor with max_workers={}."
+                        .format(executor._max_workers)
+                    )
+                    executor._resize(max_workers)
+
+        return executor
 
     def submit(self, fn, *args, **kwargs):
         with self._submit_resize_lock:

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -296,11 +296,11 @@ class MemmappingPool(PicklingPool, TemporaryResourcesManagerMixin):
                           ' 0.9.4 and will be removed in 0.11',
                           DeprecationWarning)
 
-        self._temp_folder, use_shared_mem = self.get_temp_dir(
+        temp_folder, use_shared_mem = self.get_temp_dir(
             temp_folder, id(self)
         )
         forward_reducers, backward_reducers = get_memmapping_reducers(
-            temp_folder=self._temp_folder, max_nbytes=max_nbytes,
+            temp_folder=temp_folder, max_nbytes=max_nbytes,
             mmap_mode=mmap_mode, forward_reducers=forward_reducers,
             backward_reducers=backward_reducers, verbose=verbose,
             unlink_on_gc_collect=False, prewarm=prewarm,
@@ -312,6 +312,9 @@ class MemmappingPool(PicklingPool, TemporaryResourcesManagerMixin):
             backward_reducers=backward_reducers)
         poolargs.update(kwargs)
         super(MemmappingPool, self).__init__(**poolargs)
+        # multiprocessing pools are not meant to be reused, their folder is
+        # deleted upon when the pool ``terminate()``s
+        self._setup_temp_dir_tracking(temp_folder, delete_folder_upon_gc=False)
 
     def terminate(self):
         n_retries = 10
@@ -327,4 +330,4 @@ class MemmappingPool(PicklingPool, TemporaryResourcesManagerMixin):
                     if i + 1 == n_retries:
                         warnings.warn("Failed to terminate worker processes in"
                                       " multiprocessing pool: %r" % e)
-        self._unlink_temporary_resources()
+        self._unlink_temporary_resources(delete_folder=True)

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -300,7 +300,7 @@ class MemmappingPool(PicklingPool, TemporaryResourcesManagerMixin):
             temp_folder, id(self)
         )
         forward_reducers, backward_reducers = get_memmapping_reducers(
-            id(self), temp_folder=self._temp_folder, max_nbytes=max_nbytes,
+            temp_folder=self._temp_folder, max_nbytes=max_nbytes,
             mmap_mode=mmap_mode, forward_reducers=forward_reducers,
             backward_reducers=backward_reducers, verbose=verbose,
             unlink_on_gc_collect=False, prewarm=prewarm,

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -296,12 +296,15 @@ class MemmappingPool(PicklingPool, TemporaryResourcesManagerMixin):
                           ' 0.9.4 and will be removed in 0.11',
                           DeprecationWarning)
 
-        forward_reducers, backward_reducers, self._temp_folder = \
-            get_memmapping_reducers(
-                id(self), temp_folder=temp_folder, max_nbytes=max_nbytes,
-                mmap_mode=mmap_mode, forward_reducers=forward_reducers,
-                backward_reducers=backward_reducers, verbose=verbose,
-                unlink_on_gc_collect=False, prewarm=prewarm)
+        self._temp_folder, use_shared_mem = self.get_temp_dir(
+            temp_folder, id(self)
+        )
+        forward_reducers, backward_reducers = get_memmapping_reducers(
+            id(self), temp_folder=self._temp_folder, max_nbytes=max_nbytes,
+            mmap_mode=mmap_mode, forward_reducers=forward_reducers,
+            backward_reducers=backward_reducers, verbose=verbose,
+            unlink_on_gc_collect=False, prewarm=prewarm,
+            use_shared_mem=use_shared_mem)
 
         poolargs = dict(
             processes=processes,

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -528,7 +528,7 @@ def test_child_raises_parent_exits_cleanly(backend):
 
         def get_temp_folder(parallel_obj, backend):
             if "{b}" == "loky":
-                return p._backend._temp_folder
+                return p._backend._workers._temp_folder
             else:
                 return p._backend._pool._temp_folder
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -257,8 +257,8 @@ def nested_loop(backend):
         delayed(square)(.01) for _ in range(2))
 
 
-@parametrize('child_backend', BACKENDS)
-@parametrize('parent_backend', BACKENDS)
+@parametrize('child_backend', ['loky'])
+@parametrize('parent_backend', ['multiprocessing'])
 def test_nested_loop(parent_backend, child_backend):
     Parallel(n_jobs=2, backend=parent_backend)(
         delayed(nested_loop)(child_backend) for _ in range(2))

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -257,8 +257,8 @@ def nested_loop(backend):
         delayed(square)(.01) for _ in range(2))
 
 
-@parametrize('child_backend', ['loky'])
-@parametrize('parent_backend', ['multiprocessing'])
+@parametrize('child_backend', BACKENDS)
+@parametrize('parent_backend', BACKENDS)
 def test_nested_loop(parent_backend, child_backend):
     Parallel(n_jobs=2, backend=parent_backend)(
         delayed(nested_loop)(child_backend) for _ in range(2))


### PR DESCRIPTION
follow up on #966, the design can still be improved.

In particular, 

- there is an asymetry in how the pools were subclassed: until this PR, we could not subclass `loky` Executor, while we could subclass `multiprocessing` pools. This made the implementation akward, and this PR should fix this

- I am realizing that the reusablity property of `loky`'s executor are confliciting with the current memmap collection logic. In particular, temporary folders (and `memmaps` names) are reused between `Parallel` calls. This is prone to race conditions as, at the start of a new `Parallel` call, when the reducer kicks in, the previous `memmap` can still be there if the `resource_tracker` is late, but it might then be deleted prior to the child loading the memmap, creating a pickling error in the parent. This is a hard problem, because to solve this, we have to be able to know which `Parallel` call is invoking the `reducer`.  

- There also seems to be from time to time `KeyErrors`/`FileNotFound` errors, mostly due to race conditions between folder deletion and `memmap` deletions. 
  - My guess is that it comes from calls 
like [this one](https://github.com/joblib/joblib/blob/e959a01e9f0c160e9e89f6892928d755d02f2065/joblib/_memmapping_reducer.py#L534), that is not well synchronized with the `resource_tracker`. This mis-synchronization can result in an extra `maybe_unlink` call, and a corresponding `KeyError` will happen in the `resource_tracker`.
  - We also mentioned race conditions happening when the `atexit` `_cleanup` finalizer deletes the temporary folder before the `resource_tracker` processes all the `register/maybe_unlink` precedent commands (generating a `FileNotFound` error). The easiest solution may simply be to delete temporary folder during interpreter shutdown. It will require some rewrites of the tests though.

- I also want to  disantangle temporary folder creation with reducer creation, as they should be (disantangled)


### TODO LIST

- [x] make `ReusablePoolExecutor` subclassable in `loky`, and vendor the new feature in `loky`
- [x] disantangle folder creation/preparation and reducers
- [ ] find a clean solution for the race conditions discussed above.

cc @ogrisel in case you have something to add (I'm still iterating on this post/roadmap)