### PR TITLE
[MRG] Fix a race condition during joblib's dask backend termination

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,9 @@
 codecov:
   token: 1b7eb264-fd77-469a-829a-e9cd5efd7cef
+coverage:
+  status:
+    project:
+      default:
+        # Allow coverage to drop by up to 1% in a PR before marking it as
+        # failed
+        threshold: '1%'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ In development
   during nested Parallel calls (due to joblib's auto-scattering feature)
   https://github.com/joblib/joblib/pull/1061
 
+- Workaround for a race condition after Parallel calls with the dask backend
+  that would cause low level warnings from asyncio coroutines:
+  https://github.com/joblib/joblib/pull/1078
+
 Release 0.15.1
 --------------
 

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -4,6 +4,7 @@ import asyncio
 import concurrent.futures
 import contextlib
 
+import time
 from uuid import uuid4
 import weakref
 
@@ -224,6 +225,10 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
         # The explicit call to clear is required to break a cycling reference
         # to the futures.
         self._continue = False
+        # wait for the future collection routine (self._backend._collect) to
+        # finish in order to limit asyncio warnings due to aborting _collect
+        # during a following backend termination call
+        time.sleep(0.01)
         self.call_data_futures.clear()
 
     def effective_n_jobs(self, n_jobs):

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1048,6 +1048,7 @@ class Parallel(Logger):
         finally:
             if hasattr(self._backend, 'stop_call'):
                 self._backend.stop_call()
+                time.sleep(0.01)
             if not self._managed_backend:
                 self._terminate_backend()
             self._jobs = list()

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1048,7 +1048,6 @@ class Parallel(Logger):
         finally:
             if hasattr(self._backend, 'stop_call'):
                 self._backend.stop_call()
-                time.sleep(0.01)
             if not self._managed_backend:
                 self._terminate_backend()
             self._jobs = list()


### PR DESCRIPTION
@ogrisel this PR should fix https://github.com/joblib/joblib/issues/959#issuecomment-652329167. Feel free to checkout this PR and try it out on your machine using #959's repro.

```
task: <Task pending name='Task-6045' coro=<DaskDistributedBackend._collect() running at /home/ogrisel/code/joblib/joblib/_dask.py:197> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7fae2aaf0b50>()]> cb=[IOLoop.add_future.<locals>.<lambda>() at /home/ogrisel/miniconda3/envs/pylatest/lib/python3.8/site-packages/tornado/ioloop.py:690]>
```

This PR only highlights the problem (`terminate` will destroy `_collect` while `_collect` has not had the time to exit yet.
I'm not against using a strong synchronization primitive, but we would need to be careful about it.