### PR TITLE
Fix a bad interation with dask.distributed pickle cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ In development
   properly batch short tasks.
   https://github.com/joblib/joblib/pull/1062
 
+- Fix a problem in the way the joblib dask backend batches calls that would
+  badly interact with the dask callable pickling cache and lead to wrong
+  results or errors.
+  https://github.com/joblib/joblib/pull/1055
+
 Release 0.15.1
 --------------
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,9 +39,11 @@ jobs:
         LOKY_MAX_CPU_COUNT: "2"
 
       linux_py38:
+        # To be updated regularly to use the most recent versions of the
+        # dependencies.
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.8"
-        EXTRA_CONDA_PACKAGES: "numpy=1.18"
+        EXTRA_CONDA_PACKAGES: "numpy=1.18 distributed=2.18"
       linux_py37_sklearn_tests:
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.7"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
         # dependencies.
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.8"
-        EXTRA_CONDA_PACKAGES: "numpy=1.18 distributed=2.18"
+        EXTRA_CONDA_PACKAGES: "numpy=1.18 distributed=2.17"
       linux_py37_sklearn_tests:
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.7"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
         PYTHON_VERSION: "pypy3"
         LOKY_MAX_CPU_COUNT: "2"
 
-      linux_py38:
+      linux_py38_distributed:
         # To be updated regularly to use the most recent versions of the
         # dependencies.
         imageName: 'ubuntu-latest'

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -103,7 +103,7 @@ class Batch(object):
         # Ensure each batch is serialized into a unique bytes string.  This is
         # necessary to prevent distributed to load Batch objects from its
         # function cache.
-        self.__uuid = uuid4().hex
+        self._uuid = uuid4().hex
 
     def __call__(self, *data, **kwargs):
         results = []

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -124,9 +124,9 @@ class Batch:
         return results
 
     def __repr__(self):
-        descr = f"batch-of-{self._funcname}-{self._num_tasks}-calls"
+        descr = f"batch_of_{self._funcname}_{self._num_tasks}_calls"
         if self._mixed:
-            descr = "mixed-" + descr
+            descr = "mixed_" + descr
         return descr
 
 

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -126,7 +126,7 @@ class Batch:
     def __repr__(self):
         descr = f"batch-of-{self._funcname}-{self._num_tasks}-calls"
         if self._mixed:
-            descr += "-mixed"
+            descr = "mixed-" + descr
         return descr
 
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -259,7 +259,7 @@ class BatchedCalls(object):
         return (
             BatchedCalls,
             (self.items, (self._backend, self._n_jobs), None,
-             self._pickle_cache, self._uuid)
+             self._pickle_cache)
         )
 
     def __len__(self):

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -233,7 +233,7 @@ class BatchedCalls(object):
     """Wrap a sequence of (func, args, kwargs) tuples as a single callable"""
 
     def __init__(self, iterator_slice, backend_and_jobs, reducer_callback=None,
-                 pickle_cache=None, uuid=None):
+                 pickle_cache=None):
         self.items = list(iterator_slice)
         self._size = len(self.items)
         self._reducer_callback = reducer_callback

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -233,7 +233,7 @@ class BatchedCalls(object):
     """Wrap a sequence of (func, args, kwargs) tuples as a single callable"""
 
     def __init__(self, iterator_slice, backend_and_jobs, reducer_callback=None,
-                 pickle_cache=None):
+                 pickle_cache=None, uuid=None):
         self.items = list(iterator_slice)
         self._size = len(self.items)
         self._reducer_callback = reducer_callback
@@ -248,7 +248,10 @@ class BatchedCalls(object):
         # Ensure each batch is serialized into a unique bytes string.  This is
         # necessary to prevent distributed to load BatchedCalls objects from
         # its function cache.
-        self.__uuid = uuid4().hex
+        if uuid is None:
+            self._uuid = uuid4().hex
+        else:
+            self._uuid = uuid
 
     def __call__(self):
         # Set the default nested backend to self._backend but do not set the
@@ -264,7 +267,7 @@ class BatchedCalls(object):
         return (
             BatchedCalls,
             (self.items, (self._backend, self._n_jobs), None,
-             self._pickle_cache)
+             self._pickle_cache, self._uuid)
         )
 
     def __len__(self):

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -245,14 +245,6 @@ class BatchedCalls(object):
             self._backend, self._n_jobs = backend_and_jobs, None
         self._pickle_cache = pickle_cache if pickle_cache is not None else {}
 
-        # Ensure each batch is serialized into a unique bytes string.  This is
-        # necessary to prevent distributed to load BatchedCalls objects from
-        # its function cache.
-        if uuid is None:
-            self._uuid = uuid4().hex
-        else:
-            self._uuid = uuid
-
     def __call__(self):
         # Set the default nested backend to self._backend but do not set the
         # change the default number of processes to -1

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -16,7 +16,6 @@ import threading
 import itertools
 from uuid import uuid4
 from numbers import Integral
-from uuid import uuid4
 import warnings
 import queue
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -16,6 +16,7 @@ import threading
 import itertools
 from uuid import uuid4
 from numbers import Integral
+from uuid import uuid4
 import warnings
 import queue
 
@@ -244,6 +245,11 @@ class BatchedCalls(object):
             # nested backends were returned without n_jobs indications.
             self._backend, self._n_jobs = backend_and_jobs, None
         self._pickle_cache = pickle_cache if pickle_cache is not None else {}
+
+        # Ensure each batch is serialized into a unique bytes string.  This is
+        # necessary to prevent distributed to load BatchedCalls objects from
+        # its function cache.
+        self.__uuid = uuid4().hex
 
     def __call__(self):
         # Set the default nested backend to self._backend but do not set the

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -126,7 +126,8 @@ def test_no_undesired_distributed_cache_hit(loop):
             res = Parallel()(delayed(isolated_operation)(l) for l in lists)
 
         # Here we do not pass any large numpy array as argument to
-        # isolated_operation so no scattering event should happen under the hood.
+        # isolated_operation so no scattering event should happen under the
+        # hood.
         counts = count_events('receive-from-scatter', client)
         assert sum(counts.values()) == 0
         assert all([len(r) == 1 for r in res])

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -98,6 +98,23 @@ def test_dask_funcname(loop):
             assert all(tup[0].startswith('inc-batch') for tup in log)
 
 
+def test_batch_repr(loop):
+    from joblib._dask import _make_tasks_summary, Batch
+
+    # batch with a single function being called on multiple arguments
+    single_func_tasks = [delayed(id)(i) for i in range(10)]
+    repr_ = 'Batch of <built-in function id> (10 function calls)'
+    assert _make_tasks_summary(single_func_tasks) == repr_
+    assert repr(Batch(_make_tasks_summary(single_func_tasks))) == repr_
+
+    # batch with several different functions being called
+    multiple_funcs_tasks = [
+        delayed(id)(i) if i < 5 else delayed(abs)(i) for i in range(10)
+    ]
+    repr_ = 'Mixed batch containing <built-in function id> (10 function calls)'
+    assert repr(Batch(_make_tasks_summary(multiple_funcs_tasks))) == repr_
+
+
 def test_no_undesired_distributed_cache_hit(loop):
     # Dask has a pickle cache for callables that are called many times. Because
     # the dask backends used to wrapp both the functions and the arguments

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -91,12 +91,12 @@ def test_dask_funcname(loop, mixed):
     from joblib._dask import Batch
     if not mixed:
         tasks = [delayed(inc)(i) for i in range(4)]
-        batch_repr = 'batch-of-inc-4-calls'
+        batch_repr = 'batch_of_inc_4_calls'
     else:
         tasks = [
             delayed(abs)(i) if i % 2 else delayed(inc)(i) for i in range(4)
         ]
-        batch_repr = 'mixed-batch-of-inc-4-calls'
+        batch_repr = 'mixed_batch_of_inc_4_calls'
 
     assert repr(Batch(tasks)) == batch_repr
 
@@ -109,7 +109,7 @@ def test_dask_funcname(loop, mixed):
                 return list(dask_scheduler.transition_log)
             batch_repr = batch_repr.replace('4', '2')
             log = client.run_on_scheduler(f)
-            assert all('batch-of-inc' in tup[0] for tup in log)
+            assert all('batch_of_inc' in tup[0] for tup in log)
 
 
 def test_no_undesired_distributed_cache_hit(loop):

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -96,7 +96,7 @@ def test_dask_funcname(loop, mixed):
         tasks = [
             delayed(abs)(i) if i % 2 else delayed(inc)(i) for i in range(4)
         ]
-        batch_repr = 'batch-of-inc-4-calls-mixed'
+        batch_repr = 'mixed-batch-of-inc-4-calls'
 
     assert repr(Batch(tasks)) == batch_repr
 
@@ -109,7 +109,7 @@ def test_dask_funcname(loop, mixed):
                 return list(dask_scheduler.transition_log)
             batch_repr = batch_repr.replace('4', '2')
             log = client.run_on_scheduler(f)
-            assert all(tup[0].startswith('batch-of-inc') for tup in log)
+            assert all('batch-of-inc' in tup[0] for tup in log)
 
 
 def test_no_undesired_distributed_cache_hit(loop):

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -173,7 +173,7 @@ def test_manual_scatter(loop):
     # Scattered variables only serialized once
     assert x.count == 1
     assert y.count == 1
-    assert z.count == 4
+    assert z.count == 6
 
 
 def test_auto_scatter(loop):

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -78,21 +78,6 @@ def add5(a, b, c, d=0, e=0):
     return a + b + c + d + e
 
 
-class CountSerialized(object):
-    def __init__(self, x):
-        self.x = x
-        self.count = 0
-
-    def __add__(self, other):
-        return self.x + getattr(other, 'x', other)
-
-    __radd__ = __add__
-
-    def __reduce__(self):
-        self.count += 1
-        return (CountSerialized, (self.x,))
-
-
 def test_no_undesired_distributed_cache_hit(loop):
     # When a user asks a joblib to run f(a) under the dask backend, joblib
     # submits to dask a BatchCalls/Batch with a __call__(self) instance that
@@ -146,6 +131,21 @@ def test_no_undesired_distributed_cache_hit(loop):
     finally:
         client.close()
         cluster.close()
+
+
+class CountSerialized(object):
+    def __init__(self, x):
+        self.x = x
+        self.count = 0
+
+    def __add__(self, other):
+        return self.x + getattr(other, 'x', other)
+
+    __radd__ = __add__
+
+    def __reduce__(self):
+        self.count += 1
+        return (CountSerialized, (self.x,))
 
 
 def test_manual_scatter(loop):

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -112,9 +112,9 @@ def test_no_undesired_distributed_cache_hit(loop):
     np = pytest.importorskip('numpy')
     X = np.arange(int(1e5))
 
-    def isolated_operation(l, X=None):
-        l.append(uuid4().hex)
-        return l
+    def isolated_operation(list_, X=None):
+        list_.append(uuid4().hex)
+        return list_
 
     # Both joblib.parallel.BatchedCalls and joblib._dask.Batch must miss the
     # distributed cache.

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -123,7 +123,8 @@ def test_no_undesired_distributed_cache_hit(loop):
     try:
         with parallel_backend('dask') as (ba, _):
             # dispatches joblib.parallel.BatchedCalls
-            res = Parallel()(delayed(isolated_operation)(l) for l in lists)
+            res = Parallel()(delayed(isolated_operation)(
+                list_) for list_ in lists)
 
         # Here we do not pass any large numpy array as argument to
         # isolated_operation so no scattering event should happen under the
@@ -136,7 +137,7 @@ def test_no_undesired_distributed_cache_hit(loop):
             # Append a large array which will be scattered by dask, and
             # dispatch joblib._dask.Batch
             res = Parallel()(
-                delayed(isolated_operation)(l, X=X) for l in lists
+                delayed(isolated_operation)(list_, X=X) for list_ in lists
             )
 
         counts = count_events('receive-from-scatter', client)

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -125,6 +125,8 @@ def test_no_undesired_distributed_cache_hit(loop):
             # dispatches joblib.parallel.BatchedCalls
             res = Parallel()(delayed(isolated_operation)(l) for l in lists)
 
+        # Here we do not pass any large numpy array as argument to
+        # isolated_operation so no scattering event should happen under the hood.
         counts = count_events('receive-from-scatter', client)
         assert sum(counts.values()) == 0
         assert all([len(r) == 1 for r in res])

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -530,6 +530,7 @@ def nested_function_outer(i):
 
 @with_multiprocessing
 @parametrize('backend', PARALLEL_BACKENDS)
+@pytest.mark.xfail(reason="https://github.com/joblib/loky/pull/255")
 def test_nested_exception_dispatch(backend):
     """Ensure errors for nested joblib cases gets propagated
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -31,6 +31,7 @@ from joblib.test.common import with_multiprocessing
 from joblib.testing import (parametrize, raises, check_subprocess_call,
                             skipif, SkipTest, warns)
 
+from joblib.externals.loky.process_executor import TerminatedWorkerError
 
 from queue import Queue
 
@@ -1469,8 +1470,18 @@ def test_thread_bomb_mitigation(backend):
     # saturating the operating system resources by creating a unbounded number
     # of threads.
     with parallel_backend(backend, n_jobs=2):
-        with raises(RecursionError):
+        with raises(BaseException) as excinfo:
             _recursive_parallel()
+    exc = excinfo.value
+    if backend == "loky" and isinstance(exc, TerminatedWorkerError):
+        # The recursion exception can itself cause an error when pickling it to
+        # be send back to the parent process. In this case the worker crashes
+        # but the original traceback is still printed on stderr. This could be
+        # improved but does not seem simple to do and this is is not critical
+        # for users (as long as there is no process or thread bomb happening).
+        pytest.xfail("Loky worker crash when serializing RecursionError")
+    else:
+        assert isinstance(exc, RecursionError)
 
 
 def _run_parallel_sum():


### PR DESCRIPTION
`joblib.Parallel` objects submit stateful callables to `dask`'s scheduler, which seems goes against `dask`'s assumption, which is that one should submit [pure functions](https://en.wikipedia.org/wiki/Pure_function).

Because of this assumption, `dask` sets up a pickle cache in the workers when deserializing submitted functions. This does not cause any harm in the pure function setting, but it does when one submits two *different* (e.g different id in the original interpreter), **stateful** callables with the same pickle bytes representation. In this situation, when deserializing the second callable, the pickle cache is hit, and the deserialized objects points to the first callable. This results in the first callable's state being mutated concurrently, and yields cryptic errors, especially when the callable is something like `sklearn` 's `BaseEstimator.fit`.

~This PR fixes this by ensuring each `joblib` callable sent to `dask` has a unique bytes representation~
After discussion with @ogrisel, we decided to fix this issue by making the `Batch` object stateless.

Related issues: #959, dask/distributed#3733