### PR TITLE
[MRG] Don't scatter data inside dask workers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ In development
   results or errors.
   https://github.com/joblib/joblib/pull/1055
 
+- Prevent a dask.distributed bug from surfacing in joblib's dask backend
+  during nested Parallel calls (due to joblib's auto-scattering feature)
+  https://github.com/joblib/joblib/pull/1061
+
 Release 0.15.1
 --------------
 

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -279,7 +279,7 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
                             # concurrently.
                             # set hash=False - nested scatter calls (i.e
                             # calling client.scatter inside a dask worker)
-                            # using hash=True often raises CancelledError,
+                            # using hash=True often raise CancelledError,
                             # see dask/distributed#3703
                             [f] = await self.client.scatter(
                                 [arg],

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -252,6 +252,8 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
                     try:
                         f = call_data_futures[arg]
                     except KeyError:
+                        pass
+                    if f is None:
                         if is_weakrefable(arg) and sizeof(arg) > 1e3:
                             # Automatically scatter large objects to some of
                             # the workers to avoid duplicated data transfers.

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -25,7 +25,6 @@ if distributed is not None:
         secede,
         rejoin
     )
-    from distributed import get_worker
     from distributed.utils import thread_state
 
     try:

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -260,11 +260,9 @@ def test_nested_scatter(loop, retry_no):
     NUM_OUTER_TASKS = 10
 
     def my_sum(x, i, j):
-        # print(f"running inner task {j} of outer task {i}")
         return np.sum(x)
 
     def outer_function_joblib(array, i):
-        # print(f"running outer task {i}")
         client = get_client()  # noqa
         with parallel_backend("dask"):
             results = Parallel()(


### PR DESCRIPTION
Workaround for dask/distributed#3703, which affects the `joblib-dask` integration.
When scattering data inside `dask` worker, task using this data can often end up being cancelled, see the referenced issue for more information.

This situation typically happens inside `joblib` during nested `Parallel` calls (whenn the inner parallel call scatters some data).

As suggested by @mrocklin, another workaround is to use `hash=False` inside `client.scatter` calls -- I'd like to compare the two solutions via a few benchmarks before merging this PR.

Related, but does not fix entirely #959 

This also needs tests.