### PR TITLE
added update_wrapper to NotMemorizedFunc.__init__

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -344,6 +344,10 @@ class NotMemorizedFunc(object):
     # Should be a light as possible (for speed)
     def __init__(self, func):
         self.func = func
+        try:
+            functools.update_wrapper(self, func)
+        except:
+            "Objects like ufunc don't like that"
 
     def __call__(self, *args, **kwargs):
         return self.func(*args, **kwargs)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -700,6 +700,9 @@ def test_memorized_pickling(tmpdir):
         assert result2.get() == result.get()
         os.remove(filename)
 
+def test_func_attrs(tmpdir):
+    assert NotMemorizedFunc(f).__name__ == 'f'
+    assert MemorizedFunc(f, tmpdir.strpath).__name__ == 'f'
 
 def test_memorized_repr(tmpdir):
     func = MemorizedFunc(f, tmpdir.strpath)


### PR DESCRIPTION
Quick fix for a problem I recently found. If no cache is used function wrapped with `@memory.cache` is replaced by **NotMemorizedFunc** wrapper. This wrapper does nor preserve original properties of the function - in my case **__name__** was not available. This makes function behave differently depending whether the cache is defined or not. 

Code to fix the problem is a copy paste from https://github.com/p610/joblib/blob/master/joblib/memory.py#L444

Maybe there is a better way to address it. 