### PR TITLE
cloudpickle 2.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ Development version
   arbitrary code. Now only basic numerics are supported.
   https://github.com/joblib/joblib/pull/1321
 
+- Vendor cloudpickle 2.2.0 which adds support for PyPy 3.8+.
+
 Release 1.1.0
 --------------
 

--- a/joblib/externals/cloudpickle/__init__.py
+++ b/joblib/externals/cloudpickle/__init__.py
@@ -5,4 +5,4 @@ from .cloudpickle_fast import CloudPickler, dumps, dump  # noqa
 # expose their Pickler subclass at top-level under the  "Pickler" name.
 Pickler = CloudPickler
 
-__version__ = '2.1.0'
+__version__ = '2.2.0'

--- a/joblib/externals/cloudpickle/compat.py
+++ b/joblib/externals/cloudpickle/compat.py
@@ -7,7 +7,12 @@ if sys.version_info < (3, 8):
         from pickle5 import Pickler  # noqa: F401
     except ImportError:
         import pickle  # noqa: F401
+
+        # Use the Python pickler for old CPython versions
         from pickle import _Pickler as Pickler  # noqa: F401
 else:
     import pickle  # noqa: F401
-    from _pickle import Pickler  # noqa: F401
+
+    # Pickler will the C implementation in CPython and the Python
+    # implementation in PyPy
+    from pickle import Pickler  # noqa: F401


### PR DESCRIPTION
Towards a true fix for the https://github.com/scikit-learn/scikit-learn/pull/24376 workaround to add support for PyPy 3.8+.