### PR TITLE
Fix reuse with bad type

### DIFF
--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -36,7 +36,7 @@ class MemmappingExecutor(_ReusablePoolExecutor):
         executor_args.update(env if env else {})
         executor_args.update(dict(
             timeout=timeout, initializer=initializer, initargs=initargs))
-        reuse = _executor_args is None or _executor_args == executor_args
+        reuse = _executor_args == executor_args
         _executor_args = executor_args
 
         manager = TemporaryResourcesManager(temp_folder)

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -19,6 +19,7 @@ from joblib.backports import make_memmap
 from joblib.parallel import Parallel, delayed
 
 from joblib.pool import MemmappingPool
+from joblib.executor import _ReusablePoolExecutor
 from joblib.executor import _TestingMemmappingExecutor as TestExecutor
 from joblib._memmapping_reducer import has_shareable_memory
 from joblib._memmapping_reducer import ArrayMemmapForwardReducer
@@ -1160,3 +1161,23 @@ def test_direct_mmap(tmpdir):
 
     results = Parallel(n_jobs=2)(delayed(worker)() for _ in range(1))
     np.testing.assert_array_equal(results[0], arr)
+
+
+@with_multiprocessing
+def test_correct_executor_type_in_reuse():
+    # Make sure we get the correct executor type when reusing it.
+    ex1, is_reused = _ReusablePoolExecutor.get_reusable_executor(2)
+    assert not is_reused
+
+    ex2 = TestExecutor.get_memmapping_executor(2)
+    assert isinstance(ex2, TestExecutor)  # wrong type
+    assert ex1._flags.shutdown
+
+    ex3, is_reused = _ReusablePoolExecutor.get_reusable_executor(
+        2, reuse=False
+    )
+    assert not is_reused
+
+    ex4 = TestExecutor.get_memmapping_executor(2)
+    assert isinstance(ex4, TestExecutor)  # wrong type
+    assert ex3._flags.shutdown


### PR DESCRIPTION
As mentionned by @arquolo in #1047 , the API of `_ReusablePoolExecutor.get_reusable_executor` can return an `executor` with an incorrect type. This is a small fix and a test for this.
The underlying problem is from joblib/loky#253. As we now allow to subclass the executor, we need a way to make sure the reused executor is actually of the proper class. I see two solutions:

- We force `reuse = False` if the current class is differente from the class of the global `_reusable_executor`. This is easy to implement but this means we cannot have 2 reusable executors with different classes. I would say it is fine but not sure either.

- We have a per-class singleton executor. This is a bit more work but would solve this in a clean way.