### PR TITLE
DBG try to debug the thread_bomb_mitigation test

### DIFF
--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -20,7 +20,7 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
         export PYTEST_ADDOPTS="--cov=joblib --cov-append"
     fi
 
-    pytest joblib -vl --timeout=120 --junitxml="${JUNITXML}"
+    timeout -k 60 300 pytest joblib -vl --timeout=120 --junitxml="${JUNITXML}" -k test_thread_bomb_mitigation
     make test-doc
 fi
 

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -20,7 +20,7 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
         export PYTEST_ADDOPTS="--cov=joblib --cov-append"
     fi
 
-    timeout -k 60 300 pytest joblib -vsl --timeout=120 --junitxml="${JUNITXML}" -k test_thread_bomb_mitigation
+    pytest joblib -vsl --timeout=120 --junitxml="${JUNITXML}"
     make test-doc
 fi
 

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -20,7 +20,7 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
         export PYTEST_ADDOPTS="--cov=joblib --cov-append"
     fi
 
-    pytest joblib -vsl --timeout=120 --junitxml="${JUNITXML}"
+    pytest joblib -vl --timeout=120 --junitxml="${JUNITXML}"
     make test-doc
 fi
 

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -20,7 +20,7 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
         export PYTEST_ADDOPTS="--cov=joblib --cov-append"
     fi
 
-    timeout -k 60 300 pytest joblib -vl --timeout=120 --junitxml="${JUNITXML}" -k test_thread_bomb_mitigation
+    timeout -k 60 300 pytest joblib -vsl --timeout=120 --junitxml="${JUNITXML}" -k test_thread_bomb_mitigation
     make test-doc
 fi
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1468,11 +1468,6 @@ def _recursive_parallel(nesting_limit=None):
 @parametrize(
         'backend', (['threading'] if mp is None else ['loky', 'threading'])
 )
-# XXX: unskip once issue #1150 is closed.
-@skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="this test causes a deadlock on PyPy."
-)
 def test_thread_bomb_mitigation(backend):
     # Test that recursive parallelism raises a recursion rather than
     # saturating the operating system resources by creating a unbounded number

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1466,8 +1466,9 @@ def _recursive_parallel(nesting_limit=None):
 
 
 @parametrize(
-        'backend', (['threading'] if mp is None else ['loky', 'threading'])
+    'backend', (['threading'] if mp is None else ['loky', 'threading'])
 )
+@pytest.mark.no_cover
 def test_thread_bomb_mitigation(backend):
     # Test that recursive parallelism raises a recursion rather than
     # saturating the operating system resources by creating a unbounded number
@@ -1488,8 +1489,8 @@ def test_thread_bomb_mitigation(backend):
             # simple to do and this is is not critical for users (as long
             # as there is no process or thread bomb happening).
             pytest.xfail("Loky worker crash when serializing RecursionError")
-    else:
-        assert isinstance(exc, RecursionError)
+
+    assert isinstance(exc, RecursionError)
 
 
 def _run_parallel_sum():


### PR DESCRIPTION
Investigation PR for #1150 

From the investigation, this bug seems to be related to a bad interaction between the test, Pypy and `coverage`.
I propose to disable the coverage on this test to stabilize the test suite.

I was able to reproduce the failure locally by running the test with `--cov=joblib` and by adding the following at the beginning of the test:
```python

def test_thread_bomb_mitigation(backend):
    def recursive():
        return recursive()
    with raises(RecursionError):
        recursive()
```
This could be investigated further if someone has the time to do so.