### PR TITLE
Make test  timeout more informatively on macos CI

### DIFF
--- a/joblib/testing.py
+++ b/joblib/testing.py
@@ -50,9 +50,10 @@ def check_subprocess_call(cmd, timeout=5, stdout_regex=None,
         warnings.warn("Timeout running {}".format(cmd))
         proc.kill()
 
-    timer = threading.Timer(timeout, kill_process)
     try:
-        timer.start()
+        if timeout is not None:
+            timer = threading.Timer(timeout, kill_process)
+            timer.start()
         stdout, stderr = proc.communicate()
         stdout, stderr = stdout.decode(), stderr.decode()
         if proc.returncode != 0:
@@ -74,4 +75,5 @@ def check_subprocess_call(cmd, timeout=5, stdout_regex=None,
                     stderr_regex, stderr))
 
     finally:
-        timer.cancel()
+        if timeout is not None:
+            timer.cancel()


### PR DESCRIPTION
`test_parallel_with_interactively_defined_functions_default_backend` happens to be killed from time to time on the slow macos CI host and the error message was not informative.

Using faulthandler in the subprocess script instead should help although I suspect that this wasn't really a deadlock but that the previous 5s timeout was too short for the slow CI host.

Let's see.