### PR TITLE
Ensure native byte order for memmap.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Latest changes
 In development
 --------------
 
-- TODO
+- Ensure native byte order for memmap arrays when pickling.
+  https://github.com/joblib/joblib/issues/1353
 
 Release 1.2.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Latest changes
 In development
 --------------
 
-- Ensure native byte order for memmap arrays when pickling.
+- Ensure native byte order for memmap arrays in `joblib.load`.
   https://github.com/joblib/joblib/issues/1353
 
 Release 1.2.0

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -229,7 +229,7 @@ class NumpyArrayWrapper(object):
             )
             warnings.warn(message)
 
-        return marray
+        return _ensure_native_byte_order(marray)
 
     def read(self, unpickler):
         """Read the array corresponding to this wrapper.


### PR DESCRIPTION
This pull request ensures native byte order for numpy memmap ndarray, generalizing the fix for ndarray applied in #1181.
It is supposed to fix #1353.

Thanks for considering it.