### PR TITLE
python>=3.8 func_inspect: allow POSITIONAL_ONLY parameters

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -234,7 +234,7 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
     arg_varargs = None
     arg_varkw = None
     for param in arg_sig.parameters.values():
-        if param.kind is param.POSITIONAL_OR_KEYWORD:
+        if param.kind is param.POSITIONAL_OR_KEYWORD or param.kind is param.POSITIONAL_ONLY:
             arg_names.append(param.name)
         elif param.kind is param.KEYWORD_ONLY:
             arg_names.append(param.name)

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -48,6 +48,9 @@ def m1(x, *, y):
 def m2(x, *, y, z=3):
     pass
 
+def m3(w,/,x, *, y, z=3):
+    pass
+
 
 @fixture(scope='module')
 def cached_func(tmpdir_factory):
@@ -107,7 +110,8 @@ def test_filter_varargs(func, args, filtered_args):
 
 test_filter_kwargs_extra_params = [
     (m1, [[], (1,), {'y': 2}], {'x': 1, 'y': 2}),
-    (m2, [[], (1,), {'y': 2}], {'x': 1, 'y': 2, 'z': 3})
+    (m2, [[], (1,), {'y': 2}], {'x': 1, 'y': 2, 'z': 3}),
+    (m3, [[], (-1,1), {'y': 2}], {'w':-1,'x': 1, 'y': 2, 'z': 3})
 ]
 
 


### PR DESCRIPTION
This PR  enables correct caching for functions with positional-only arguments. This breaks compatibility with python3.7. As soon as python3.7 support is replaced by python>=3.8, this can be merged.

Positional only parameters (added in python3.8) are not hashed. This is due to filter_args which handles POSITIONAL_OR_KEYWORD parameters but ignores POSITIONAL_ONLY parameters. Since hashing uses a name-value tuple list, it is possible to treat POSITIONAL_ONLY equivalently to POSITIONAL_OR_KEYWORD parameters. 

