### PR TITLE
IterableParallel

### DIFF
--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -118,6 +118,7 @@ from .numpy_pickle import dump
 from .numpy_pickle import load
 from .compressor import register_compressor
 from .parallel import Parallel
+from .parallel import IterableParallel
 from .parallel import delayed
 from .parallel import cpu_count
 from .parallel import register_parallel_backend
@@ -127,7 +128,7 @@ from ._cloudpickle_wrapper import wrap_non_picklable_objects
 
 
 __all__ = ['Memory', 'MemorizedResult', 'PrintTime', 'Logger', 'hash', 'dump',
-           'load', 'Parallel', 'delayed', 'cpu_count', 'effective_n_jobs',
+           'load', 'Parallel', 'IterableParallel', 'delayed', 'cpu_count', 'effective_n_jobs',
            'register_parallel_backend', 'parallel_backend',
            'register_store_backend', 'register_compressor',
            'wrap_non_picklable_objects']

--- a/joblib/__init__.py
+++ b/joblib/__init__.py
@@ -128,7 +128,8 @@ from ._cloudpickle_wrapper import wrap_non_picklable_objects
 
 
 __all__ = ['Memory', 'MemorizedResult', 'PrintTime', 'Logger', 'hash', 'dump',
-           'load', 'Parallel', 'IterableParallel', 'delayed', 'cpu_count', 'effective_n_jobs',
+           'load', 'Parallel', 'IterableParallel', 'delayed',
+           'cpu_count', 'effective_n_jobs',
            'register_parallel_backend', 'parallel_backend',
            'register_store_backend', 'register_compressor',
            'wrap_non_picklable_objects']

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1129,7 +1129,8 @@ class IterableParallel(Parallel):
 
     Examples
     --------
-    An example of iterating over outputs and write each one to a file, while keeping track of progress using ``tqdm``:
+    An example of iterating over outputs and write each one to a file,
+    while keeping track of progress using ``tqdm``:
 
     >>> import time, tempfile
     >>> from joblib import IterableParallel, delayed
@@ -1141,7 +1142,8 @@ class IterableParallel(Parallel):
     ...
     >>> t = tqdm(total=5) #doctest: +SKIP
     >>> with open(tempfile.mktemp(), 'w') as f_out:
-    ...     for out in IterableParallel(-1)(delayed(dummy_task)(x) for x in range(5)): #doctest: +SKIP
+    ...     for out in IterableParallel(-1)(
+    ...         delayed(dummy_task)(x) for x in range(5)): #doctest: +SKIP
     ...         f_out.write(f'got result: {out}')
     ...         t.update(1) #doctest: +SKIP
     ...

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1131,7 +1131,7 @@ class IterableParallel(Parallel):
     --------
     An example of iterating over outputs and write each one to a file, while keeping track of progress using ``tqdm``:
 
-    >>> import time
+    >>> import time, tempfile
     >>> from joblib import IterableParallel, delayed
     >>> from tqdm.auto import tqdm #doctest: +SKIP
     >>>
@@ -1140,10 +1140,10 @@ class IterableParallel(Parallel):
     ...     return x
     ...
     >>> t = tqdm(total=5) #doctest: +SKIP
-    >>> all = list()
-    >>> for out in IterableParallel(-1)(delayed(dummy_task)(x) for x in range(5)): #doctest: +SKIP
-    ...     all.append(out)
-    ...     t.update(1) #doctest: +SKIP
+    >>> with open(tempfile.mktemp(), 'w') as f_out:
+    ...     for out in IterableParallel(-1)(delayed(dummy_task)(x) for x in range(5)): #doctest: +SKIP
+    ...         f_out.write(f'got result: {out}')
+    ...         t.update(1) #doctest: +SKIP
     ...
     >>> t.close() #doctest: +SKIP
     """

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -60,7 +60,7 @@ from joblib._parallel_backends import ParallelBackendBase
 from joblib._parallel_backends import LokyBackend
 from joblib._parallel_backends import SafeFunction
 
-from joblib.parallel import Parallel, delayed
+from joblib.parallel import Parallel, delayed, IterableParallel
 from joblib.parallel import register_parallel_backend, parallel_backend
 from joblib.parallel import effective_n_jobs, cpu_count
 
@@ -169,6 +169,18 @@ def test_simple_parallel(backend, n_jobs, verbose):
             Parallel(n_jobs=n_jobs, backend=backend,
                      verbose=verbose)(
                 delayed(square)(x) for x in range(5)))
+
+
+@parametrize('backend', ALL_VALID_BACKENDS)
+@parametrize('n_jobs', [1, 2, -1, -2])
+@parametrize('verbose', [2, 11, 100])
+def test_simple_iterable_parallel(backend, n_jobs, verbose):
+    outputs = {
+        v for v in IterableParallel(n_jobs=n_jobs, backend=backend,
+                                    verbose=verbose)(
+            delayed(square)(x) for x in range(5))
+    }
+    assert ({square(x) for x in range(5)} == outputs)
 
 
 @parametrize('backend', ALL_VALID_BACKENDS)


### PR DESCRIPTION
The original `Parallel` executor collects all outputs in a list and return the full list. This could cause excessive memory usages if the job has large number of tasks each with substantial outputs. This `IterableParallel` allows the caller to consume and dispose the outputs in a loop as the each becomes available and thus both serialize the consumption and reduce memory usages.