### PR TITLE
fix joblib.load from stream

### DIFF
--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -69,8 +69,9 @@ def _detect_compressor(fileobj):
         first_bytes = fileobj.peek(max_prefix_len)
     else:
         # Fallback to seek if the fileobject is not peekable.
+        prev_pos = fileobj.tell()
         first_bytes = fileobj.read(max_prefix_len)
-        fileobj.seek(0)
+        fileobj.seek(prev_pos)
 
     if first_bytes.startswith(_ZFILE_PREFIX):
         return "compat"

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -634,6 +634,7 @@ def test_in_memory_persistence():
     for obj in objs:
         f = io.BytesIO()
         numpy_pickle.dump(obj, f)
+        f.seek(0)
         obj_reloaded = numpy_pickle.load(f)
         if isinstance(obj, np.ndarray):
             np.testing.assert_array_equal(obj_reloaded, obj)
@@ -678,6 +679,7 @@ def test_file_handle_persistence_in_memory_mmap():
     buf = io.BytesIO()
 
     numpy_pickle.dump(obj, buf)
+    buf.seek(0)
 
     with warns(UserWarning) as warninfo:
         numpy_pickle.load(buf, mmap_mode='r+')


### PR DESCRIPTION
I founded an issue when loading data from stream.
Code example
```
>>> import numpy as np
>>> a = np.array([1, 2, 3])
>>> b = np.array([3, 4, 5])
>>>
>>> import io
>>> import joblib
>>> buf = io.BytesIO()
>>>
>>> joblib.dump(a, buf)
>>> joblib.dump(b, buf)
>>>
>>> buf.seek(0)
0
>>> joblib.load(buf)
array([1, 2, 3])
>>> joblib.load(buf)
array([1, 2, 3])
>>>
```

VS

```
>>> import numpy as np
>>> a = np.array([1, 2, 3])
>>> b = np.array([3, 4, 5])
>>> 
>>> import joblib
>>> with open('1.bin', 'wb') as fd:
...     joblib.dump(a, fd)
...     joblib.dump(b, fd)
... 
>>> with open('1.bin', 'rb') as fd:
...     joblib.load(fd)
...     joblib.load(fd)
... 
array([1, 2, 3])
array([3, 4, 5])
```

My patch will fix it