### PR TITLE
Revert "ENH make temp resource cleanup safer (#1391)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
 
   variables:
     JUNITXML: 'test-data.xml'
-    COVERAGE: "true"
+    COVERAGE: "false"
 
   pool:
     vmImage: $(imageName)

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -568,6 +568,20 @@ class TemporaryResourcesManager(object):
         """Return a folder name specific to the currently activated context"""
         return self._cached_temp_folders[self._current_context_id]
 
+    def _unregister_context(self, context_id=None):
+        if context_id is None:
+            for context_id in list(self._cached_temp_folders):
+                self._unregister_context(context_id)
+        else:
+            temp_folder = self._cached_temp_folders[context_id]
+            finalizer = self._finalizers[context_id]
+
+            resource_tracker.unregister(temp_folder, "folder")
+            atexit.unregister(finalizer)
+
+            self._cached_temp_folders.pop(context_id)
+            self._finalizers.pop(context_id)
+
     # resource management API
 
     def register_folder_finalizer(self, pool_subfolder, context_id):
@@ -589,8 +603,7 @@ class TemporaryResourcesManager(object):
             # because joblib should only use relative imports to allow
             # easy vendoring.
             delete_folder = __import__(
-                pool_module_name, fromlist=['delete_folder']
-            ).delete_folder
+                pool_module_name, fromlist=['delete_folder']).delete_folder
             try:
                 delete_folder(pool_subfolder, allow_non_empty=True)
                 resource_tracker.unregister(pool_subfolder, "folder")
@@ -600,53 +613,56 @@ class TemporaryResourcesManager(object):
 
         self._finalizers[context_id] = atexit.register(_cleanup)
 
-    def _clean_temporary_resources(self, context_id=None, force=False,
-                                   allow_non_empty=False):
-        """Clean temporary resources created by a process-based pool"""
+    def _unlink_temporary_resources(self, context_id=None):
+        """Unlink temporary resources created by a process-based pool"""
         if context_id is None:
-            # Iterates over a copy of the cache keys to avoid Error due to
-            # iterating over a changing size dictionary.
-            for context_id in list(self._cached_temp_folders):
-                self._clean_temporary_resources(
-                    context_id, force=force, allow_non_empty=allow_non_empty
+            # iterate over a copy of the cache keys because
+            # unlink_temporary_resources further deletes an entry in this
+            # cache
+            for context_id in self._cached_temp_folders.copy():
+                self._unlink_temporary_resources(context_id)
+        else:
+            temp_folder = self._cached_temp_folders[context_id]
+            if os.path.exists(temp_folder):
+                for filename in os.listdir(temp_folder):
+                    resource_tracker.maybe_unlink(
+                        os.path.join(temp_folder, filename), "file"
+                    )
+                self._try_delete_folder(
+                    allow_non_empty=False, context_id=context_id
+                )
+
+    def _unregister_temporary_resources(self, context_id=None):
+        """Unregister temporary resources created by a process-based pool"""
+        if context_id is None:
+            for context_id in self._cached_temp_folders:
+                self._unregister_temporary_resources(context_id)
+        else:
+            temp_folder = self._cached_temp_folders[context_id]
+            if os.path.exists(temp_folder):
+                for filename in os.listdir(temp_folder):
+                    resource_tracker.unregister(
+                        os.path.join(temp_folder, filename), "file"
+                    )
+
+    def _try_delete_folder(self, allow_non_empty, context_id=None):
+        if context_id is None:
+            # ditto
+            for context_id in self._cached_temp_folders.copy():
+                self._try_delete_folder(
+                    allow_non_empty=allow_non_empty, context_id=context_id
                 )
         else:
-            temp_folder = self._cached_temp_folders.get(context_id)
-            if temp_folder and os.path.exists(temp_folder):
-                for filename in os.listdir(temp_folder):
-                    if force:
-                        # Some workers have failed and the ref counted might
-                        # be off. The workers should have shut down by this
-                        # time so forcefully clean up the files.
-                        resource_tracker.unregister(
-                            os.path.join(temp_folder, filename), "file"
-                        )
-                    else:
-                        resource_tracker.maybe_unlink(
-                            os.path.join(temp_folder, filename), "file"
-                        )
+            temp_folder = self._cached_temp_folders[context_id]
+            try:
+                delete_folder(
+                    temp_folder, allow_non_empty=allow_non_empty
+                )
+                # Now that this folder is deleted, we can forget about it
+                self._unregister_context(context_id)
 
-                # When forcing clean-up, try to delete the folder even if some
-                # files are still in it. Otherwise, try to delete the folder
-                allow_non_empty |= force
-
-                # Clean up the folder if possible, either if it is empty or
-                # if none of the files in it are in used and allow_non_empty.
-                try:
-                    delete_folder(
-                        temp_folder, allow_non_empty=allow_non_empty
-                    )
-                    # Forget the folder once it has been deleted
-                    self._cached_temp_folders.pop(context_id, None)
-                    resource_tracker.unregister(temp_folder, "folder")
-
-                    # Also cancel the finalizers  that gets triggered at gc.
-                    finalizer = self._finalizers.pop(context_id, None)
-                    if finalizer is not None:
-                        atexit.unregister(finalizer)
-
-                except OSError:
-                    # Temporary folder cannot be deleted right now.
-                    # This folder will be cleaned up by an atexit
-                    # finalizer registered by the memmapping_reducer.
-                    pass
+            except OSError:
+                # Temporary folder cannot be deleted right now. No need to
+                # handle it though, as this folder will be cleaned up by an
+                # atexit finalizer registered by the memmapping_reducer.
+                pass

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -573,8 +573,8 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
             # Don't terminate the workers as we want to reuse them in later
             # calls, but cleanup the temporary resources that the Parallel call
             # created. This 'hack' requires a private, low-level operation.
-            self._workers._temp_folder_manager._clean_temporary_resources(
-                context_id=self.parallel._id, force=False
+            self._workers._temp_folder_manager._unlink_temporary_resources(
+                context_id=self.parallel._id
             )
             self._workers = None
 

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -71,22 +71,25 @@ class MemmappingExecutor(_ReusablePoolExecutor):
         return _executor
 
     def terminate(self, kill_workers=False):
-
         self.shutdown(kill_workers=kill_workers)
+        if kill_workers:
+            # When workers are killed in such a brutal manner, they cannot
+            # execute the finalizer of their shared memmaps. The refcount of
+            # those memmaps may be off by an unknown number, so instead of
+            # decref'ing them, we delete the whole temporary folder, and
+            # unregister them. There is no risk of PermissionError at folder
+            # deletion because because at this point, all child processes are
+            # dead, so all references to temporary memmaps are closed.
 
-        # When workers are killed in a brutal manner, they cannot execute the
-        # finalizer of their shared memmaps. The refcount of those memmaps may
-        # be off by an unknown number, so instead of decref'ing them, we force
-        # delete the whole temporary folder, and unregister them. There is no
-        # risk of PermissionError at folder deletion because because at this
-        # point, all child processes are dead, so all references to temporary
-        # memmaps are closed. Otherwise, just try to delete as much as possible
-        # with allow_non_empty=True but if we can't, it will be clean up later
-        # on by the resource_tracker.
-        with self._submit_resize_lock:
-            self._temp_folder_manager._clean_temporary_resources(
-                force=kill_workers, allow_non_empty=True
-            )
+            # unregister temporary resources from all contexts
+            with self._submit_resize_lock:
+                self._temp_folder_manager._unregister_temporary_resources()
+                self._temp_folder_manager._try_delete_folder(
+                    allow_non_empty=True
+                )
+        else:
+            self._temp_folder_manager._unlink_temporary_resources()
+            self._temp_folder_manager._try_delete_folder(allow_non_empty=True)
 
     @property
     def _temp_folder(self):

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -336,9 +336,7 @@ class MemmappingPool(PicklingPool):
                     if i + 1 == n_retries:
                         warnings.warn("Failed to terminate worker processes in"
                                       " multiprocessing pool: %r" % e)
-
-        # Clean up the temporary resources as the workers should now be off.
-        self._temp_folder_manager._clean_temporary_resources()
+        self._temp_folder_manager._unlink_temporary_resources()
 
     @property
     def _temp_folder(self):

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -750,7 +750,7 @@ def test_memmapping_pool_for_large_arrays(factory, tmpdir):
                 break
         else:  # pragma: no cover
             raise AssertionError(
-                'temporary folder {} was not deleted'.format(p._temp_folder)
+                'temporary folder of {} was not deleted'.format(p)
             )
         del p
 


### PR DESCRIPTION
This reverts commit df122868c0a27cd4f47a1d8f8e398c0d3cc3c907 that is suspected to have introduced a new failure in https://github.com/joblib/joblib/pull/1393 pipelines.