### PR TITLE
Avoid Memory collision between notebooks with same function name

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -128,10 +128,20 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
             # mangling of full path to filename
             parts = filename.split(os.sep)
             if parts[-1].startswith('<ipython-input'):
-                # function is defined in an IPython session. The filename
-                # will change with every new kernel instance. This hack
-                # always returns the same filename
-                parts[-1] = '__ipython-input__'
+                # We're in a IPython (or notebook) session. parts[-1] comes
+                # from func.__code__.co_filename and is of the form
+                # <ipython-input-N-XYZ>, where:
+                # - N is the cell number where the function was defined
+                # - XYZ is a hash representing the function's code (and name).
+                #   It will be consistent across sessions and kernel restarts,
+                #   and will change if the function's code/name changes
+                # We remove N so that cache is properly hit if the cell where
+                # the func is defined is re-exectuted.
+                # The XYZ hash should avoid collisions between functions with
+                # the same name, both within the same notebook but also across
+                # notebooks
+                splitted = parts[-1].split('-')
+                parts[-1] = '-'.join(splitted[:2] + splitted[3:])
             filename = '-'.join(parts)
             if filename.endswith('.py'):
                 filename = filename[:-3]

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -175,7 +175,7 @@ def test_parallel_call_cached_function_defined_in_jupyter(
 
         assert len(os.listdir(tmpdir / 'joblib')) == 1
         f_cache_relative_directory = os.listdir(tmpdir / 'joblib')[0]
-        assert '__ipython-input__' in f_cache_relative_directory
+        assert '<ipython-input' in f_cache_relative_directory
 
         f_cache_directory = tmpdir / 'joblib' / f_cache_relative_directory
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -175,7 +175,7 @@ def test_parallel_call_cached_function_defined_in_jupyter(
 
         assert len(os.listdir(tmpdir / 'joblib')) == 1
         f_cache_relative_directory = os.listdir(tmpdir / 'joblib')[0]
-        assert '<ipython-input' in f_cache_relative_directory
+        assert 'ipython-input' in f_cache_relative_directory
 
         f_cache_directory = tmpdir / 'joblib' / f_cache_relative_directory
 


### PR DESCRIPTION
Fixes #1096

This PR changes the cache directory from

`[...]/joblib-__ipython-input__/<TheFunctionName>/`

to

`[...]/joblib-<ipython-input-XYZ>/<TheFunctionName>/,`
where `XYZ` comes from `co_filename` and is a hash of the function.

Ideally this should probably use the `.ipynb` filename  but I don't think we can retrieve it easily, and it wouldn't work for pure IPython sessions.

I'm not sure how to test this?