### PR TITLE
FIX upload to codecov

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -47,7 +47,7 @@ if [ -n "$NUMPY_VERSION" ]; then
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then
-    PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES coverage pytest-cov codecov"
+    PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES coverage pytest-cov"
 fi
 
 if [[ "pypy3" != *"$PYTHON_VERSION"* ]]; then


### PR DESCRIPTION
The `codecov` package is deprecated and we actually don't need it so it should be safe to remove it.