### PR TITLE
Add default value for StoreBackendBase.compress

### DIFF
--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -36,6 +36,12 @@ class StoreBackendBase(metaclass=ABCMeta):
 
     location = None
 
+    # Default flag to tell whether a given backend instance supports compression
+    # or not. This value is typically updated by the
+    # StoredBackendMixin.configure method for backend implementation that also
+    # inherit from the mixin class.
+    compress = False
+
     @abstractmethod
     def _open_item(self, f, mode):
         """Opens an item on the store and return a file-like object.


### PR DESCRIPTION
Fixes #1127.

Ideally we would need update the tests but the bare try / except in `StoreBackendBase.dump_item` makes this difficult and looks like an anti-pattern anyway. However I am not sure which exception we should expect in case of a race condition in the creation of directory (probably `OSError`?). We probably need more tests, including multi-threaded stress tests to check for the robustness of concurrent directory creation.

@aabadie if you are still interested in this, please feel free to send a PR :)