### PR TITLE
Alter memory.MemorizedFunc._get_argument_hash to accept pre-hashed args to support cache fusion.

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -631,13 +631,14 @@ class MemorizedFunc(Logger):
     # ------------------------------------------------------------------------
 
     def _get_argument_hash(self, *args, pre_hashed: Dict[str, str] = None, **kwargs):
-        f = lambda x: pre_hashed.get(x) if x in pre_hashed else hashing.hash(x)
+        hash_ = functools.partial(hashing.hash, coerce_mmap=(self.mmap_mode is not None))
+        f = lambda x: pre_hashed.get(x) if x in pre_hashed else hash_(x)
 
-        return hashing.hash(
+        return hash_(
             list(sorted(map(
-                    hashing.hash if pre_hashed is None else f,
+                    hash_ if pre_hashed is None else f,
                     filter_args(self.func, self.ignore, args, kwargs),))),
-            coerce_mmap=(self.mmap_mode is not None))
+            )
 
     def _get_output_identifiers(self, *args, **kwargs):
         """Return the func identifier and input parameter hash of a result."""

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -629,9 +629,14 @@ class MemorizedFunc(Logger):
     # Private interface
     # ------------------------------------------------------------------------
 
-    def _get_argument_hash(self, *args, **kwargs):
-        return hashing.hash(filter_args(self.func, self.ignore, args, kwargs),
-                            coerce_mmap=(self.mmap_mode is not None))
+    def _get_argument_hash(self, *args, pre_hashed: dict[str, str] = None, **kwargs):
+        f = lambda x: pre_hashed.get(x) if x in pre_hashed else hashing.hash(x)
+
+        return hashing.hash(
+            list(sorted(map(
+                    hashing.hash if pre_hashed is None else f,
+                    filter_args(self.func, self.ignore, args, kwargs),))),
+                coerce_mmap=(self.mmap_mode is not None))
 
     def _get_output_identifiers(self, *args, **kwargs):
         """Return the func identifier and input parameter hash of a result."""

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -17,6 +17,7 @@ import pydoc
 import re
 import functools
 import traceback
+from typing import Dict
 import warnings
 import inspect
 import weakref
@@ -629,14 +630,14 @@ class MemorizedFunc(Logger):
     # Private interface
     # ------------------------------------------------------------------------
 
-    def _get_argument_hash(self, *args, pre_hashed: dict[str, str] = None, **kwargs):
+    def _get_argument_hash(self, *args, pre_hashed: Dict[str, str] = None, **kwargs):
         f = lambda x: pre_hashed.get(x) if x in pre_hashed else hashing.hash(x)
 
         return hashing.hash(
             list(sorted(map(
                     hashing.hash if pre_hashed is None else f,
                     filter_args(self.func, self.ignore, args, kwargs),))),
-                coerce_mmap=(self.mmap_mode is not None))
+            coerce_mmap=(self.mmap_mode is not None))
 
     def _get_output_identifiers(self, *args, **kwargs):
         """Return the func identifier and input parameter hash of a result."""


### PR DESCRIPTION
I have been using joblib in a piplining scenario where one function produces args for another function. This patch will enable callers to perform cache fusion for chained functions. The prehashing permits reading the result from the cache and identifying if the next call can be found already within the cache.

This alters hashing to be more 'git-like' by hashing the result of hashes. This will alter the hashes for previous cache entries but I have put this here for your thoughts.