### PR TITLE
Remove deprecated `cachedir`

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -876,12 +876,6 @@ class Memory(Logger):
             The 'local' backend is using regular filesystem operations to
             manipulate data (open, mv, etc) in the backend.
 
-        cachedir: str or None, optional
-
-            .. deprecated: 0.12
-                'cachedir' has been deprecated in 0.12 and will be
-                removed in 0.14. Use the 'location' parameter instead.
-
         mmap_mode: {None, 'r+', 'r', 'w+', 'c'}, optional
             The memmapping mode used when loading from cache
             numpy arrays. See numpy.load for the meaning of the
@@ -913,10 +907,9 @@ class Memory(Logger):
     # Public interface
     # ------------------------------------------------------------------------
 
-    def __init__(self, location=None, backend='local', cachedir=None,
+    def __init__(self, location=None, backend='local',
                  mmap_mode=None, compress=False, verbose=1, bytes_limit=None,
                  backend_options=None):
-        # XXX: Bad explanation of the None value of cachedir
         Logger.__init__(self)
         self._verbose = verbose
         self.mmap_mode = mmap_mode
@@ -931,22 +924,6 @@ class Memory(Logger):
         if compress and mmap_mode is not None:
             warnings.warn('Compressed results cannot be memmapped',
                           stacklevel=2)
-        if cachedir is not None:
-            if location is not None:
-                raise ValueError(
-                    'You set both "location={0!r} and "cachedir={1!r}". '
-                    "'cachedir' has been deprecated in version "
-                    "0.12 and will be removed in version 0.14.\n"
-                    'Please only set "location={0!r}"'.format(
-                        location, cachedir))
-
-            warnings.warn(
-                "The 'cachedir' parameter has been deprecated in version "
-                "0.12 and will be removed in version 0.14.\n"
-                'You provided "cachedir={0!r}", '
-                'use "location={0!r}" instead.'.format(cachedir),
-                DeprecationWarning, stacklevel=2)
-            location = cachedir
 
         self.location = location
         if isinstance(location, str):
@@ -956,17 +933,6 @@ class Memory(Logger):
             backend, location, verbose=self._verbose,
             backend_options=dict(compress=compress, mmap_mode=mmap_mode,
                                  **backend_options))
-
-    @property
-    def cachedir(self):
-        warnings.warn(
-            "The 'cachedir' attribute has been deprecated in version 0.12 "
-            "and will be removed in version 0.14.\n"
-            "Use os.path.join(memory.location, 'joblib') attribute instead.",
-            DeprecationWarning, stacklevel=2)
-        if self.location is None:
-            return None
-        return os.path.join(self.location, 'joblib')
 
     def cache(self, func=None, ignore=None, verbose=None, mmap_mode=False):
         """ Decorates the given function func to only compute its return

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -64,7 +64,7 @@ class Klass(object):
 class KlassWithCachedMethod(object):
 
     def __init__(self, cachedir):
-        mem = Memory(cachedir=cachedir)
+        mem = Memory(location=cachedir)
         self.f = mem.cache(self.f)
 
     def f(self, x):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -564,10 +564,6 @@ def test_func_dir(tmpdir):
     assert location == path
     assert os.path.exists(path)
     assert memory.location == os.path.dirname(g.store_backend.location)
-    with warns(DeprecationWarning) as w:
-        assert memory.cachedir == g.store_backend.location
-    assert len(w) == 1
-    assert "The 'cachedir' attribute has been deprecated" in str(w[-1].message)
 
     # Test that the code is stored.
     # For the following test to be robust to previous execution, we clear
@@ -1087,29 +1083,6 @@ def test_memory_recomputes_after_an_error_while_loading_results(
     except KeyError as e:
         message = "is corrupted"
         assert message in str(e.args)
-
-
-def test_deprecated_cachedir_behaviour(tmpdir):
-    # verify the right deprecation warnings are raised when using cachedir
-    # option instead of new location parameter.
-    with warns(None) as w:
-        memory = Memory(cachedir=tmpdir.strpath, verbose=0)
-        assert memory.store_backend.location.startswith(tmpdir.strpath)
-
-    assert len(w) == 1
-    assert "The 'cachedir' parameter has been deprecated" in str(w[-1].message)
-
-    with warns(None) as w:
-        memory = Memory()
-        assert memory.cachedir is None
-
-    assert len(w) == 1
-    assert "The 'cachedir' attribute has been deprecated" in str(w[-1].message)
-
-    error_regex = """You set both "location='.+ and "cachedir='.+"""
-    with raises(ValueError, match=error_regex):
-        memory = Memory(location=tmpdir.strpath, cachedir=tmpdir.strpath,
-                        verbose=0)
 
 
 class IncompleteStoreBackend(StoreBackendBase):


### PR DESCRIPTION
Hi there,

While cleaning up some deprecation warnings in Nilearn, I realized that a few of them were due to our use of `cachedir` instead of `location`, which has been deprecated since joblib `0.12` and was scheduled to be removed in `0.14` (see https://github.com/nilearn/nilearn/pull/3037).
I'm not sure whether keeping it despite the fact that the deprecation cycle has been finished for a while is intentional or not. If it isn't, this PR proposes to remove it and update the corresponding tests. Feel free to close it otherwise.