### PR TITLE
Update some joblib-dask integration tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,9 +10,10 @@ try:
 except ImportError:
     lz4 = None
 try:
-    from distributed.utils_test import loop
+    from distributed.utils_test import loop, loop_in_thread
 except ImportError:
     loop = None
+    loop_in_thread = None
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
https://github.com/dask/distributed/tree/b2f594e69751e0733ac595026e04181c55119ae9 changed the `IOLoop` closing logic of  `distributed`, and some test of ours need to be ajusted. It may be a good time to bump the `distributed` version, or test this version of distributed in another existing CI entry. Otherwise someone can just test this PR locally too.

cc @ogrisel @tomMoral 