### PR TITLE
Fix a bug preventing the dask backend to use auto-batching.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Latest changes
 In development
 --------------
 
+- Fix a problem in the constructors of of Parallel backends classes that
+  inherit from the `AutoBatchingMixin` that prevented the dask backend to
+  properly batch short tasks.
+  https://github.com/joblib/joblib/pull/1062
 
 Release 0.15.1
 --------------

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -120,7 +120,7 @@ def _joblib_probe_task():
     pass
 
 
-class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
+class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
     MIN_IDEAL_BATCH_DURATION = 0.2
     MAX_IDEAL_BATCH_DURATION = 1.0
     supports_timeout = True
@@ -128,6 +128,8 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
     def __init__(self, scheduler_host=None, scatter=None,
                  client=None, loop=None, wait_for_workers_timeout=10,
                  **submit_kwargs):
+        AutoBatchingMixin.__init__(self)
+
         if distributed is None:
             msg = ("You are trying to use 'dask' as a joblib parallel backend "
                    "but dask is not installed. Please install dask "
@@ -195,6 +197,7 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
         return DaskDistributedBackend(client=self.client), -1
 
     def configure(self, n_jobs=1, parallel=None, **backend_args):
+        self.parallel = parallel
         return self.effective_n_jobs(n_jobs)
 
     def start_call(self):

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -128,7 +128,7 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
     def __init__(self, scheduler_host=None, scatter=None,
                  client=None, loop=None, wait_for_workers_timeout=10,
                  **submit_kwargs):
-        AutoBatchingMixin.__init__(self)
+        super().__init__()
 
         if distributed is None:
             msg = ("You are trying to use 'dask' as a joblib parallel backend "

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -416,6 +416,13 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin,
 
     supports_timeout = True
 
+    def __init__(self, nesting_level=None, inner_max_num_threads=None):
+        AutoBatchingMixin.__init__(self)
+        ParallelBackendBase.__init__(
+            self, nesting_level=nesting_level,
+            inner_max_num_threads=inner_max_num_threads
+        )
+
     def effective_n_jobs(self, n_jobs):
         """Determine the number of jobs which are going to run in parallel.
 

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -31,7 +31,9 @@ class ParallelBackendBase(metaclass=ABCMeta):
     supports_inner_max_num_threads = False
     nesting_level = None
 
-    def __init__(self, nesting_level=None, inner_max_num_threads=None):
+    def __init__(self, nesting_level=None, inner_max_num_threads=None,
+                 **kwargs):
+        super().__init__(**kwargs)
         self.nesting_level = nesting_level
         self.inner_max_num_threads = inner_max_num_threads
 
@@ -276,6 +278,7 @@ class AutoBatchingMixin(object):
     _DEFAULT_SMOOTHED_BATCH_DURATION = 0.0
 
     def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self._effective_batch_size = self._DEFAULT_EFFECTIVE_BATCH_SIZE
         self._smoothed_batch_duration = self._DEFAULT_SMOOTHED_BATCH_DURATION
 
@@ -416,13 +419,6 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin,
 
     supports_timeout = True
 
-    def __init__(self, nesting_level=None, inner_max_num_threads=None):
-        AutoBatchingMixin.__init__(self)
-        ParallelBackendBase.__init__(
-            self, nesting_level=nesting_level,
-            inner_max_num_threads=inner_max_num_threads
-        )
-
     def effective_n_jobs(self, n_jobs):
         """Determine the number of jobs which are going to run in parallel.
 
@@ -486,13 +482,6 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
 
     supports_timeout = True
     supports_inner_max_num_threads = True
-
-    def __init__(self, nesting_level=None, inner_max_num_threads=None):
-        AutoBatchingMixin.__init__(self)
-        ParallelBackendBase.__init__(
-            self, nesting_level=nesting_level,
-            inner_max_num_threads=inner_max_num_threads
-        )
 
     def configure(self, n_jobs=1, parallel=None, prefer=None, require=None,
                   idle_worker_timeout=300, **memmappingexecutor_args):

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -278,7 +278,6 @@ class AutoBatchingMixin(object):
     def __init__(self, **kwargs):
         self._effective_batch_size = self._DEFAULT_EFFECTIVE_BATCH_SIZE
         self._smoothed_batch_duration = self._DEFAULT_SMOOTHED_BATCH_DURATION
-        super(AutoBatchingMixin, self).__init__(**kwargs)
 
     def compute_batch_size(self):
         """Determine the optimal batch size"""
@@ -480,6 +479,13 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
 
     supports_timeout = True
     supports_inner_max_num_threads = True
+
+    def __init__(self, nesting_level=None, inner_max_num_threads=None):
+        AutoBatchingMixin.__init__(self)
+        ParallelBackendBase.__init__(
+            self, nesting_level=nesting_level,
+            inner_max_num_threads=inner_max_num_threads
+        )
 
     def configure(self, n_jobs=1, parallel=None, prefer=None, require=None,
                   idle_worker_timeout=300, **memmappingexecutor_args):

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -52,6 +52,7 @@ def test_dask_backend_uses_autobatching(loop):
                     # batch size of 1:
                     backend = parallel._backend
                     assert isinstance(backend, DaskDistributedBackend)
+                    assert backend.parallel is parallel
                     assert backend._effective_batch_size == 1
 
                     # Launch many short tasks that should trigger

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -6,7 +6,7 @@ from random import random
 from time import sleep
 
 from .. import Parallel, delayed, parallel_backend
-from ..parallel import ThreadingBackend
+from ..parallel import ThreadingBackend, AutoBatchingMixin
 from .._dask import DaskDistributedBackend
 
 distributed = pytest.importorskip('distributed')
@@ -23,6 +23,10 @@ def slow_raise_value_error(condition, duration=0.05):
     sleep(duration)
     if condition:
         raise ValueError("condition evaluated to True")
+
+
+def test_dask_backend_uses_autobatching(loop):
+    assert DaskDistributedBackend.compute_batch_size == AutoBatchingMixin.compute_batch_size  # noqa
 
 
 def test_simple(loop):


### PR DESCRIPTION
Until now, the `DaskDistributedBackend` would use `ParallelBackendBase`'s `compute_batch_size` method instead of `AutoBatchingMixin`'s `compute_batch_size`. The first one is actually a smoke method always returning 1, so the `dask` backend would always use a  batch size of 1 when submitting tasks.
This PR fixes this.
This also needs a quick test.