### PR TITLE
Drop runtime dependency on `distutils`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ In development
 - Ensure native byte order for memmap arrays in `joblib.load`.
   https://github.com/joblib/joblib/issues/1353
 
+- Drop runtime dependency on ``distutils``. ``distutils`` is going away
+  in Python 3.12 and is deprecated from Python 3.10 onwards. This import
+  was kept around to avoid breaking scikit-learn, however it's now been
+  long enough since scikit-learn deployed a fixed (verion 1.1 was released
+  in May 2022) that it should be safe to remove this.
+  https://github.com/joblib/joblib/pull/1361
+
 Release 1.2.0
 -------------
 

--- a/joblib/backports.py
+++ b/joblib/backports.py
@@ -8,19 +8,6 @@ import time
 from os.path import basename
 from multiprocessing import util
 
-# Prior to joblib 1.2, joblib used to import LooseVersion from
-# distutils.version. This import had a side-effect with setuptools that was
-# implicitly required in sklearn.show_versions() to work without raising an
-# exception for scikit-learn 1.0 and earlier. This has been fixed in
-# scikit-learn 1.1 (not yet released at the time of writing), see:
-# https://github.com/scikit-learn/scikit-learn/issues/22614
-#
-# To avoid unnecessary disruption for users who might update to joblib 1.2
-# prior to a release of scikit-learn that includes the fix, let's keep on
-# importing distutils here. TODO: Remove this for a future release of joblib,
-# e.g. 6 months after the release of scikit-learn 1.1.
-import distutils  # noqa
-
 
 class Version:
     """Backport from deprecated distutils


### PR DESCRIPTION
`distutils` is going away in Python 3.12 and is deprecated from Python 3.10 onwards. It's also kinda slow to import. This import was kept around to avoid breaking scikit-learn, however it's now been long enough since scikit-learn deployed a fix ([scikit-learn 1.1](https://pypi.org/project/scikit-learn/1.1.0/) was released in May 2022) that it should be safe to remove this.