### PR TITLE
FIX Avoid name collisions for nested functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ In development
   in May 2022) that it should be safe to remove this.
   https://github.com/joblib/joblib/pull/1361
 
+- Avoid (module, name) collisions when caching nested functions. This fix changes the
+  module name of nested functions, invalidating caches from previous versions of Joblib.
+  https://github.com/joblib/joblib/pull/1385
+
 Release 1.2.0
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,8 +22,9 @@ In development
   in May 2022) that it should be safe to remove this.
   https://github.com/joblib/joblib/pull/1361
 
-- Avoid (module, name) collisions when caching nested functions. This fix changes the
-  module name of nested functions, invalidating caches from previous versions of Joblib.
+- Avoid (module, name) collisions when caching nested functions. This fix
+  changes the module name of nested functions, invalidating caches from
+  previous versions of Joblib.
   https://github.com/joblib/joblib/pull/1385
 
 Release 1.2.0

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -167,8 +167,8 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
             if not func.func_globals[name] is func:
                 name = '%s-alias' % name
     if hasattr(func, '__qualname__') and func.__qualname__ != name:
-        # Extend the module name in case of nested functions to avoid (module, name)
-        # collisions
+        # Extend the module name in case of nested functions to avoid
+        # (module, name) collisions
         module.extend(func.__qualname__.split(".")[:-1])
     if inspect.ismethod(func):
         # We need to add the name of the class

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -166,6 +166,10 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
         if hasattr(func, 'func_globals') and name in func.func_globals:
             if not func.func_globals[name] is func:
                 name = '%s-alias' % name
+    if hasattr(func, '__qualname__') and func.__qualname__ != name:
+        # Extend the module name in case of nested functions to avoid (module, name)
+        # collisions
+        module.extend(func.__qualname__.split(".")[:-1])
     if inspect.ismethod(func):
         # We need to add the name of the class
         if hasattr(func, 'im_class'):

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -72,7 +72,7 @@ def other_cached_func(tmpdir_factory):
 
     @mem.cache
     def cached_func_inner(x):
-        return x
+        return x  # pragma: no cover
 
     return cached_func_inner
 


### PR DESCRIPTION
finalize #1374, adding a test and an entry in the change log.