### PR TITLE
MAINT: Be nitpicky about docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+python:
+  # make sure joblib is installed in the virtualenv (it is imported in
+  # conf.py)
+  install:
+    - requirements: .readthedocs-requirements.txt
+    - method: pip
+      path: .
+
+sphinx:
+  fail_on_warning: true
+

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,5 +1,5 @@
 # You can set these variables from the command lines
-SPHINXOPTS   ?= -j $(shell nproc)
+SPHINXOPTS   ?= -j $(shell nproc) -nWT --keep-going
 SPHINXBUILD  ?= sphinx-build
 
 .PHONY: all html clean
@@ -8,7 +8,7 @@ all: html
 
 # generate html documentation with warning as errors
 html:
-	$(SPHINXBUILD) -W -b html . ./_build/html/
+	$(SPHINXBUILD) $(SPHINXOPTS) -b html . ./_build/html/
 
 # remove generated sphinx gallery examples and sphinx documentation
 clean:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,3 +13,8 @@ html:
 # remove generated sphinx gallery examples and sphinx documentation
 clean:
 	rm -rf auto_examples && rm -rf generated && rm -rf _build
+
+view:
+	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/_build/html/index.html')"
+
+show: view

--- a/doc/_templates/class.rst
+++ b/doc/_templates/class.rst
@@ -1,25 +1,11 @@
-:mod:`{{module}}`.{{objname}}
-{{ underline }}==============
+{{ fullname | escape | underline }}
 
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
+   :members:
 
-   {% block methods %}
-   .. automethod:: __init__
+.. _sphx_glr_backreferences_{{ fullname }}:
 
-   {% if methods %}
-   .. rubric:: Methods
-
-   .. autosummary::
-   {% for item in methods %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-.. include:: {{module}}.{{objname}}.examples
-
-.. raw:: html
-
-    <div class="clearer"></div>
+.. minigallery:: {{ fullname }}
+    :add-heading:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,7 +32,6 @@ Introduction
 
 
 .. automodule:: joblib
-    :no-members:
 
 User manual
 --------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,6 +32,7 @@ Introduction
 
 
 .. automodule:: joblib
+    :no-members:
 
 User manual
 --------------

--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -19,19 +19,6 @@ The :class:`~joblib.Memory` class defines a context for lazy evaluation of
 function, by putting the results in a store, by default using a disk, and not
 re-running the function twice for the same arguments.
 
-..
- Commented out in favor of briefness
-
-    You can use it as a context, with its `eval` method:
-
-    .. automethod:: Memory.eval
-       :noindex:
-
-    or decorate functions with the `cache` method:
-
-    .. automethod:: Memory.cache
-       :noindex:
-
 It works by explicitly saving the output to a file and it is designed to
 work with non-hashable and potentially large input and output data types
 such as numpy arrays.
@@ -104,7 +91,7 @@ An example
 
   Define two functions: the first with a number as an argument,
   outputting an array, used by the second one. Both functions are decorated
-  with `Memory.cache`::
+  with :meth:`Memory.cache <joblib.Memory.cache>`::
 
     >>> import numpy as np
 
@@ -418,18 +405,16 @@ change, for instance a debug flag. `Memory` provides the `ignore` list::
 Reference documentation of the :class:`~joblib.Memory` class
 ------------------------------------------------------------
 
-.. currentmodule:: joblib
-
-.. autoclass:: Memory
+.. autoclass:: joblib.Memory
     :members: __init__, cache, eval, clear, reduce_size, format
     :no-inherited-members:
-
-.. currentmodule:: joblib.memory
+    :noindex:
 
 Useful methods of decorated functions
 -------------------------------------
 
-Functions decorated by :meth:`Memory.cache` are :class:`MemorizedFunc`
+Functions decorated by :meth:`Memory.cache <joblib.Memory.cache>` are
+:class:`MemorizedFunc`
 objects that, in addition of behaving like normal functions, expose
 methods useful for cache exploration and management. For example, you can
 use :meth:`func.check_call_in_cache <MemorizedFunc.check_call_in_cache>` to

--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -15,9 +15,9 @@ On demand recomputing: the `Memory` class
 Use case
 --------
 
-The `Memory` class defines a context for lazy evaluation of function, by
-putting the results in a store, by default using a disk, and not re-running
-the function twice for the same arguments.
+The :class:`~joblib.Memory` class defines a context for lazy evaluation of
+function, by putting the results in a store, by default using a disk, and not
+re-running the function twice for the same arguments.
 
 ..
  Commented out in favor of briefness
@@ -25,10 +25,12 @@ the function twice for the same arguments.
     You can use it as a context, with its `eval` method:
 
     .. automethod:: Memory.eval
+       :noindex:
 
     or decorate functions with the `cache` method:
 
     .. automethod:: Memory.cache
+       :noindex:
 
 It works by explicitly saving the output to a file and it is designed to
 work with non-hashable and potentially large input and output data types
@@ -413,11 +415,16 @@ change, for instance a debug flag. `Memory` provides the `ignore` list::
 
 .. _memory_reference:
 
-Reference documentation of the `Memory` class
----------------------------------------------
+Reference documentation of the :class:`~joblib.Memory` class
+------------------------------------------------------------
+
+.. currentmodule:: joblib
 
 .. autoclass:: Memory
-    :members: __init__, cache, eval, clear
+    :members: __init__, cache, eval, clear, reduce_size, format
+    :no-inherited-members:
+
+.. currentmodule:: joblib.memory
 
 Useful methods of decorated functions
 -------------------------------------

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -397,10 +397,21 @@ does not exist (but multiprocessing has more overhead).
 ==================================
 
 .. autoclass:: joblib.Parallel
-    :noindex:
+   :members: dispatch_next, dispatch_one_batch, format, print_progress
+   :no-inherited-members:
 
 .. autofunction:: joblib.delayed
 
 .. autofunction:: joblib.register_parallel_backend
 
 .. autofunction:: joblib.parallel_backend
+
+.. autofunction:: joblib.wrap_non_picklable_objects
+
+.. autofunction:: joblib.parallel.register_parallel_backend
+
+.. autoclass:: joblib.parallel.parallel_config
+
+.. autoclass:: joblib.parallel.ParallelBackendBase
+
+.. autoclass:: joblib.parallel.AutoBatchingMixin

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -399,6 +399,7 @@ does not exist (but multiprocessing has more overhead).
 .. autoclass:: joblib.Parallel
    :members: dispatch_next, dispatch_one_batch, format, print_progress
    :no-inherited-members:
+   :noindex:
 
 .. autofunction:: joblib.delayed
 

--- a/examples/parallel_generator.py
+++ b/examples/parallel_generator.py
@@ -81,7 +81,7 @@ def return_big_object(i):
 
 ##############################################################################
 # We create a reduce step. The input will be a generator on big objects
-# generated in parallel by several instances of :func:`return_big_object`.
+# generated in parallel by several instances of ``return_big_object``.
 
 def accumulator_sum(generator):
     result = 0

--- a/examples/serialization_and_wrappers.py
+++ b/examples/serialization_and_wrappers.py
@@ -118,7 +118,7 @@ except Exception:
 ###############################################################################
 # To have both fast pickling, safe process creation and serialization of
 # interactive functions, ``loky`` provides a wrapper function
-# ``wrap_non_picklable_objects`` to wrap the non-picklable function and
+# :func:`wrap_non_picklable_objects` to wrap the non-picklable function and
 # indicate to the serialization process that this specific function should be
 # serialized using ``cloudpickle``. This changes the serialization behavior
 # only for this function and keeps using ``pickle`` for all other objects. The

--- a/examples/serialization_and_wrappers.py
+++ b/examples/serialization_and_wrappers.py
@@ -118,7 +118,7 @@ except Exception:
 ###############################################################################
 # To have both fast pickling, safe process creation and serialization of
 # interactive functions, ``loky`` provides a wrapper function
-# :func:`wrap_non_picklable_objects` to wrap the non-picklable function and
+# ``wrap_non_picklable_objects`` to wrap the non-picklable function and
 # indicate to the serialization process that this specific function should be
 # serialized using ``cloudpickle``. This changes the serialization behavior
 # only for this function and keeps using ``pickle`` for all other objects. The
@@ -141,7 +141,7 @@ print("With pickle from stdlib and wrapper: {:.3f}s"
 
 ###############################################################################
 # The same wrapper can also be used for non-picklable classes. Note that the
-# side effects of :func:`wrap_non_picklable_objects` on objects can break magic
+# side effects of ``wrap_non_picklable_objects`` on objects can break magic
 # methods such as ``__add__`` and can mess up the ``isinstance`` and
 # ``issubclass`` functions. Some improvements will be considered if use-cases
 # are reported.

--- a/joblib/_cloudpickle_wrapper.py
+++ b/joblib/_cloudpickle_wrapper.py
@@ -10,6 +10,7 @@ from ._multiprocessing_helpers import mp
 def _my_wrap_non_picklable_objects(obj, keep_wrapper=True):
     return obj
 
+
 if mp is not None:
     from .externals.loky import wrap_non_picklable_objects
 else:

--- a/joblib/_cloudpickle_wrapper.py
+++ b/joblib/_cloudpickle_wrapper.py
@@ -7,10 +7,12 @@ multiprocessing is not available.
 from ._multiprocessing_helpers import mp
 
 
+def _my_wrap_non_picklable_objects(obj, keep_wrapper=True):
+    return obj
+
 if mp is not None:
     from .externals.loky import wrap_non_picklable_objects
 else:
-    def wrap_non_picklable_objects(obj, keep_wrapper=True):
-        return obj
+    wrap_non_picklable_objects = _my_wrap_non_picklable_objects
 
 __all__ = ["wrap_non_picklable_objects"]

--- a/joblib/_cloudpickle_wrapper.py
+++ b/joblib/_cloudpickle_wrapper.py
@@ -7,11 +7,10 @@ multiprocessing is not available.
 from ._multiprocessing_helpers import mp
 
 
-def my_wrap_non_picklable_objects(obj, keep_wrapper=True):
-    return obj
-
-
-if mp is None:
-    wrap_non_picklable_objects = my_wrap_non_picklable_objects
+if mp is not None:
+    from .externals.loky import wrap_non_picklable_objects
 else:
-    from .externals.loky import wrap_non_picklable_objects # noqa
+    def wrap_non_picklable_objects(obj, keep_wrapper=True):
+        return obj
+
+__all__ = ["wrap_non_picklable_objects"]

--- a/joblib/compressor.py
+++ b/joblib/compressor.py
@@ -47,7 +47,7 @@ def register_compressor(compressor_name, compressor,
     """Register a new compressor.
 
     Parameters
-    -----------
+    ----------
     compressor_name: str.
         The name of the compressor.
     compressor: CompressorWrapper

--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -245,9 +245,8 @@ def hash(obj, hash_name='md5', coerce_mmap=False):
     """ Quick calculation of a hash to identify uniquely Python objects
         containing numpy arrays.
 
-
         Parameters
-        -----------
+        ----------
         hash_name: 'md5' or 'sha1'
             Hashing algorithm used. sha1 is supposedly safer, but md5 is
             faster.

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -427,7 +427,7 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
     Read more in the :ref:`User Guide <persistence>`.
 
     Parameters
-    -----------
+    ----------
     value: any Python object
         The object to store to disk.
     filename: str, pathlib.Path, or file object.
@@ -611,7 +611,7 @@ def load(filename, mmap_mode=None):
     to load files from untrusted sources.
 
     Parameters
-    -----------
+    ----------
     filename: str, pathlib.Path, or file object.
         The file object or path of the file from which to load the object
     mmap_mode: {None, 'r+', 'r', 'w+', 'c'}, optional

--- a/joblib/numpy_pickle_compat.py
+++ b/joblib/numpy_pickle_compat.py
@@ -203,7 +203,7 @@ def load_compatibility(filename):
     (<= 0.9.3).
 
     Parameters
-    -----------
+    ----------
     filename: string
         The name of the file from which to load the object
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -210,7 +210,7 @@ def _get_active_backend(
 
 
 class parallel_config:
-    """Change the default backend or configuration used by :class:`~joblib.Parallel`
+    """Change the default backend or configuration for :class:`~joblib.Parallel`
 
     This is an alternative to directly passing keyword arguments to the
     :class:`~joblib.Parallel` class constructor. It is particularly useful when

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -210,10 +210,10 @@ def _get_active_backend(
 
 
 class parallel_config:
-    """Change the default backend or configuration used by :class:`~Parallel`
+    """Change the default backend or configuration used by :class:`~joblib.Parallel`
 
     This is an alternative to directly passing keyword arguments to the
-    :class:`~Parallel` class constructor. It is particularly useful when
+    :class:`~joblib.Parallel` class constructor. It is particularly useful when
     calling into library code that uses joblib internally but does not expose
     the various parallel configuration arguments in its own API.
 
@@ -237,7 +237,7 @@ class parallel_config:
         multiprocessing and loky may not be available, in which case joblib
         defaults to threading.
 
-        In addition, if the `dask` and `distributed` Python packages are
+        In addition, if the ``dask`` and ``distributed`` Python packages are
         installed, it is possible to use the 'dask' backend for better
         scheduling of nested parallel calls without over-subscription and
         potentially distribute parallel calls over a networked cluster of
@@ -251,14 +251,14 @@ class parallel_config:
 
     n_jobs : int, default=None
         The maximum number of concurrently running jobs, such as the number
-        of Python worker processes when `backend="loky"` or the size of the
-        thread-pool when `backend="threading"`.
+        of Python worker processes when ``backend="loky"`` or the size of the
+        thread-pool when ``backend="threading"``.
         If -1 all CPUs are used. If 1 is given, no parallel computing code
-        is used at all, which is useful for debugging. For `n_jobs` below -1,
-        (n_cpus + 1 + n_jobs) are used. Thus for `n_jobs=-2`, all
+        is used at all, which is useful for debugging. For ``n_jobs`` below -1,
+        (n_cpus + 1 + n_jobs) are used. Thus for ``n_jobs=-2``, all
         CPUs but one are used.
-        `None` is a marker for 'unset' that will be interpreted as `n_jobs=1`
-        in most backends.
+        ``None`` is a marker for 'unset' that will be interpreted as
+        ``n_jobs=1`` in most backends.
 
     verbose : int, default=0
         The verbosity level: if non zero, progress messages are
@@ -271,14 +271,14 @@ class parallel_config:
         for sharing memory with worker processes. If None, this will try in
         order:
 
-        - a folder pointed by the `JOBLIB_TEMP_FOLDER` environment
+        - a folder pointed by the ``JOBLIB_TEMP_FOLDER`` environment
           variable,
-        - `/dev/shm` if the folder exists and is writable: this is a
+        - ``/dev/shm`` if the folder exists and is writable: this is a
           RAM disk filesystem available by default on modern Linux
           distributions,
         - the default system temporary folder that can be
-          overridden with `TMP`, `TMPDIR` or `TEMP` environment
-          variables, typically `/tmp` under Unix operating systems.
+          overridden with ``TMP``, ``TMPDIR`` or ``TEMP`` environment
+          variables, typically ``/tmp`` under Unix operating systems.
 
     max_nbytes int, str, or None, optional, default='1M'
         Threshold on the size of arrays passed to the workers that
@@ -305,7 +305,7 @@ class parallel_config:
     inner_max_num_threads : int, default=None
         If not None, overwrites the limit set on the number of threads
         usable in some third-party library threadpools like OpenBLAS,
-        MKL or OpenMP. This is only used with the `loky` backend.
+        MKL or OpenMP. This is only used with the ``loky`` backend.
 
     backend_params : dict
         Additional parameters to pass to the backend constructor when
@@ -320,6 +320,8 @@ class parallel_config:
     overwritten with the ``inner_max_num_threads`` argument which will be used
     to set this limit in the child processes.
 
+    .. versionadded:: 1.3
+
     Examples
     --------
     >>> from operator import neg
@@ -328,7 +330,7 @@ class parallel_config:
     ...
     [-1, -2, -3, -4, -5]
 
-    To use the 'ray' joblib backend add the following lines::
+    To use the 'ray' joblib backend add the following lines:
 
     >>> from ray.util.joblib import register_ray  # doctest: +SKIP
     >>> register_ray()  # doctest: +SKIP
@@ -336,7 +338,6 @@ class parallel_config:
     ...     print(Parallel()(delayed(neg)(i + 1) for i in range(5)))
     [-1, -2, -3, -4, -5]
 
-    .. versionadded:: 1.3
     """
     def __init__(
         self,
@@ -441,8 +442,9 @@ class parallel_config:
 class parallel_backend(parallel_config):
     """Change the default backend used by Parallel inside a with block.
 
-    It is advised to use the `parallel_config` context manager instead,
-    which allows more fine-grained control over the backend configuration.
+    It is advised to use the :class:`~joblib.parallel.parallel_config` context
+    manager instead, which allows more fine-grained control over the backend
+    configuration.
 
     If ``backend`` is a string it must match a previously registered
     implementation using the :func:`~register_parallel_backend` function.
@@ -510,12 +512,12 @@ class parallel_backend(parallel_config):
     overwritten with the ``inner_max_num_threads`` argument which will be used
     to set this limit in the child processes.
 
-    See Also
-    --------
-    parallel_config : context manager to change the backend configuration
-
     .. versionadded:: 0.10
 
+    See Also
+    --------
+    joblib.parallel.parallel_config : context manager to change the backend
+                                      configuration
     """
     def __init__(self, backend, n_jobs=-1, inner_max_num_threads=None,
                  **backend_params):
@@ -880,7 +882,6 @@ def register_parallel_backend(name, factory, make_default=False):
     version of joblib.
 
     .. versionadded:: 0.10
-
     """
     BACKENDS[name] = factory
     if make_default:
@@ -908,7 +909,6 @@ def effective_n_jobs(n_jobs=-1):
     version of joblib.
 
     .. versionadded:: 0.10
-
     """
     if n_jobs == 1:
         return 1
@@ -926,7 +926,7 @@ class Parallel(Logger):
         Read more in the :ref:`User Guide <parallel>`.
 
         Parameters
-        -----------
+        ----------
         n_jobs: int, default: None
             The maximum number of concurrently running jobs, such as the number
             of Python worker processes when backend="multiprocessing"

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -210,7 +210,7 @@ def _get_active_backend(
 
 
 class parallel_config:
-    """Change the default backend or configuration for :class:`~joblib.Parallel`
+    """Set the default backend or configuration for :class:`~joblib.Parallel`.
 
     This is an alternative to directly passing keyword arguments to the
     :class:`~joblib.Parallel` class constructor. It is particularly useful when

--- a/joblib/test/test_cloudpickle_wrapper.py
+++ b/joblib/test/test_cloudpickle_wrapper.py
@@ -4,7 +4,7 @@ properly the loky implementation.
 """
 
 from .._cloudpickle_wrapper import wrap_non_picklable_objects
-from .._cloudpickle_wrapper import my_wrap_non_picklable_objects
+from .._cloudpickle_wrapper import _my_wrap_non_picklable_objects
 
 
 def a_function(x):
@@ -23,5 +23,5 @@ def test_wrap_non_picklable_objects():
     # upstream one
     for obj in (a_function, AClass()):
         wrapped_obj = wrap_non_picklable_objects(obj)
-        my_wrapped_obj = my_wrap_non_picklable_objects(obj)
+        my_wrapped_obj = _my_wrap_non_picklable_objects(obj)
         assert wrapped_obj(1) == my_wrapped_obj(1)

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,0 @@
-python:
-  # make sure joblib is installed in the virtualenv (it is imported in
-  # conf.py)
-  pip_install: true
-
-requirements_file: .readthedocs-requirements.txt


### PR DESCRIPTION
Closes #1436

1. `SPHINXOPTS` wasn't used in `doc/Makefile`, now it is so you can do stuff like `make clean && make html SPHINXOPTS="-nWT --keep-going -D sphinx_gallery_conf.filename_pattern=none"`
2. Modify `SPHINXOPTS` to use `-nWT --keep-geing` to be nitpicky
3. Fix a bunch of nitpicky problems

There are a few left I still need to sort out but this is at least close to working locally.