### PR TITLE
Update parallel.py

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -324,10 +324,10 @@ def delayed(function):
     def delayed_function(*args, **kwargs):
         return function, args, kwargs
     try:
-        delayed_function = functools.wraps(function)(delayed_function)
+        the_delayed_function = functools.wraps(function)(delayed_function)
     except AttributeError:
         " functools.wraps fails on some callable objects "
-    return delayed_function
+    return the_delayed_function
 
 
 ###############################################################################


### PR DESCRIPTION
name obfuscation is solved by renaming in line 327 and 330 (to solve the clash with defintion in line 324)
related to issue obscured declaration in delayed #1173