### PR TITLE
DOC: improve Memory bytes_limit documentation.

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -885,8 +885,10 @@ class Memory(Logger):
             Limit in bytes of the size of the cache. By default, the size of
             the cache is unlimited.
 
-            Note: you need to call :meth:`~joblib.Memory.reduce_size` to
-            actually reduce the cache size to be less than ``bytes_limit``.
+            .. note::
+
+               You need to call :meth:`~joblib.Memory.reduce_size` to actually
+               reduce the cache size to be less than ``bytes_limit``.
 
         backend_options: dict, optional
             Contains a dictionnary of named parameters used to configure

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -884,11 +884,8 @@ class Memory(Logger):
         bytes_limit: int, optional
             Limit in bytes of the size of the cache. By default, the size of
             the cache is unlimited.
-
-            .. note::
-
-               You need to call :meth:`joblib.Memory.reduce_size` to actually
-               reduce the cache size to be less than ``bytes_limit``.
+            Note: You need to call :meth:`joblib.Memory.reduce_size` to
+            actually reduce the cache size to be less than ``bytes_limit``.
 
         backend_options: dict, optional
             Contains a dictionnary of named parameters used to configure

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -882,7 +882,11 @@ class Memory(Logger):
             as functions are evaluated.
 
         bytes_limit: int, optional
-            Limit in bytes of the size of the cache.
+            Limit in bytes of the size of the cache. By default, the size of
+            the cache is unlimited.
+
+            Note: you need to call :meth:`~joblib.Memory.reduce_size` to
+            actually reduce the cache size to be less than ``bytes_limit``.
 
         backend_options: dict, optional
             Contains a dictionnary of named parameters used to configure

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -887,7 +887,7 @@ class Memory(Logger):
 
             .. note::
 
-               You need to call :meth:`~joblib.Memory.reduce_size` to actually
+               You need to call :meth:`joblib.Memory.reduce_size` to actually
                reduce the cache size to be less than ``bytes_limit``.
 
         backend_options: dict, optional


### PR DESCRIPTION
Fix #574.

The link does not seem to be created in the locally generated HTML for some reason, but good enough for now.