### PR TITLE
MNT Replaces tostring with tobytes

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -100,7 +100,7 @@ class NumpyArrayWrapper(object):
                                                   'zerosize_ok'],
                                            buffersize=buffersize,
                                            order=self.order):
-                pickler.file_handle.write(chunk.tostring('C'))
+                pickler.file_handle.write(chunk.tobytes('C'))
 
     def read_array(self, unpickler):
         """Read array from unpickler file handle.

--- a/joblib/numpy_pickle_compat.py
+++ b/joblib/numpy_pickle_compat.py
@@ -126,7 +126,7 @@ class ZNDArrayWrapper(NDArrayWrapper):
     retrieve it.
     The reason that we store the raw buffer data of the array and
     the meta information, rather than array representation routine
-    (tostring) is that it enables us to use completely the strided
+    (tobytes) is that it enables us to use completely the strided
     model to avoid memory copies (a and a.T store as fast). In
     addition saving the heavy information separately can avoid
     creating large temporary buffers when unpickling data with

--- a/joblib/test/data/create_numpy_pickle.py
+++ b/joblib/test/data/create_numpy_pickle.py
@@ -86,9 +86,6 @@ if __name__ == '__main__':
                  np.arange(5, dtype=np.dtype('<f8')),
                  np.array([1, 'abc', {'a': 1, 'b': 2}], dtype='O'),
                  # all possible bytes as a byte string
-                 # .tobytes actually returns bytes and is a
-                 # compatibility alias for .tobytes which was
-                 # added in 1.9.0
                  np.arange(256, dtype=np.uint8).tobytes(),
                  np.matrix([0, 1, 2], dtype=np.dtype('<i8')),
                  # unicode string with non-ascii chars

--- a/joblib/test/data/create_numpy_pickle.py
+++ b/joblib/test/data/create_numpy_pickle.py
@@ -86,10 +86,10 @@ if __name__ == '__main__':
                  np.arange(5, dtype=np.dtype('<f8')),
                  np.array([1, 'abc', {'a': 1, 'b': 2}], dtype='O'),
                  # all possible bytes as a byte string
-                 # .tostring actually returns bytes and is a
+                 # .tobytes actually returns bytes and is a
                  # compatibility alias for .tobytes which was
                  # added in 1.9.0
-                 np.arange(256, dtype=np.uint8).tostring(),
+                 np.arange(256, dtype=np.uint8).tobytes(),
                  np.matrix([0, 1, 2], dtype=np.dtype('<i8')),
                  # unicode string with non-ascii chars
                  u"C'est l'\xe9t\xe9 !"]

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -340,9 +340,6 @@ def test_compressed_pickle_dump_and_load(tmpdir):
                      np.arange(5, dtype=np.dtype('<f8')),
                      np.arange(5, dtype=np.dtype('>f8')),
                      np.array([1, 'abc', {'a': 1, 'b': 2}], dtype='O'),
-                     # .tobytes actually returns bytes and is a
-                     # compatibility alias for .tobytes which was
-                     # added in 1.9.0
                      np.arange(256, dtype=np.uint8).tobytes(),
                      # np.matrix is a subclass of np.ndarray, here we want
                      # to verify this type of object is correctly unpickled
@@ -436,9 +433,6 @@ def test_joblib_pickle_across_python_versions():
     expected_list = [np.arange(5, dtype=np.dtype('<i8')),
                      np.arange(5, dtype=np.dtype('<f8')),
                      np.array([1, 'abc', {'a': 1, 'b': 2}], dtype='O'),
-                     # .tobytes actually returns bytes and is a
-                     # compatibility alias for .tobytes which was
-                     # added in 1.9.0
                      np.arange(256, dtype=np.uint8).tobytes(),
                      # np.matrix is a subclass of np.ndarray, here we want
                      # to verify this type of object is correctly unpickled

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -340,10 +340,10 @@ def test_compressed_pickle_dump_and_load(tmpdir):
                      np.arange(5, dtype=np.dtype('<f8')),
                      np.arange(5, dtype=np.dtype('>f8')),
                      np.array([1, 'abc', {'a': 1, 'b': 2}], dtype='O'),
-                     # .tostring actually returns bytes and is a
+                     # .tobytes actually returns bytes and is a
                      # compatibility alias for .tobytes which was
                      # added in 1.9.0
-                     np.arange(256, dtype=np.uint8).tostring(),
+                     np.arange(256, dtype=np.uint8).tobytes(),
                      # np.matrix is a subclass of np.ndarray, here we want
                      # to verify this type of object is correctly unpickled
                      # among versions.
@@ -436,10 +436,10 @@ def test_joblib_pickle_across_python_versions():
     expected_list = [np.arange(5, dtype=np.dtype('<i8')),
                      np.arange(5, dtype=np.dtype('<f8')),
                      np.array([1, 'abc', {'a': 1, 'b': 2}], dtype='O'),
-                     # .tostring actually returns bytes and is a
+                     # .tobytes actually returns bytes and is a
                      # compatibility alias for .tobytes which was
                      # added in 1.9.0
-                     np.arange(256, dtype=np.uint8).tostring(),
+                     np.arange(256, dtype=np.uint8).tobytes(),
                      # np.matrix is a subclass of np.ndarray, here we want
                      # to verify this type of object is correctly unpickled
                      # among versions.


### PR DESCRIPTION
`tostring` is [deprecated](https://numpy.org/devdocs/reference/generated/numpy.ndarray.tostring.html#numpy.ndarray.tostring). This PR replaces `tostring` with `tobytes`.