### PR TITLE
Do not swallow PicklingError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ In development
   https://github.com/joblib/joblib/pull/1361
 
 - A warning is raised when a pickling error occurs during caching operations.
-  In the future, this warning will be turned into an error. For all other
+  In version 1.5, this warning will be turned into an error. For all other
   errors, a new warning has been introduced: `joblib.memory.CacheWarning`.
   https://github.com/joblib/joblib/pull/1359
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ In development
   in May 2022) that it should be safe to remove this.
   https://github.com/joblib/joblib/pull/1361
 
+- A warning is raised when a pickling error occurs during caching operations.
+  In the future, this warning will be turned into an error. For all other
+  errors, a new warning has been introduced: `joblib.memory.CacheWarning`.
+  https://github.com/joblib/joblib/pull/1359
+
 Release 1.2.0
 -------------
 

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -1,5 +1,6 @@
 """Storage providers backends for Memory caching."""
 
+from pickle import PicklingError
 import re
 import os
 import os.path
@@ -189,6 +190,8 @@ class StoreBackendMixin(object):
                                       compress=self.compress)
 
             self._concurrency_safe_write(item, filename, write_func)
+        except PicklingError:
+            raise
         except:  # noqa: E722
             " Race condition in the creation of the directory "
 

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -21,6 +21,11 @@ CacheItemInfo = collections.namedtuple('CacheItemInfo',
                                        'path size last_access')
 
 
+class CacheWarning(Warning):
+    """Warning to capture dump failures except for PicklingError."""
+    pass
+
+
 def concurrency_safe_write(object_to_write, filename, write_func):
     """Writes an object into a unique file in a concurrency-safe way."""
     thread_id = id(threading.current_thread())
@@ -190,20 +195,19 @@ class StoreBackendMixin(object):
                         numpy_pickle.dump(to_write, f, compress=self.compress)
                     except PicklingError as e:
                         warnings.warn(
-                            'Unable to cache to disk: '
-                            'failed to pickle output. '
-                            'In future versions of joblib '
-                            'this will raise an exception.'
-                            'Exception: %s.' % e,
+                            "Unable to cache to disk: failed to pickle "
+                            "output. In future versions of joblib this "
+                            f"will raise an exception. Exception: {e}.",
                             FutureWarning
                         )
 
             self._concurrency_safe_write(item, filename, write_func)
         except Exception as e:  # noqa: E722
             warnings.warn(
-                'Unable to cache to disk. '
-                'Possibly a race condition in the creation of the directory. '
-                'Exception: %s' % e)
+                "Unable to cache to disk. Possibly a race condition in the "
+                f"creation of the directory. Exception: {e}.",
+                CacheWarning
+            )
 
     def clear_item(self, path):
         """Clear the item at the path, given as a list of strings."""

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -194,10 +194,11 @@ class StoreBackendMixin(object):
                     try:
                         numpy_pickle.dump(to_write, f, compress=self.compress)
                     except PicklingError as e:
+                        #TODO(1.5) turn into error
                         warnings.warn(
                             "Unable to cache to disk: failed to pickle "
-                            "output. In future versions of joblib this "
-                            f"will raise an exception. Exception: {e}.",
+                            "output. In version 1.5 this will raise an "
+                            f"exception. Exception: {e}.",
                             FutureWarning
                         )
 

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -190,16 +190,20 @@ class StoreBackendMixin(object):
                         numpy_pickle.dump(to_write, f, compress=self.compress)
                     except PicklingError as e:
                         warnings.warn(
-                            'Unable to cache to disk: failed to pickle output. '
-                            'In future versions of joblib this will raise an exception.'
+                            'Unable to cache to disk: '
+                            'failed to pickle output. '
+                            'In future versions of joblib '
+                            'this will raise an exception.'
                             'Exception: %s.' % e,
                             FutureWarning
                         )
 
             self._concurrency_safe_write(item, filename, write_func)
         except Exception as e:  # noqa: E722
-            warnings.warn('Unable to cache to disk. Possibly race condition in the creation of the directory. '
-                          'Exception: %s' % e)
+            warnings.warn(
+                'Unable to cache to disk. '
+                'Possibly a race condition in the creation of the directory. '
+                'Exception: %s' % e)
 
     def clear_item(self, path):
         """Clear the item at the path, given as a list of strings."""

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -194,7 +194,7 @@ class StoreBackendMixin(object):
                     try:
                         numpy_pickle.dump(to_write, f, compress=self.compress)
                     except PicklingError as e:
-                        #TODO(1.5) turn into error
+                        # TODO(1.5) turn into error
                         warnings.warn(
                             "Unable to cache to disk: failed to pickle "
                             "output. In version 1.5 this will raise an "

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -30,6 +30,7 @@ from .func_inspect import format_call
 from .func_inspect import format_signature
 from .logger import Logger, format_time, pformat
 from ._store_backends import StoreBackendBase, FileSystemStoreBackend
+from ._store_backends import CacheWarning  # noqa
 
 
 FIRST_LINE_TEXT = "# first line:"

--- a/joblib/test/test_store_backends.py
+++ b/joblib/test/test_store_backends.py
@@ -15,7 +15,8 @@ from joblib.testing import parametrize, timeout
 from joblib.test.common import with_multiprocessing
 from joblib.backports import concurrency_safe_rename
 from joblib import Parallel, delayed, numpy_pickle
-from joblib._store_backends import concurrency_safe_write, FileSystemStoreBackend
+from joblib._store_backends import concurrency_safe_write, \
+    FileSystemStoreBackend
 
 
 def write_func(output, filename):

--- a/joblib/test/test_store_backends.py
+++ b/joblib/test/test_store_backends.py
@@ -81,7 +81,8 @@ def test_warning_on_dump_failure(tmpdir, monkeypatch):
 
 @with_multiprocessing
 def test_warning_on_pickling_error(tmpdir, monkeypatch):
-    # This is separate from test_warning_on_dump_failure because in the future we will turn this into an exception.
+    # This is separate from test_warning_on_dump_failure because in the
+    # future we will turn this into an exception.
     backend = FileSystemStoreBackend()
     backend.location = tmpdir.join('test_warning_on_pickling_error').strpath
     backend.compress = None


### PR DESCRIPTION
Currently, when caching fails because the function output can't be pickled, there is no warning, but the output will not be cached. This surprises users, who expect their output to be cached.

This is related to https://github.com/joblib/joblib/issues/952 and https://github.com/joblib/joblib/issues/896 . It does not solve the underlying race condition in https://github.com/joblib/joblib/issues/896, but it does implement the suggestion made by @tomMoral [in this comment](https://github.com/joblib/joblib/issues/952#issuecomment-546370327): it just raises an error when the caching fails due to pickling.