### PR TITLE
Use inspect.signature() instead of inspect.getfullargspec()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Latest changes
 ==============
 
+Development version
+-------------------
+
+- Fix joblib.Memory bug with the ``ignore`` parameter when the cached function
+  is a decorated function.
+  https://github.com/joblib/joblib/pull/1165
+
 1.0.1
 -----
 

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -243,7 +243,8 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
         # we need to add it back:
         args = [func.__self__, ] + args
         # func is an instance method, inspect.signature(func) does not
-        # include self, we need to fetch it from the class method
+        # include self, we need to fetch it from the class method, i.e
+        # func.__func__
         class_method_sig = inspect.signature(func.__func__)
         self_name = next(iter(class_method_sig.parameters))
         arg_names = [self_name] + arg_names

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -242,10 +242,11 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
         # First argument is 'self', it has been removed by Python
         # we need to add it back:
         args = [func.__self__, ] + args
-        # inspect.signature(func) does not include self, so we need to fetch it
-        # from inspect.signature(func.__func__):
-        funcsig = inspect.signature(func.__func__)
-        arg_names = [next(iter(funcsig.parameters.keys()))] + arg_names
+        # func is an instance method, inspect.signature(func) does not
+        # include self, we need to fetch it from the class method
+        class_method_sig = inspect.signature(func.__func__)
+        self_name = next(iter(class_method_sig.parameters))
+        arg_names = [self_name] + arg_names
     # XXX: Maybe I need an inspect.isbuiltin to detect C-level methods, such
     # as on ndarrays.
 

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -242,9 +242,10 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
         # First argument is 'self', it has been removed by Python
         # we need to add it back:
         args = [func.__self__, ] + args
-        # inspect.signature() does not include self, so we need to fetch it
-        # from inspect.getfullargspec():
-        arg_names = inspect.getfullargspec(func).args[:1] + arg_names
+        # inspect.signature(func) does not include self, so we need to fetch it
+        # from inspect.signature(func.__func__):
+        funcsig = inspect.signature(func.__func__)
+        arg_names = [next(iter(funcsig.parameters.keys()))] + arg_names
     # XXX: Maybe I need an inspect.isbuiltin to detect C-level methods, such
     # as on ndarrays.
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -6,6 +6,7 @@ Test the memory module.
 # Copyright (c) 2009 Gael Varoquaux
 # License: BSD Style, 3 clauses.
 
+import functools
 import gc
 import shutil
 import os
@@ -475,6 +476,32 @@ def test_memory_ignore(tmpdir):
     accumulator = list()
 
     @memory.cache(ignore=['y'])
+    def z(x, y=1):
+        accumulator.append(1)
+
+    assert z.ignore == ['y']
+
+    z(0, y=1)
+    assert len(accumulator) == 1
+    z(0, y=1)
+    assert len(accumulator) == 1
+    z(0, y=2)
+    assert len(accumulator) == 1
+
+
+def test_memory_ignore_decorated(tmpdir):
+    " Test the ignore feature of memory on a decorated function "
+    memory = Memory(location=tmpdir.strpath, verbose=0)
+    accumulator = list()
+
+    def decorate(f):
+        @functools.wraps(f)
+        def wrapped(*args, **kwargs):
+            return f(*args, **kwargs)
+        return wrapped
+
+    @memory.cache(ignore=['y'])
+    @decorate
     def z(x, y=1):
         accumulator.append(1)
 


### PR DESCRIPTION
Fixes #1164.