### PR TITLE
Fix - Do not split abspath with dot

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -119,7 +119,8 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
     if module is None:
         # Happens in doctests, eg
         module = ''
-    if module == '__main__':
+    module = module.split('.')
+    if module == ['__main__']:
         try:
             filename = os.path.abspath(inspect.getsourcefile(func))
         except:
@@ -152,8 +153,7 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
             filename = '-'.join(parts)
             if filename.endswith('.py'):
                 filename = filename[:-3]
-            module = module + '-' + filename
-    module = module.split('.')
+            module[0] = module[0] + '-' + filename
     if hasattr(func, 'func_name'):
         name = func.func_name
     elif hasattr(func, '__name__'):


### PR DESCRIPTION
Hello,

Following issue #1362, this improvement avoid splitting the absolute path whenever a dot is found in it. Let's say that a folder in this path is named name.folder, then the test `test_parallel_call_cached_function_defined_in_jupyter`  does not pass. Plus it create an extra level in the tree structure of backend store.

Let me know if there is a problem with that.

Thank you!