### PR TITLE
Add more user-friendly warning about using joblib inside a Dask worker.

### DIFF
--- a/.readthedocs-requirements.txt
+++ b/.readthedocs-requirements.txt
@@ -1,4 +1,5 @@
 sphinx
+docutils<0.18
 numpy
 matplotlib
 pillow

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -24,9 +24,11 @@ if distributed is not None:
         as_completed,
         get_client,
         secede,
-        rejoin
+        rejoin,
+        get_worker
     )
     from distributed.utils import thread_state
+
 
     try:
         # asyncio.TimeoutError, Python3-only error thrown by recent versions of

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -431,10 +431,21 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin,
         if mp.current_process().daemon:
             # Daemonic processes cannot have children
             if n_jobs != 1:
-                warnings.warn(
-                    'Multiprocessing-backed parallel loops cannot be nested,'
-                    ' setting n_jobs=1',
-                    stacklevel=3)
+                if inside_dask_worker():
+                    msg = (
+                        "Inside a Dask worker with daemon=True, "
+                        "setting n_jobs=1.\nPossible work-arounds:\n"
+                        "- dask.config.set({'distributed.worker.daemon': False})\n"
+                        "- set the environment variable "
+                        "DASK_DISTRIBUTED__WORKER__DAEMON=False\n"
+                        "before creating your Dask cluster."
+                    )
+                else:
+                    msg = (
+                        'Multiprocessing-backed parallel loops cannot be nested,'
+                        ' setting n_jobs=1',
+                    )
+                warnings.warn(msg, stacklevel=3)
             return 1
 
         if process_executor._CURRENT_DEPTH > 0:
@@ -509,10 +520,22 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
         elif mp.current_process().daemon:
             # Daemonic processes cannot have children
             if n_jobs != 1:
-                warnings.warn(
-                    'Loky-backed parallel loops cannot be called in a'
-                    ' multiprocessing, setting n_jobs=1',
-                    stacklevel=3)
+                if inside_dask_worker():
+                    msg = (
+                        "Inside a Dask worker with daemon=True, "
+                        "setting n_jobs=1.\nPossible work-arounds:\n"
+                        "- dask.config.set({'distributed.worker.daemon': False})\n"
+                        "- set the environment variable "
+                        "DASK_DISTRIBUTED__WORKER__DAEMON=False\n"
+                        "before creating your Dask cluster."
+                    )
+                else:
+                    msg = (
+                        'Loky-backed parallel loops cannot be called in a'
+                        ' multiprocessing, setting n_jobs=1',
+                    )
+                warnings.warn(msg, stacklevel=3)
+
             return 1
         elif not (self.in_main_thread() or self.nesting_level == 0):
             # Prevent posix fork inside in non-main posix threads
@@ -608,3 +631,21 @@ class FallbackToBackend(Exception):
 
     def __init__(self, backend):
         self.backend = backend
+
+
+def inside_dask_worker():
+    """Check whether the current function is executed inside a Dask worker.
+    """
+    # This function can not be in joblib._dask because there would be a
+    # circular import:
+    # _dask imports _parallel_backend that imports _dask ...
+    try:
+        from distributed import get_worker
+    except ImportError:
+        return False
+
+    try:
+        get_worker()
+        return True
+    except ValueError:
+        return False

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -435,15 +435,16 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin,
                     msg = (
                         "Inside a Dask worker with daemon=True, "
                         "setting n_jobs=1.\nPossible work-arounds:\n"
-                        "- dask.config.set({'distributed.worker.daemon': False})\n"
+                        "- dask.config.set("
+                        "{'distributed.worker.daemon': False})"
                         "- set the environment variable "
                         "DASK_DISTRIBUTED__WORKER__DAEMON=False\n"
                         "before creating your Dask cluster."
                     )
                 else:
                     msg = (
-                        'Multiprocessing-backed parallel loops cannot be nested,'
-                        ' setting n_jobs=1',
+                        'Multiprocessing-backed parallel loops '
+                        'cannot be nested, setting n_jobs=1',
                     )
                 warnings.warn(msg, stacklevel=3)
             return 1
@@ -524,7 +525,8 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
                     msg = (
                         "Inside a Dask worker with daemon=True, "
                         "setting n_jobs=1.\nPossible work-arounds:\n"
-                        "- dask.config.set({'distributed.worker.daemon': False})\n"
+                        "- dask.config.set("
+                        "{'distributed.worker.daemon': False})\n"
                         "- set the environment variable "
                         "DASK_DISTRIBUTED__WORKER__DAEMON=False\n"
                         "before creating your Dask cluster."

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -444,7 +444,7 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin,
                 else:
                     msg = (
                         'Multiprocessing-backed parallel loops '
-                        'cannot be nested, setting n_jobs=1',
+                        'cannot be nested, setting n_jobs=1'
                     )
                 warnings.warn(msg, stacklevel=3)
             return 1
@@ -534,7 +534,7 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
                 else:
                     msg = (
                         'Loky-backed parallel loops cannot be called in a'
-                        ' multiprocessing, setting n_jobs=1',
+                        ' multiprocessing, setting n_jobs=1'
                     )
                 warnings.warn(msg, stacklevel=3)
 


### PR DESCRIPTION
When trying to use joblib inside a Dask worker, the warning is not super helpful.
```
UserWarning: Loky-backed parallel loops cannot be called in a multiprocessing, setting n_jobs=1
```

Probably better to point to the fact that you can start Dask workers in non-daemonic mode.

A case where this setup makes sense is if you combine dask-jobqueue to launch multiple jobs on a HPC cluster and then use joblib to do some parallel computation within each job.

To be fair, I don't know whether there is any caveats in having non-daemonic Dask workers and I could not find anything in the Dask documentation.

The only thing I found was about why multiprocessins launch processes in daemonic mode:
https://mail.python.org/pipermail/python-list/2011-March/750543.html