### PR TITLE
MAINT add back pytest warnings plugin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 addopts =
     --doctest-glob="doc/*.rst"
     --doctest-modules
-    -p no:warnings
     --ignore joblib/externals
 testpaths = joblib
 


### PR DESCRIPTION
It was removed in https://github.com/joblib/joblib/pull/525, not sure whether this is still needed. At least locally the test pass on my machine with the changes in my PR.

Context: I was trying to trigger warnings due to `pytest.warns(None)` and pytest 7 and could not see them. https://docs.pytest.org/en/7.0.x/deprecations.html#using-pytest-warns-none

Probably it would be good to get the `pytest.warns(None)` replacement from https://github.com/joblib/joblib/pull/1264
