### PR TITLE
Document parallel_config

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -58,6 +58,7 @@ Module reference
 
    Memory
    Parallel
+   parallel_config
 
 .. autosummary::
    :toctree: generated/

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -72,11 +72,11 @@ instead of the default ``"loky"`` backend:
     ...     delayed(sqrt)(i ** 2) for i in range(10))
     [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 
-It is also possible to manually select a specific backend implementation
-with the help of a context manager:
+The :class:`parallel_config` context manager helps selecting
+a specific backend implementation or setting the default number of jobs:
 
     >>> from joblib import parallel_backend
-    >>> with parallel_backend('threading', n_jobs=2):
+    >>> with parallel_config('threading', n_jobs=2):
     ...    Parallel()(delayed(sqrt)(i ** 2) for i in range(10))
     [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -75,7 +75,7 @@ instead of the default ``"loky"`` backend:
 The :class:`parallel_config` context manager helps selecting
 a specific backend implementation or setting the default number of jobs:
 
-    >>> from joblib import parallel_backend
+    >>> from joblib import parallel_config
     >>> with parallel_config('threading', n_jobs=2):
     ...    Parallel()(delayed(sqrt)(i ** 2) for i in range(10))
     [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]


### PR DESCRIPTION
It seems that parallel_config was not very visible in the docs.

This is a quick fix to improve a bit the situation.

We should probably adapt more our docs, but I only have a little bit of time.