### PR TITLE
MAINT: pin pytest<7 in pypy3 CI

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -12,8 +12,8 @@ set -e
 
 create_new_conda_env() {
     conda update --yes conda
-    # TODO: unpin pytest once it no longer cause freeze at the end
-    # of the tests.
+    # TODO: unpin pytest once it no longer causes test errors because of
+    # PytestRemovedIn8Warning warnings
     TO_INSTALL="python=$PYTHON_VERSION pip pytest<7.0 $EXTRA_CONDA_PACKAGES"
     conda create -n testenv --yes $TO_INSTALL
     source activate testenv
@@ -25,7 +25,9 @@ create_new_pypy3_env() {
     tar xvf $PYPY_FOLDER.tar.bz2
     $PYPY_FOLDER/bin/pypy3 -m venv pypy3
     source pypy3/bin/activate
-    pip install -U pip pytest
+    # TODO: unpin pytest once it no longer causes test errors because of
+    # PytestRemovedIn8Warning warnings
+    pip install -U pip 'pytest<7.0'
 }
 
 if [[ "$PYTHON_VERSION" == "pypy3" ]]; then


### PR DESCRIPTION
similar to https://github.com/joblib/joblib/pull/1261 but for pypy

Also tweak the comments, I don't think this causes freezes but only test errors because there are additional PytestRemovedIn8Warning (but maybe I missed something ...)