### PR TITLE
FIX parse pre-dispatch with AST instead of calling eval

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Development version
 
 - Fix a security issue where ``eval(pre_dispatch)`` could potentially run
   arbitrary code. Now only basic numerics are supported.
-  https://github.com/joblib/joblib/pull/1321
+  https://github.com/joblib/joblib/pull/1327
 
 - Vendor cloudpickle 2.2.0 which adds support for PyPy 3.8+.
 

--- a/joblib/_utils.py
+++ b/joblib/_utils.py
@@ -1,0 +1,35 @@
+import ast
+import operator as op
+
+# supported operators
+operators = {
+    ast.Add: op.add,
+    ast.Sub: op.sub,
+    ast.Mult: op.mul,
+    ast.Div: op.truediv,
+    ast.Pow: op.pow,
+    ast.USub: op.neg,
+}
+
+
+def eval_expr(expr):
+    """
+    >>> eval_expr('2*6')
+    12
+    >>> eval_expr('2**6')
+    64
+    >>> eval_expr('1 + 2*3**(4) / (6 + -7)')
+    -161.0
+    """
+    return eval_(ast.parse(expr, mode="eval").body)
+
+
+def eval_(node):
+    if isinstance(node, ast.Num):  # <number>
+        return node.n
+    elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
+        return operators[type(node.op)](eval_(node.left), eval_(node.right))
+    elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
+        return operators[type(node.op)](eval_(node.operand))
+    else:
+        raise TypeError(node)

--- a/joblib/_utils.py
+++ b/joblib/_utils.py
@@ -1,3 +1,5 @@
+# Adapted from https://stackoverflow.com/a/9558001/2536294
+
 import ast
 import operator as op
 

--- a/joblib/_utils.py
+++ b/joblib/_utils.py
@@ -28,7 +28,9 @@ def eval_expr(expr):
     try:
         return eval_(ast.parse(expr, mode="eval").body)
     except (TypeError, SyntaxError, KeyError) as e:
-        raise ValueError(f"{expr!r} is not a valid arithmetic expression.") from e
+        raise ValueError(
+            f"{expr!r} is not a valid or supported arithmetic expression."
+        ) from e
 
 
 def eval_(node):

--- a/joblib/_utils.py
+++ b/joblib/_utils.py
@@ -9,6 +9,8 @@ operators = {
     ast.Sub: op.sub,
     ast.Mult: op.mul,
     ast.Div: op.truediv,
+    ast.FloorDiv: op.floordiv,
+    ast.Mod: op.mod,
     ast.Pow: op.pow,
     ast.USub: op.neg,
 }
@@ -23,7 +25,10 @@ def eval_expr(expr):
     >>> eval_expr('1 + 2*3**(4) / (6 + -7)')
     -161.0
     """
-    return eval_(ast.parse(expr, mode="eval").body)
+    try:
+        return eval_(ast.parse(expr, mode="eval").body)
+    except (TypeError, SyntaxError, KeyError) as e:
+        raise ValueError(f"{expr!r} is not a valid arithmetic expression.") from e
 
 
 def eval_(node):

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -27,6 +27,7 @@ from ._parallel_backends import (FallbackToBackend, MultiprocessingBackend,
                                  ThreadingBackend, SequentialBackend,
                                  LokyBackend)
 from .externals.cloudpickle import dumps, loads
+from ._utils import eval_expr
 
 # Make sure that those two classes are part of the public joblib.parallel API
 # so that 3rd party backend implementers can import them from here.
@@ -1051,10 +1052,8 @@ class Parallel(Logger):
         else:
             self._original_iterator = iterator
             if hasattr(pre_dispatch, 'endswith'):
-                pre_dispatch = eval(
-                    pre_dispatch,
-                    {"n_jobs": n_jobs, "__builtins__": {}},  # globals
-                    {}  # locals
+                pre_dispatch = eval_expr(
+                    pre_dispatch.replace("n_jobs", str(n_jobs))
                 )
             self._pre_dispatch_amount = pre_dispatch = int(pre_dispatch)
 

--- a/joblib/test/test_utils.py
+++ b/joblib/test/test_utils.py
@@ -8,7 +8,9 @@ from joblib._utils import eval_expr
     ["exec('import os')", "print(1)", "import os", "1+1; import os", "1^1"],
 )
 def test_eval_expr_invalid(expr):
-    with pytest.raises(ValueError, match="is not a valid or supported arithmetic"):
+    with pytest.raises(
+        ValueError, match="is not a valid or supported arithmetic"
+    ):
         eval_expr(expr)
 
 

--- a/joblib/test/test_utils.py
+++ b/joblib/test/test_utils.py
@@ -8,7 +8,7 @@ from joblib._utils import eval_expr
     ["exec('import os')", "print(1)", "import os", "1+1; import os", "1^1"],
 )
 def test_eval_expr_invalid(expr):
-    with pytest.raises(ValueError, match="is not a valid arithmetic expression"):
+    with pytest.raises(ValueError, match="is not a valid or supported arithmetic"):
         eval_expr(expr)
 
 

--- a/joblib/test/test_utils.py
+++ b/joblib/test/test_utils.py
@@ -1,0 +1,25 @@
+import pytest
+
+from joblib._utils import eval_expr
+
+
+@pytest.mark.parametrize(
+    "expr, error, message",
+    [
+        ("exec('import os')", TypeError, "ast.Call object"),
+        ("print(1)", TypeError, "ast.Call object"),
+        ("import os", SyntaxError, "invalid syntax"),
+        ("1+1; import os", SyntaxError, "invalid syntax"),
+        ("1^1", KeyError, "class 'ast.BitXor'"),
+    ],
+)
+def test_eval_expr_invalid(expr, error, message):
+    with pytest.raises(error, match=message):
+        eval_expr(expr)
+
+
+@pytest.mark.parametrize(
+    "expr, result", [("2*6", 12), ("2**6", 64), ("1 + 2*3**(4) / (6 + -7)", -161.0)]
+)
+def test_eval_expr_valid(expr, result):
+    assert eval_expr(expr) == result

--- a/joblib/test/test_utils.py
+++ b/joblib/test/test_utils.py
@@ -4,22 +4,22 @@ from joblib._utils import eval_expr
 
 
 @pytest.mark.parametrize(
-    "expr, error, message",
-    [
-        ("exec('import os')", TypeError, "ast.Call object"),
-        ("print(1)", TypeError, "ast.Call object"),
-        ("import os", SyntaxError, "invalid syntax"),
-        ("1+1; import os", SyntaxError, "invalid syntax"),
-        ("1^1", KeyError, "class 'ast.BitXor'"),
-    ],
+    "expr",
+    ["exec('import os')", "print(1)", "import os", "1+1; import os", "1^1"],
 )
-def test_eval_expr_invalid(expr, error, message):
-    with pytest.raises(error, match=message):
+def test_eval_expr_invalid(expr):
+    with pytest.raises(ValueError, match="is not a valid arithmetic expression"):
         eval_expr(expr)
 
 
 @pytest.mark.parametrize(
-    "expr, result", [("2*6", 12), ("2**6", 64), ("1 + 2*3**(4) / (6 + -7)", -161.0)]
+    "expr, result",
+    [
+        ("2*6", 12),
+        ("2**6", 64),
+        ("1 + 2*3**(4) / (6 + -7)", -161.0),
+        ("(20 // 3) % 5", 1),
+    ],
 )
 def test_eval_expr_valid(expr, result):
     assert eval_expr(expr) == result


### PR DESCRIPTION
I realized https://github.com/joblib/joblib/pull/1321 doesn't actually fix the issue, since `eval("exec('import os')", {}, {})` would still work.

This PR uses AST and limits the operations to the very basic ones.

This should be an actual fix for https://github.com/joblib/joblib/issues/1128

cc @ogrisel 