### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setup(
     author='Gael Varoquaux',
     author_email='gael.varoquaux@normalesup.org',
     url='https://joblib.readthedocs.io',
+    project_urls={
+        'Source': 'https://github.com/joblib/joblib',
+    },
     license='BSD',
     description="Lightweight pipelining with Python functions",
     long_description=long_description,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.