### PR TITLE
Eliminate use of distutils

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import pytest
 from _pytest.doctest import DoctestItem
@@ -26,7 +26,7 @@ def pytest_collection_modifyitems(config, items):
             # numpy changed the str/repr formatting of numpy arrays in 1.14.
             # We want to run doctests only for numpy >= 1.14.
             import numpy as np
-            if LooseVersion(np.__version__) >= LooseVersion('1.14'):
+            if Version(np.__version__) >= Version('1.14'):
                 skip_doctests = False
         except ImportError:
             pass

--- a/joblib/backports.py
+++ b/joblib/backports.py
@@ -4,7 +4,7 @@ Backports of fixes for joblib dependencies
 import os
 import time
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 from os.path import basename
 from multiprocessing import util
 
@@ -33,7 +33,7 @@ try:
 
         mm = np.memmap(filename, dtype=dtype, mode=mode, offset=offset,
                        shape=shape, order=order)
-        if LooseVersion(np.__version__) < '1.13':
+        if Version(np.__version__) < Version('1.13'):
             mm.offset = offset
         if unlink_on_gc_collect:
             from ._memmapping_reducer import add_maybe_unlink_finalizer

--- a/joblib/compressor.py
+++ b/joblib/compressor.py
@@ -2,7 +2,7 @@
 
 import io
 import zlib
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 try:
     from threading import RLock
@@ -201,7 +201,7 @@ class LZ4CompressorWrapper(CompressorWrapper):
         lz4_version = lz4.__version__
         if lz4_version.startswith("v"):
             lz4_version = lz4_version[1:]
-        if LooseVersion(lz4_version) < LooseVersion('0.19'):
+        if Version(lz4_version) < Version('0.19'):
             raise ValueError(LZ4_NOT_INSTALLED_ERROR)
 
     def compressor_file(self, fileobj, compresslevel=None):

--- a/joblib/test/_openmp_test_helper/setup.py
+++ b/joblib/test/_openmp_test_helper/setup.py
@@ -2,9 +2,9 @@
 """
 import os
 import sys
-from distutils.core import setup
+from setuptools import setup
 from Cython.Build import cythonize
-from distutils.extension import Extension
+from setuptools.extension import Extension
 
 
 if sys.platform == "darwin":

--- a/setup.py
+++ b/setup.py
@@ -55,4 +55,5 @@ setup(
         'joblib.externals.loky', 'joblib.externals.loky.backend',
     ],
     python_requires='>=3.6',
+    install_requires=['packaging'],
 )


### PR DESCRIPTION
As of Python 3.10 (released on Monday), distutils is deprecated and will be removed in Python 3.12.  As a result, using joblib under 3.10 produces deprecation warnings.  This PR fixes those warnings by replacing distutils with either [`packaging`](https://packaging.pypa.io/en/latest/) (for version comparison) or `setuptools`.

Note that, since all of the version comparisons that `LooseVersion` was used for were carried out against Python package versions, we can assume the versions in question are valid PEP 440 versions, and so `packaging.version.Version` should be used instead of the deprecated `packaging.version.LooseVersion`.