### PR TITLE
MAINT fix sklearn test setup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,6 @@ jobs:
       linux_py39_sklearn_tests:
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.9"
-        EXTRA_CONDA_PACKAGES: "numpy"
         # SKIP_TESTS: "true"
         SKLEARN_TESTS: "true"
       linux_py38_distributed:

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -28,7 +28,9 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
     # Install scikit-learn from conda and test against the installed
     # development version of joblib.
     conda remove -y numpy
-    conda install -y -c conda-forge cython pillow pip numpy scipy
+    # TODO: unpin pip once either https://github.com/pypa/pip/issues/10825
+    # accepts invalid HTML or Anaconda is fixed.
+    conda install -y -c conda-forge cython pillow numpy scipy "pip<22"
     pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
 

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -39,12 +39,20 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
     NEW_TEST_DIR=$(mktemp -d)
     cd $NEW_TEST_DIR
 
-    # Don't worry about deprecated imports: this is tested for real
-    # in upstream scikit-learn and this is not joblib's responsibility.
-    # Let's skip this test to avoid false positives in joblib's CI.
     pytest -vl --maxfail=5 -p no:doctest \
         -k "not test_import_is_deprecated" \
+        -k "not test_check_memory" \
         --pyargs sklearn
+
+    # Justification for skipping some tests:
+    #
+    # test_import_is_deprecated: Don't worry about deprecated imports: this is
+    # tested for real in upstream scikit-learn and this is not joblib's
+    # responsibility. Let's skip this test to avoid false positives in joblib's
+    # CI.
+    #
+    # test_check_memory: scikit-learn test need to be updated to avoid using
+    # cachedir: https://github.com/scikit-learn/scikit-learn/pull/22365
 fi
 
 if [[ "$SKIP_TESTS" != "true" && "$COVERAGE" == "true" ]]; then

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -25,20 +25,25 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
 fi
 
 if [[ "$SKLEARN_TESTS" == "true" ]]; then
-    # Install scikit-learn from conda and test against the installed
+    # Move to a dedicated folder to avoid being polluted by joblib specific conftest.py
+    # and disable the doctest plugin to avoid issues with doctests in scikit-learn
+    # docstrings that require setting print_changed_only=True temporarily.
+    NEW_TEST_DIR=$(mktemp -d)
+    cd $NEW_TEST_DIR
+
+    # Install the nightly build of scikit-learn and test against the installed
     # development version of joblib.
-    conda remove -y numpy
     # TODO: unpin pip once either https://github.com/pypa/pip/issues/10825
     # accepts invalid HTML or Anaconda is fixed.
     conda install -y -c conda-forge cython pillow numpy scipy "pip<22"
     pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
 
-    # Move to a dedicated folder to avoid being polluted by joblib specific conftest.py
-    # and disable the doctest plugin to avoid issues with doctests in scikit-learn
-    # docstrings that require setting print_changed_only=True temporarily.
-    NEW_TEST_DIR=$(mktemp -d)
-    cd $NEW_TEST_DIR
+    # DEBUG env
+    which pip
+    which python
+    which pytest
+
     pytest -vl --maxfail=5 -p no:doctest \
         # Don't worry about deprecated imports: this is tested for real
         # in upstream scikit-learn and this is not joblib's responsibility.

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -35,7 +35,8 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
     # Move to a dedicated folder to avoid being polluted by joblib specific conftest.py
     # and disable the doctest plugin to avoid issues with doctests in scikit-learn
     # docstrings that require setting print_changed_only=True temporarily.
-    cd "/tmp"
+    NEW_TEST_DIR=$(mktemp -d)
+    cd $NEW_TEST_DIR
     pytest -vl --maxfail=5 -p no:doctest \
         # Don't worry about deprecated imports: this is tested for real
         # in upstream scikit-learn and this is not joblib's responsibility.

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -25,12 +25,6 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
 fi
 
 if [[ "$SKLEARN_TESTS" == "true" ]]; then
-    # Move to a dedicated folder to avoid being polluted by joblib specific conftest.py
-    # and disable the doctest plugin to avoid issues with doctests in scikit-learn
-    # docstrings that require setting print_changed_only=True temporarily.
-    NEW_TEST_DIR=$(mktemp -d)
-    cd $NEW_TEST_DIR
-
     # Install the nightly build of scikit-learn and test against the installed
     # development version of joblib.
     # TODO: unpin pip once either https://github.com/pypa/pip/issues/10825
@@ -39,15 +33,16 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
     pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
 
-    # DEBUG env
-    which pip
-    which python
-    which pytest
+    # Move to a dedicated folder to avoid being polluted by joblib specific conftest.py
+    # and disable the doctest plugin to avoid issues with doctests in scikit-learn
+    # docstrings that require setting print_changed_only=True temporarily.
+    NEW_TEST_DIR=$(mktemp -d)
+    cd $NEW_TEST_DIR
 
+    # Don't worry about deprecated imports: this is tested for real
+    # in upstream scikit-learn and this is not joblib's responsibility.
+    # Let's skip this test to avoid false positives in joblib's CI.
     pytest -vl --maxfail=5 -p no:doctest \
-        # Don't worry about deprecated imports: this is tested for real
-        # in upstream scikit-learn and this is not joblib's responsibility.
-        # Let's skip this test to avoid false positives in joblib's CI.
         -k "not test_import_is_deprecated" \
         --pyargs sklearn
 fi


### PR DESCRIPTION
This should fix the sklearn test setup by making pytest not try to collect tests on unrelated XML files with missing read permission in the `/tmp` folder.