### PR TITLE
MTN skip thread_bomb mitigation test on PyPy for now

### DIFF
--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1465,8 +1465,14 @@ def _recursive_parallel(nesting_limit=None):
     return Parallel()(delayed(_recursive_parallel)() for i in range(2))
 
 
-@parametrize('backend',
-             (['threading'] if mp is None else ['loky', 'threading']))
+@parametrize(
+        'backend', (['threading'] if mp is None else ['loky', 'threading'])
+)
+# XXX: unskip once issue #1150 is closed.
+@skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="this test causes a deadlock on PyPy."
+)
 def test_thread_bomb_mitigation(backend):
     # Test that recursive parallelism raises a recursion rather than
     # saturating the operating system resources by creating a unbounded number


### PR DESCRIPTION
This test causes a deadlock reliably on pypy.
Skipping to make CI on `master` run again but this should be properly investigated in a dedicated PR.