### PR TITLE
[WAIT] New way to hash numpy dtypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Latest changes
 In development
 --------------
 
+- Fix a problem when hashing numpy 1.20 arrays with non-picklable dtype
+  classes.
+  https://github.com/joblib/joblib/issues/1080
+
 Release 0.16.0
 --------------
 

--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -151,6 +151,10 @@ class Hasher(Pickler):
     dispatch[type(set())] = save_set
 
 
+def _numpy_dtype_hashing_marker():
+    """Unique symbol to avoid conflicts when hashing numpy dtypes"""
+
+
 class NumpyHasher(Hasher):
     """ Special case the hasher for when numpy is loaded.
     """
@@ -231,8 +235,10 @@ class NumpyHasher(Hasher):
             # To prevent the hash from being sensitive to this, we use
             # .descr which is a full (and never interned) description of
             # the array dtype according to the numpy doc.
-            klass = obj.__class__
-            obj = (klass, ('HASHED', obj.descr))
+            #
+            # See also:
+            # https://github.com/joblib/joblib/issues/1080
+            obj = (_numpy_dtype_hashing_marker, obj.descr)
         Hasher.save(self, obj)
 
 

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -9,7 +9,6 @@ Test the hashing module.
 import time
 import hashlib
 import sys
-import os
 import gc
 import io
 import collections
@@ -19,7 +18,7 @@ import random
 from decimal import Decimal
 import pytest
 
-from joblib.hashing import hash
+from joblib.hashing import hash, np_version
 from joblib.func_inspect import filter_args
 from joblib.memory import Memory
 from joblib.testing import raises, skipif, fixture, parametrize
@@ -378,6 +377,8 @@ def test_0d_and_1d_array_hashing_is_different():
 
 @with_numpy
 def test_hashes_stay_the_same_with_numpy_objects():
+    if np_version >= '1.20':
+        pytest.skip("Not possible to preserve old hash values anymore")
     # We want to make sure that hashes don't change with joblib
     # version. For end users, that would mean that they have to
     # regenerate their cache from scratch, which potentially means


### PR DESCRIPTION
Fix for #1080.

There is a test failures that checks that we did not change the hash values.

I am not sure what to do: shall we remove this test or change it to avoid hard-coding the hash values in it?

Shall we check the numpy version and only do the change for numpy < 1.20?