### PR TITLE
High verbosity mode that prints arguments, hash and store location.

### DIFF
--- a/joblib/logger.py
+++ b/joblib/logger.py
@@ -76,6 +76,9 @@ class Logger(object):
     def warn(self, msg):
         logging.warning("[%s]: %s" % (self, msg))
 
+    def info(self, msg):
+        logging.info("[%s]: %s" % (self, msg))
+
     def debug(self, msg):
         # XXX: This conflicts with the debug flag used in children class
         logging.debug("[%s]: %s" % (self, msg))

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -10,6 +10,7 @@ is called with the same input arguments.
 
 
 from __future__ import with_statement
+import logging
 import os
 import time
 import pathlib
@@ -490,6 +491,22 @@ class MemorizedFunc(Logger):
 
         # Whether or not the memorized function must be called
         must_call = False
+
+        if self._verbose >= 20:
+            logging.basicConfig(level=logging.INFO)
+            _, name = get_func_name(self.func)
+            location = self.store_backend.get_cached_func_info([func_id])['location']
+            path, signature = format_signature(self.func, *args, **kwargs)
+
+            self.info(f"""
+Querying {name} with signature 
+{signature}.
+
+(argument hash {args_id}) 
+
+The store location is {location}. 
+            """
+            )
 
         # FIXME: The statements below should be try/excepted
         # Compare the function code with the previous to see if the

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -12,6 +12,7 @@ is called with the same input arguments.
 from __future__ import with_statement
 import logging
 import os
+from textwrap import dedent
 import time
 import pathlib
 import pydoc
@@ -499,14 +500,18 @@ class MemorizedFunc(Logger):
                 'location']
             _, signature = format_signature(self.func, *args, **kwargs)
 
-            self.info(f"""
-Querying {name} with signature
-{signature}.
+            self.info(
+                dedent(
+                    f"""
+                        Querying {name} with signature
+                        {signature}.
 
-(argument hash {args_id})
+                        (argument hash {args_id})
 
-The store location is {location}.
-            """)
+                        The store location is {location}.
+                        """
+                )
+            )
 
         # FIXME: The statements below should be try/excepted
         # Compare the function code with the previous to see if the

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -495,18 +495,18 @@ class MemorizedFunc(Logger):
         if self._verbose >= 20:
             logging.basicConfig(level=logging.INFO)
             _, name = get_func_name(self.func)
-            location = self.store_backend.get_cached_func_info([func_id])['location']
-            path, signature = format_signature(self.func, *args, **kwargs)
+            location = self.store_backend.get_cached_func_info([func_id])[
+                'location']
+            _, signature = format_signature(self.func, *args, **kwargs)
 
             self.info(f"""
-Querying {name} with signature 
+Querying {name} with signature
 {signature}.
 
-(argument hash {args_id}) 
+(argument hash {args_id})
 
-The store location is {location}. 
-            """
-            )
+The store location is {location}.
+            """)
 
         # FIXME: The statements below should be try/excepted
         # Compare the function code with the previous to see if the

--- a/joblib/test/test_logger.py
+++ b/joblib/test/test_logger.py
@@ -5,13 +5,9 @@ Test the logger module.
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
 # Copyright (c) 2009 Gael Varoquaux
 # License: BSD Style, 3 clauses.
-
-import logging
 import re
 
-from joblib.logger import Logger, PrintTime
-from joblib.memory import Memory
-
+from joblib.logger import PrintTime
 
 def test_print_time(tmpdir, capsys):
     # A simple smoke test for PrintTime.
@@ -32,68 +28,3 @@ def test_print_time(tmpdir, capsys):
     if not re.match(match, err_printed_text):
         raise AssertionError('Excepted %s, got %s' %
                              (match, err_printed_text))
-
-
-def test_logging_levels(caplog):
-    logger = Logger()
-    warn_msg = "This is a message at logging level WARNING. "
-    info_msg = "This is a message at logging level INFO. "
-    debug_msg = "This is a message at logging level DEBUG. "
-
-    logging.basicConfig(level=logging.INFO)
-    caplog.set_level(logging.INFO)
-    logger.warn(warn_msg)
-    logger.info(info_msg)
-    logger.debug(debug_msg)
-
-    assert warn_msg in caplog.text
-    assert info_msg in caplog.text
-    assert debug_msg not in caplog.text
-    caplog.clear()
-
-    logging.basicConfig(level=logging.WARNING)
-    caplog.set_level(logging.WARNING)
-    logger.warn(warn_msg)
-    logger.info(info_msg)
-    logger.debug(debug_msg)
-
-    assert warn_msg in caplog.text
-    assert info_msg not in caplog.text
-    assert debug_msg not in caplog.text
-    caplog.clear()
-
-    logging.basicConfig(level=logging.DEBUG)
-    caplog.set_level(logging.DEBUG)
-    logger.warn(warn_msg)
-    logger.info(info_msg)
-    logger.debug(debug_msg)
-
-    assert warn_msg in caplog.text
-    assert info_msg in caplog.text
-    assert debug_msg in caplog.text
-    caplog.clear()
-
-
-def test_info_log(tmpdir, caplog):
-    caplog.set_level(logging.INFO)
-    x = 3
-
-    memory = Memory(location=tmpdir.strpath, verbose=20)
-
-    @memory.cache
-    def f(x):
-        return x ** 2
-
-    _ = f(x)
-    assert "Querying" in caplog.text
-    caplog.clear()
-
-    memory = Memory(location=tmpdir.strpath, verbose=0)
-
-    @memory.cache
-    def f(x):
-        return x ** 2
-
-    _ = f(x)
-    assert "Querying" not in caplog.text
-    caplog.clear()

--- a/joblib/test/test_logger.py
+++ b/joblib/test/test_logger.py
@@ -84,7 +84,7 @@ def test_info_log(tmpdir, caplog):
     def f(x):
         return x ** 2
 
-    y = f(x)
+    _ = f(x)
     assert "Querying" in caplog.text
     caplog.clear()
 
@@ -94,6 +94,6 @@ def test_info_log(tmpdir, caplog):
     def f(x):
         return x ** 2
 
-    y = f(x)
+    _ = f(x)
     assert "Querying" not in caplog.text
     caplog.clear()

--- a/joblib/test/test_logger.py
+++ b/joblib/test/test_logger.py
@@ -6,9 +6,11 @@ Test the logger module.
 # Copyright (c) 2009 Gael Varoquaux
 # License: BSD Style, 3 clauses.
 
+import logging
 import re
 
-from joblib.logger import PrintTime
+from joblib.logger import Logger, PrintTime
+from joblib.memory import Memory
 
 
 def test_print_time(tmpdir, capsys):
@@ -30,3 +32,68 @@ def test_print_time(tmpdir, capsys):
     if not re.match(match, err_printed_text):
         raise AssertionError('Excepted %s, got %s' %
                              (match, err_printed_text))
+
+
+def test_logging_levels(caplog):
+    logger = Logger()
+    warn_msg = "This is a message at logging level WARNING. "
+    info_msg = "This is a message at logging level INFO. "
+    debug_msg = "This is a message at logging level DEBUG. "
+
+    logging.basicConfig(level=logging.INFO)
+    caplog.set_level(logging.INFO)
+    logger.warn(warn_msg)
+    logger.info(info_msg)
+    logger.debug(debug_msg)
+
+    assert warn_msg in caplog.text
+    assert info_msg in caplog.text
+    assert debug_msg not in caplog.text
+    caplog.clear()
+
+    logging.basicConfig(level=logging.WARNING)
+    caplog.set_level(logging.WARNING)
+    logger.warn(warn_msg)
+    logger.info(info_msg)
+    logger.debug(debug_msg)
+
+    assert warn_msg in caplog.text
+    assert info_msg not in caplog.text
+    assert debug_msg not in caplog.text
+    caplog.clear()
+
+    logging.basicConfig(level=logging.DEBUG)
+    caplog.set_level(logging.DEBUG)
+    logger.warn(warn_msg)
+    logger.info(info_msg)
+    logger.debug(debug_msg)
+
+    assert warn_msg in caplog.text
+    assert info_msg in caplog.text
+    assert debug_msg in caplog.text
+    caplog.clear()
+
+
+def test_info_log(tmpdir, caplog):
+    caplog.set_level(logging.INFO)
+    x = 3
+
+    memory = Memory(location=tmpdir.strpath, verbose=20)
+
+    @memory.cache
+    def f(x):
+        return x ** 2
+
+    y = f(x)
+    assert "Querying" in caplog.text
+    caplog.clear()
+
+    memory = Memory(location=tmpdir.strpath, verbose=0)
+
+    @memory.cache
+    def f(x):
+        return x ** 2
+
+    y = f(x)
+    assert "Querying" not in caplog.text
+    caplog.clear()

--- a/joblib/test/test_logger.py
+++ b/joblib/test/test_logger.py
@@ -9,6 +9,7 @@ import re
 
 from joblib.logger import PrintTime
 
+
 def test_print_time(tmpdir, capsys):
     # A simple smoke test for PrintTime.
     logfile = tmpdir.join('test.log').strpath

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -1316,6 +1316,7 @@ def test_memory_pickle_dump_load(tmpdir, memory_kwargs):
             ignored_attrs=set(['store_backend', 'timestamp', '_func_code_id']))
     assert hash(memorized_result) == hash(memorized_result_reloaded)
 
+
 def test_info_log(tmpdir, caplog):
     caplog.set_level(logging.INFO)
     x = 3

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -8,6 +8,7 @@ Test the memory module.
 
 import functools
 import gc
+import logging
 import shutil
 import os
 import os.path
@@ -1314,3 +1315,27 @@ def test_memory_pickle_dump_load(tmpdir, memory_kwargs):
     compare(memorized_result, memorized_result_reloaded,
             ignored_attrs=set(['store_backend', 'timestamp', '_func_code_id']))
     assert hash(memorized_result) == hash(memorized_result_reloaded)
+
+def test_info_log(tmpdir, caplog):
+    caplog.set_level(logging.INFO)
+    x = 3
+
+    memory = Memory(location=tmpdir.strpath, verbose=20)
+
+    @memory.cache
+    def f(x):
+        return x ** 2
+
+    _ = f(x)
+    assert "Querying" in caplog.text
+    caplog.clear()
+
+    memory = Memory(location=tmpdir.strpath, verbose=0)
+
+    @memory.cache
+    def f(x):
+        return x ** 2
+
+    _ = f(x)
+    assert "Querying" not in caplog.text
+    caplog.clear()


### PR DESCRIPTION
I found this feature useful when inspecting the synchronisation of caches between a remote and local machine. In particular, it can happen that arguments are hashed differently depending on the platform. 
For example, this inspection revealed that 

1. class-valued arguments were stored at a different location in memory and therefore had different hashes, as their str representation is different, and 
2. some numerical arguments that did result from a numerical did not agree because of floating point inaccuracies in their value.

In logging the arguments and their hash, I was able to track down and resolve those differences so that syncing the caches does now work. 