### PR TITLE
TST Close client in test_pickle_in_socket

### DIFF
--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -932,27 +932,27 @@ def test_pickle_in_socket():
     listener.bind(_ADDR)
     listener.listen(1)
 
-    client = socket.create_connection(_ADDR)
-    server, client_addr = listener.accept()
+    with socket.create_connection(_ADDR) as client:
+        server, client_addr = listener.accept()
 
-    with server.makefile("wb") as sf:
-        numpy_pickle.dump(test_array, sf)
+        with server.makefile("wb") as sf:
+            numpy_pickle.dump(test_array, sf)
 
-    with client.makefile("rb") as cf:
-        array_reloaded = numpy_pickle.load(cf)
+        with client.makefile("rb") as cf:
+            array_reloaded = numpy_pickle.load(cf)
 
-    np.testing.assert_array_equal(array_reloaded, test_array)
+        np.testing.assert_array_equal(array_reloaded, test_array)
 
-    # Check that a byte-aligned numpy array written in a file can be send over
-    # a socket and then read on the other side
-    bytes_to_send = io.BytesIO()
-    numpy_pickle.dump(test_array, bytes_to_send)
-    server.send(bytes_to_send.getvalue())
+        # Check that a byte-aligned numpy array written in a file can be send over
+        # a socket and then read on the other side
+        bytes_to_send = io.BytesIO()
+        numpy_pickle.dump(test_array, bytes_to_send)
+        server.send(bytes_to_send.getvalue())
 
-    with client.makefile("rb") as cf:
-        array_reloaded = numpy_pickle.load(cf)
+        with client.makefile("rb") as cf:
+            array_reloaded = numpy_pickle.load(cf)
 
-    np.testing.assert_array_equal(array_reloaded, test_array)
+        np.testing.assert_array_equal(array_reloaded, test_array)
 
 
 @with_numpy

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -943,8 +943,8 @@ def test_pickle_in_socket():
 
         np.testing.assert_array_equal(array_reloaded, test_array)
 
-        # Check that a byte-aligned numpy array written in a file can be send over
-        # a socket and then read on the other side
+        # Check that a byte-aligned numpy array written in a file can be send
+        # over a socket and then read on the other side
         bytes_to_send = io.BytesIO()
         numpy_pickle.dump(test_array, bytes_to_send)
         server.send(bytes_to_send.getvalue())


### PR DESCRIPTION
I have noticed `OSError: [Errno 98] Address already in use` with `nogil` when running multiple times the following command:
```
pytest joblib/test/test_numpy_pickle.py -k socket
```

```
================================================ test session starts ================================================
platform linux -- Python 3.9.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/lesteve/dev/joblib, configfile: setup.cfg
plugins: timeout-2.1.0, forked-1.4.0, flaky-3.7.0, xdist-3.1.0
collected 130 items / 129 deselected / 1 selected                                                                   

joblib/test/test_numpy_pickle.py F                                                                            [100%]

===================================================== FAILURES ======================================================
_______________________________________________ test_pickle_in_socket _______________________________________________

    @with_numpy
    def test_pickle_in_socket():
        # test that joblib can pickle in sockets
        test_array = np.arange(10)
        _ADDR = ("localhost", 12345)
        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
>       listener.bind(_ADDR)
E       OSError: [Errno 98] Address already in use

joblib/test/test_numpy_pickle.py:932: OSError
============================================== short test summary info ==============================================
FAILED joblib/test/test_numpy_pickle.py::test_pickle_in_socket - OSError: [Errno 98] Address already in use
========================================= 1 failed, 129 deselected in 0.30s =========================================
[INFO:MainProcess:MainThread] process shutting down
[DEBUG:MainProcess:MainThread] running all "atexit" finalizers with priority >= 0
[DEBUG:MainProcess:MainThread] running the remaining "atexit" finalizers
```