### PR TITLE
MAINT fix setup.py warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ release = egg_info -RDb ''
 upload = upload upload_docs --upload-dir doc/_build/html
 
 [bdist_rpm]
-doc-files = doc
+doc_files = doc
 
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS


### PR DESCRIPTION
Fix the following setup.py warning:

    /usr/lib/python3.10/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'doc-files' will not be supported in future versions. Please use the underscore name 'doc_files' instead