### PR TITLE
Fix memmapping_reducer when 'os' has no attribute 'statvfs'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ In development
   JOBLIB_TESTS_DEFAULT_PARALLEL_BACKEND environment variable.
   https://github.com/joblib/joblib/pull/1356
 
+- Fix temporary folder creation in `joblib.Parallel` on Linux subsystems on Windows
+  which do have `/dev/shm` but don't have the `os.statvfs` function 
+  https://github.com/joblib/joblib/issues/1353
+
 - Drop runtime dependency on ``distutils``. ``distutils`` is going away
   in Python 3.12 and is deprecated from Python 3.10 onwards. This import
   was kept around to avoid breaking scikit-learn, however it's now been

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -203,7 +203,7 @@ def _get_temp_dir(pool_folder_name, temp_folder=None):
     if temp_folder is None:
         temp_folder = os.environ.get('JOBLIB_TEMP_FOLDER', None)
     if temp_folder is None:
-        if os.path.exists(SYSTEM_SHARED_MEM_FS):
+        if os.path.exists(SYSTEM_SHARED_MEM_FS) and hasattr(os, 'statvfs'):
             try:
                 shm_stats = os.statvfs(SYSTEM_SHARED_MEM_FS)
                 available_nbytes = shm_stats.f_bsize * shm_stats.f_bavail

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -1057,6 +1057,21 @@ def test_pool_get_temp_dir(tmpdir):
         assert shared_mem is False
     assert pool_folder.endswith(pool_folder_name)
 
+def test_pool_get_temp_dir_no_statvfs(tmpdir, monkeypatch):
+    """Check that _get_temp_dir works when os.statvfs is not defined
+
+    Regression test for #902
+    """
+    pool_folder_name = 'test.tmpdir'
+    import joblib._memmapping_reducer
+    monkeypatch.delattr(joblib._memmapping_reducer.os, 'statvfs')
+
+    pool_folder, shared_mem = _get_temp_dir(pool_folder_name, temp_folder=None)
+    if sys.platform.startswith('win'):
+        assert shared_mem is False
+    assert pool_folder.endswith(pool_folder_name)
+
+
 
 @with_numpy
 @skipif(sys.platform == 'win32', reason='This test fails with a '

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -1065,7 +1065,9 @@ def test_pool_get_temp_dir_no_statvfs(tmpdir, monkeypatch):
     """
     pool_folder_name = 'test.tmpdir'
     import joblib._memmapping_reducer
-    monkeypatch.delattr(joblib._memmapping_reducer.os, 'statvfs')
+    if hasattr(joblib._memmapping_reducer.os, 'statvfs'):
+        # We are on Unix, since Windows doesn't have this function
+        monkeypatch.delattr(joblib._memmapping_reducer.os, 'statvfs')
 
     pool_folder, shared_mem = _get_temp_dir(pool_folder_name, temp_folder=None)
     if sys.platform.startswith('win'):

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -1057,6 +1057,7 @@ def test_pool_get_temp_dir(tmpdir):
         assert shared_mem is False
     assert pool_folder.endswith(pool_folder_name)
 
+
 def test_pool_get_temp_dir_no_statvfs(tmpdir, monkeypatch):
     """Check that _get_temp_dir works when os.statvfs is not defined
 
@@ -1070,7 +1071,6 @@ def test_pool_get_temp_dir_no_statvfs(tmpdir, monkeypatch):
     if sys.platform.startswith('win'):
         assert shared_mem is False
     assert pool_folder.endswith(pool_folder_name)
-
 
 
 @with_numpy


### PR DESCRIPTION
Closes https://github.com/joblib/joblib/issues/902

In this case when 'os' has no attribute 'statvfs' we don't use `/dev/shm` even if it exists, as we are then not able to determine how much free space it has.

The other possible solution could be to ignore `SYSTEM_SHARED_MEM_FS_MIN_SIZE` and still write to `/dev/shm`.

The typical use case where this could happen is when running a Linux like system on Windows (which doesn't have statvfs apparently). I'm not sure what would be better.

