### PR TITLE
FIX make sure pre_dispatch cannot do arbitrary code execution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Development version
   specific assembly.
   https://github.com/joblib/joblib/pull/1254
 
+- Fix a security issue where ``eval(pre_dispatch)`` could potentially run
+  arbitrary code. Now only basic numerics are supported.
+
 Release 1.1.0
 --------------
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -504,7 +504,9 @@ class Parallel(Logger):
         pre_dispatch: {'all', integer, or expression, as in '3*n_jobs'}
             The number of batches (of tasks) to be pre-dispatched.
             Default is '2*n_jobs'. When batch_size="auto" this is reasonable
-            default and the workers should never starve.
+            default and the workers should never starve. Note that only basic
+            arithmetics are allowed here and no modules can be used in this
+            expression.
         batch_size: int or 'auto', default: 'auto'
             The number of atomic tasks to dispatch at once to each
             worker. When individual evaluations are very fast, dispatching
@@ -1049,7 +1051,11 @@ class Parallel(Logger):
         else:
             self._original_iterator = iterator
             if hasattr(pre_dispatch, 'endswith'):
-                pre_dispatch = eval(pre_dispatch)
+                pre_dispatch = eval(
+                    pre_dispatch,
+                    {"n_jobs": n_jobs, "__builtins__": {}},  # globals
+                    {}  # locals
+                )
             self._pre_dispatch_amount = pre_dispatch = int(pre_dispatch)
 
             # The main thread will consume the first pre_dispatch items and


### PR DESCRIPTION
Fixes #1128

Make sure nothing's available to `eval` for `pre_dispatch`.

cc @ogrisel 