### PR TITLE
Prevent spurious cache clearing when calling a cached func inside a Parallel call

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -155,7 +155,7 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
             klass = func.im_class
             module.append(klass.__name__)
     if os.name == 'nt' and win_characters:
-        # Stupid windows can't encode certain characters in filenames
+        # Windows can't encode certain characters in filenames
         name = _clean_win_chars(name)
         module = [_clean_win_chars(s) for s in module]
     return module, name

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -449,6 +449,8 @@ class MemorizedFunc(Logger):
             doc = func.__doc__
         self.__doc__ = 'Memoized version of %s' % doc
 
+        self._func_code_info = None
+
     def _cached_call(self, args, kwargs, shelving=False):
         """Call wrapped function and cache result, or read cache if available.
 
@@ -541,6 +543,21 @@ class MemorizedFunc(Logger):
 
         return (out, args_id, metadata)
 
+    @property
+    def func_code_info(self):
+        # 3-tuple property containing: func_code, source_file, first_line
+        if self._func_code_info is None:
+            # Cache the source code of self.func . Provided that get_func_code
+            # (which should be called once on self) gets called in the process
+            # in which self.func was defined, this caching mechanism prevents
+            # undesired cache clearing when the cached function is called in
+            # an environement where the introspection utilitiees get_func_code
+            # relies on do not work (typicially, in joblib child processes).
+            # See #1035 for  more info
+            # TODO (pierreglaser): do the same with get_func_name?
+            self._func_code_info = get_func_code(self.func)
+        return self._func_code_info
+
     def call_and_shelve(self, *args, **kwargs):
         """Call wrapped function, cache result and return a reference.
 
@@ -565,9 +582,13 @@ class MemorizedFunc(Logger):
         return self._cached_call(args, kwargs)[0]
 
     def __getstate__(self):
-        """ We don't store the timestamp when pickling, to avoid the hash
-            depending from it.
-        """
+        # Make sure self.func's source is introspected prior to being pickled -
+        # code introspection utilities typically do not work inside childe
+        # processes
+        _ = self.func_code_info
+
+        # We don't store the timestamp when pickling, to avoid the hash
+        # depending from it.
         state = self.__dict__.copy()
         state['timestamp'] = None
         return state
@@ -641,7 +662,7 @@ class MemorizedFunc(Logger):
         # Here, we go through some effort to be robust to dynamically
         # changing code and collision. We cannot inspect.getsource
         # because it is not reliable when using IPython's magic "%run".
-        func_code, source_file, first_line = get_func_code(self.func)
+        func_code, source_file, first_line = self.func_code_info
         func_id = _build_func_identifier(self.func)
 
         try:
@@ -713,7 +734,7 @@ class MemorizedFunc(Logger):
             self.warn("Clearing function cache identified by %s" % func_id)
         self.store_backend.clear_path([func_id, ])
 
-        func_code, _, first_line = get_func_code(self.func)
+        func_code, _, first_line = self.func_code_info
         self._write_func_code(func_code, first_line)
 
     def call(self, *args, **kwargs):

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -592,7 +592,7 @@ class MemorizedFunc(Logger):
 
     def __getstate__(self):
         # Make sure self.func's source is introspected prior to being pickled -
-        # code introspection utilities typically do not work inside childe
+        # code introspection utilities typically do not work inside child
         # processes
         _ = self.func_code_info
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -195,6 +195,10 @@ def test_parallel_call_cached_function_defined_in_jupyter(tmpdir):
     # contains ALL cached functions calls (f(1), f(2), f(3)) and 'func_code.py'
     assert len(os.listdir(f_cache_directory / 'f')) == 4
 
+    # TODO: test the case where f is sent to a Parallel call without being
+    # previously called - to work properly, this requires get_func_code to be
+    # called when during __reduce__'ing the cached function
+
 
 def test_no_memory():
     """ Test memory with location=None: no memoize """

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -180,7 +180,7 @@ def test_parallel_call_cached_function_defined_in_jupyter(tmpdir):
     assert cached_f(3)
 
     # Two files were just created, func_code.py, and a folder containing the
-    # informations (inputs hash/ouptput) of cached_f(1)
+    # informations (inputs hash/ouptput) of cached_f(3)
     assert len(os.listdir(f_cache_directory / 'f')) == 2
 
     # Now, testing  #1035: when calling a cached function, joblib used to

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -164,12 +164,11 @@ def test_parallel_call_cached_function_defined_in_jupyter(
         # bind locals()['f'] to a different name in the local namespace
         aliased_f = locals()['f']
         aliased_f.__module__ = "__main__"
-        assert aliased_f.__code__.co_filename == ipython_cell_id
 
         # Preliminary sanity checks, and tests checking that joblib properly
         # identified f as an interactive function defined in a jupyter notebook
         assert aliased_f(1) == 1
-        assert aliased_f.__code__.co_filename.startswith('<ipython-input')
+        assert aliased_f.__code__.co_filename == ipython_cell_id
 
         memory = Memory(location=tmpdir.strpath, verbose=0)
         cached_f = memory.cache(aliased_f)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -1252,7 +1252,7 @@ def test_memory_pickle_dump_load(tmpdir, memory_kwargs):
     # Compare Memory instance before and after pickle roundtrip
     compare(memory.store_backend, memory_reloaded.store_backend)
     compare(memory, memory_reloaded,
-            ignored_attrs=set(['store_backend', 'timestamp']))
+            ignored_attrs=set(['store_backend', 'timestamp', '_func_code_id']))
     assert hash(memory) == hash(memory_reloaded)
 
     func_cached = memory.cache(f)
@@ -1262,7 +1262,7 @@ def test_memory_pickle_dump_load(tmpdir, memory_kwargs):
     # Compare MemorizedFunc instance before/after pickle roundtrip
     compare(func_cached.store_backend, func_cached_reloaded.store_backend)
     compare(func_cached, func_cached_reloaded,
-            ignored_attrs=set(['store_backend', 'timestamp']))
+            ignored_attrs=set(['store_backend', 'timestamp', '_func_code_id']))
     assert hash(func_cached) == hash(func_cached_reloaded)
 
     # Compare MemorizedResult instance before/after pickle roundtrip
@@ -1272,5 +1272,5 @@ def test_memory_pickle_dump_load(tmpdir, memory_kwargs):
     compare(memorized_result.store_backend,
             memorized_result_reloaded.store_backend)
     compare(memorized_result, memorized_result_reloaded,
-            ignored_attrs=set(['store_backend', 'timestamp']))
+            ignored_attrs=set(['store_backend', 'timestamp', '_func_code_id']))
     assert hash(memorized_result) == hash(memorized_result_reloaded)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -167,11 +167,11 @@ def test_parallel_call_cached_function_defined_in_jupyter(tmpdir):
     memory = Memory(location=tmpdir.strpath, verbose=0)
     cached_f = memory.cache(aliased_f)
 
-    f_cache_relative_directory = '__main__-{}-__ipython-input__'.format(
-        os.getcwd().replace('/', '-')
-    )
+    assert len(os.listdir(tmpdir / 'joblib')) == 1
+    f_cache_relative_directory = os.listdir(tmpdir / 'joblib')[0]
+    assert '__ipython-input__' in f_cache_relative_directory
+
     f_cache_directory = tmpdir / 'joblib' / f_cache_relative_directory
-    assert os.path.exists(f_cache_directory)
 
     # The cache should be empty as cached_f has not been called yet.
     assert os.listdir(f_cache_directory) == ['f']


### PR DESCRIPTION
Fixes #1035

cc @ogrisel - I need to test a few more cases, but it should be reviewable.