### PR TITLE
Drop 3.6 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Dependencies
 ============
 
 - Joblib has no mandatory dependencies besides Python (supported versions are
-  3.6+).
+  3.7+).
 - Joblib has an optional dependency on Numpy (at least version 1.6.1) for array
   manipulation.
 - Joblib includes its own vendored copy of

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,20 +54,20 @@ jobs:
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.7"
         EXTRA_CONDA_PACKAGES: "numpy=1.15 distributed=2.13"
-      linux_py36_cython:
+      linux_py37_cython:
         imageName: 'ubuntu-latest'
-        PYTHON_VERSION: "3.6"
-        EXTRA_CONDA_PACKAGES: "numpy=1.14"
+        PYTHON_VERSION: "3.7"
+        EXTRA_CONDA_PACKAGES: "numpy=1.15"
         CYTHON: "true"
-      linux_py36_no_multiprocessing_no_lzma:
+      linux_py37_no_multiprocessing_no_lzma:
         imageName: 'ubuntu-latest'
-        PYTHON_VERSION: "3.6"
-        EXTRA_CONDA_PACKAGES: "numpy=1.14"
+        PYTHON_VERSION: "3.7"
+        EXTRA_CONDA_PACKAGES: "numpy=1.15"
         JOBLIB_MULTIPROCESSING: "0"
         NO_LZMA: "1"
-      linux_py36_no_numpy:
+      linux_py37_no_numpy:
         imageName: 'ubuntu-latest'
-        PYTHON_VERSION: "3.6"
+        PYTHON_VERSION: "3.7"
 
       windows_py38:
         imageName: "vs2017-win2016"
@@ -78,9 +78,9 @@ jobs:
         imageName: "macos-10.14"
         PYTHON_VERSION: "3.8"
         EXTRA_CONDA_PACKAGES: "numpy=1.18"
-      macos_py36_no_numpy:
+      macos_py37_no_numpy:
         imageName: "macos-10.14"
-        PYTHON_VERSION: "3.6"
+        PYTHON_VERSION: "3.7"
 
   variables:
     JUNITXML: 'test-data.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
         PYTHON_VERSION: "3.7"
 
       windows_py38:
-        imageName: "vs2017-win2016"
+        imageName: "windows-latest"
         PYTHON_VERSION: "3.8"
         EXTRA_CONDA_PACKAGES: "numpy=1.18"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,11 +75,11 @@ jobs:
         EXTRA_CONDA_PACKAGES: "numpy=1.18"
 
       macos_py38:
-        imageName: "macos-10.14"
+        imageName: "macos-latest"
         PYTHON_VERSION: "3.8"
         EXTRA_CONDA_PACKAGES: "numpy=1.18"
       macos_py37_no_numpy:
-        imageName: "macos-10.14"
+        imageName: "macos-latest"
         PYTHON_VERSION: "3.7"
 
   variables:

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -18,7 +18,7 @@ create_new_conda_env() {
 }
 
 create_new_pypy3_env() {
-    PYPY_FOLDER="pypy3.6-v7.3.1-linux64"
+    PYPY_FOLDER="pypy3.7-v7.3.7-linux64"
     wget https://downloads.python.org/pypy/$PYPY_FOLDER.tar.bz2
     tar xvf $PYPY_FOLDER.tar.bz2
     $PYPY_FOLDER/bin/pypy3 -m venv pypy3

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -28,14 +28,20 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
     # Install scikit-learn from conda and test against the installed
     # development version of joblib.
     conda remove -y numpy
-    conda install -y -c conda-forge cython pillow scikit-learn
+    conda install -y -c conda-forge cython pillow pip
+    pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
 
     # Move to a dedicated folder to avoid being polluted by joblib specific conftest.py
     # and disable the doctest plugin to avoid issues with doctests in scikit-learn
     # docstrings that require setting print_changed_only=True temporarily.
     cd "/tmp"
-    pytest -vl --maxfail=5 -p no:doctest -k "not test_import_is_deprecated" --pyargs sklearn
+    pytest -vl --maxfail=5 -p no:doctest \
+        # Don't worry about deprecated imports: this is tested for real
+        # in upstream scikit-learn and this is not joblib's responsibility.
+        # Let's skip this test to avoid false positives in joblib's CI.
+        -k "not test_import_is_deprecated" \
+        --pyargs sklearn
 fi
 
 if [[ "$SKIP_TESTS" != "true" && "$COVERAGE" == "true" ]]; then

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -28,7 +28,7 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
     # Install scikit-learn from conda and test against the installed
     # development version of joblib.
     conda remove -y numpy
-    conda install -y -c conda-forge cython pillow pip
+    conda install -y -c conda-forge cython pillow pip numpy scipy
     pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
 

--- a/joblib/test/test_deprecated_objects.py
+++ b/joblib/test/test_deprecated_objects.py
@@ -2,15 +2,12 @@
 Tests making sure that deprecated objects properly raise a deprecation warning
 when imported/created.
 """
-import sys
-
 import pytest
 
 from joblib.my_exceptions import _deprecated_names as _deprecated_exceptions
 from joblib.format_stack import _deprecated_names as _deprecated_format_utils
 
 
-@pytest.mark.xfail(sys.version_info < (3, 7), reason="no module-level getattr")
 def test_deprecated_joblib_exceptions():
     assert 'JoblibException' in _deprecated_exceptions
     for name in _deprecated_exceptions:
@@ -20,7 +17,6 @@ def test_deprecated_joblib_exceptions():
             exec('from joblib.my_exceptions import {}'.format(name))
 
 
-@pytest.mark.xfail(sys.version_info < (3, 7), reason="no module-level getattr")
 def test_deprecated_formatting_utilities(capsys):
     assert 'safe_repr' in _deprecated_format_utils
     assert 'eq_repr' in _deprecated_format_utils

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -828,7 +828,7 @@ def test_child_raises_parent_exits_cleanly(backend):
     out, err = p.communicate()
     out, err = out.decode(), err.decode()
     filename = out.split('\n')[0]
-    assert p.returncode == 0, out
+    assert p.returncode == 0, err or out
     assert err == ''  # no resource_tracker warnings.
     assert not os.path.exists(filename)
 

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -815,10 +815,13 @@ def test_child_raises_parent_exits_cleanly(backend):
                     temp_folder = get_temp_folder(p, "{b}")
                     p(delayed(print_filename_and_raise)(data)
                               for i in range(1))
-            except ValueError:
+            except ValueError as e:
                 # the temporary folder should be deleted by the end of this
                 # call
-                assert not os.path.exists(temp_folder)
+                if os.path.exists(temp_folder):
+                    raise AssertionError(
+                        temp_folder + " was not deleted"
+                    ) from e
     """.format(b=backend)
     env = os.environ.copy()
     env['PYTHONPATH'] = os.path.dirname(__file__)

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering',
         'Topic :: Utilities',
         'Topic :: Software Development :: Libraries',
@@ -54,5 +54,5 @@ setup(
         'joblib.externals', 'joblib.externals.cloudpickle',
         'joblib.externals.loky', 'joblib.externals.loky.backend',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
Loky is about to do a big spring cleanup  to remove all hard to maintain backports for Python versions in the range [2.7-3.6].

Furthermore we have failing tests with joblib on Python 3.6. Let's not waste scarce maintainer's time on no longer supported Python versions.