### PR TITLE
Handle new naming scheme in newer Jupyter notebook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Development version
   is a decorated function.
   https://github.com/joblib/joblib/pull/1165
 
+- Fix `joblib.Memory` to properly handle caching for functions defined
+  interactively in a IPython session or in Jupyter notebook cell.
+  https://github.com/joblib/joblib/pull/1214
+
 1.0.1
 -----
 

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -142,6 +142,13 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
                 # notebooks
                 splitted = parts[-1].split('-')
                 parts[-1] = '-'.join(splitted[:2] + splitted[3:])
+            elif parts[-2].startswith('ipykernel_'):
+                # In a notebook session (ipykernel). Filename seems to be
+                # 'xyz' of above. parts[-2] has the structure ipykernel_XXXXXX
+                # where XXXXXX is a six-digit number identifying the current run (?).
+                # If we split it off, the function again has the same identifyer
+                # across runs.
+                parts[-2] = 'ipykernel_'
             filename = '-'.join(parts)
             if filename.endswith('.py'):
                 filename = filename[:-3]

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -142,13 +142,13 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
                 # notebooks
                 splitted = parts[-1].split('-')
                 parts[-1] = '-'.join(splitted[:2] + splitted[3:])
-            elif parts[-2].startswith('ipykernel_'):
-                # In a notebook session (ipykernel). Filename seems to be
-                # 'xyz' of above. parts[-2] has the structure ipykernel_XXXXXX
-                # where XXXXXX is a six-digit number identifying the current run (?).
-                # If we split it off, the function again has the same identifyer
-                # across runs.
-                parts[-2] = 'ipykernel_'
+            elif len(parts) > 2 and parts[-2].startswith('ipykernel_'):
+                # In a notebook session (ipykernel). Filename seems to be 'xyz'
+                # of above. parts[-2] has the structure ipykernel_XXXXXX where
+                # XXXXXX is a six-digit number identifying the current run (?).
+                # If we split it off, the function again has the same
+                # identifier across runs.
+                parts[-2] = 'ipykernel'
             filename = '-'.join(parts)
             if filename.endswith('.py'):
                 filename = filename[:-3]


### PR DESCRIPTION
As mentioned in #1210, this adds handling of a different cell code naming scheme in the newest Jupyter notebook / IPython version  (at least as packaged on Arch Linux).

Let me know if anything else can / needs to be done.

Cheers!