### PR TITLE
Fix remaining resource_tracker-related test warning failures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Latest changes
 Development version
 -------------------
 
+- Avoid unnecessary warnings when workers and main process delete
+  the temporary memmap folder contents concurrently.
+  https://github.com/joblib/joblib/pull/1263
+
 Release 1.1.0
 --------------
 

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -99,6 +99,10 @@ def unlink_file(filename):
                 raise
             else:
                 time.sleep(.2)
+        except FileNotFoundError:
+            # In case of a race condition when deleting the temporary folder,
+            # avoid noisy FileNotFoundError exception in the resource tracker.
+            pass
 
 
 resource_tracker._CLEANUP_FUNCS['file'] = unlink_file

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -661,7 +661,7 @@ class TemporaryResourcesManager(object):
                 # Now that this folder is deleted, we can forget about it
                 self._unregister_context(context_id)
 
-            except PermissionError:
+            except OSError:
                 # Temporary folder cannot be deleted right now. No need to
                 # handle it though, as this folder will be cleaned up by an
                 # atexit finalizer registered by the memmapping_reducer.

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -661,7 +661,7 @@ class TemporaryResourcesManager(object):
                 # Now that this folder is deleted, we can forget about it
                 self._unregister_context(context_id)
 
-            except OSError:
+            except PermissionError:
                 # Temporary folder cannot be deleted right now. No need to
                 # handle it though, as this folder will be cleaned up by an
                 # atexit finalizer registered by the memmapping_reducer.

--- a/joblib/disk.py
+++ b/joblib/disk.py
@@ -69,7 +69,7 @@ def mkdirp(d):
 # exception. this mechanism ensures that the sub-process gc have the time to
 # collect and close the memmaps before we fail.
 RM_SUBDIRS_RETRY_TIME = 0.1
-RM_SUBDIRS_N_RETRY = 5
+RM_SUBDIRS_N_RETRY = 10
 
 
 def rm_subdirs(path, onerror=None):

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -822,8 +822,13 @@ def test_child_raises_parent_exits_cleanly(backend):
                               for i in range(1))
             except ValueError as e:
                 # the temporary folder should be deleted by the end of this
-                # call
-                if os.path.exists(temp_folder):
+                # call but apparently on some file systems, this takes
+                # some time to be visible.
+                for i in range(10):
+                    if not os.path.exists(temp_folder):
+                        break
+                    sleep(.1)
+                else:
                     raise AssertionError(
                         temp_folder + " was not deleted"
                     ) from e


### PR DESCRIPTION
Blindly trying something on the CI.

I cannot reproduce the race condition on my laptop unfortunately.

Furthermore it seems that we also observe this test failing on one of the macos builds with the multiprocessing backend although I am not 100% sure why.