### PR TITLE
MAINT Explicit support for Python 3.11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,10 +60,10 @@ jobs:
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.7"
         EXTRA_CONDA_PACKAGES: "numpy=1.15 distributed=2.13"
-      linux_py310_cython:
+      linux_py311_cython:
         imageName: 'ubuntu-latest'
-        PYTHON_VERSION: "3.10"
-        EXTRA_CONDA_PACKAGES: "numpy=1.23"
+        PYTHON_VERSION: "3.11"
+        EXTRA_CONDA_PACKAGES: "numpy=1.24.1"
         CYTHON: "true"
       linux_py37_no_multiprocessing_no_lzma:
         imageName: 'ubuntu-latest'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
     "Topic :: Utilities",
     "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
Fixes #1388.

Python 3.11 is already supported but is not tested and documented as such.

This updates the CI and adds a classifier for Python 3.11 to update the metadata.