### PR TITLE
DOC reference parallel_config instead of parallel_backend

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,9 +39,9 @@ autosummary_generate = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{.major}'.format(
         sys.version_info), None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
-    'distributed': ('https://distributed.readthedocs.io/en/latest/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy', None),
+    'distributed': ('https://distributed.dask.org/en/latest/', None),
 }
 
 # sphinx-gallery configuration

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -230,7 +230,7 @@ number of threads using the ``inner_max_num_threads`` argument of the
 
     from joblib import Parallel, delayed, parallel_config
 
-    with parallel_config("loky", inner_max_num_threads=2):
+    with parallel_config(backend="loky", inner_max_num_threads=2):
         results = Parallel(n_jobs=4)(delayed(func)(x, y) for x, y in data)
 
 In this example, 4 Python worker processes will be allowed to use 2 threads
@@ -274,7 +274,7 @@ The connection parameters can then be passed to the
 :func:`~joblib.parallel_config` context manager::
 
     with parallel_config(backend='custom', endpoint='http://compute',
-                         api_key='42'):
+                        api_key='42'):
         Parallel()(delayed(some_function)(i) for i in range(10))
 
 Using the context manager can be helpful when using a third-party library that

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -72,7 +72,7 @@ instead of the default ``"loky"`` backend:
     ...     delayed(sqrt)(i ** 2) for i in range(10))
     [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 
-The :class:`parallel_config` context manager helps selecting
+The :func:`~joblib.parallel_config` context manager helps selecting
 a specific backend implementation or setting the default number of jobs:
 
     >>> from joblib import parallel_config
@@ -89,7 +89,7 @@ In prior versions, the same effect could be achieved by hardcoding a
 specific backend implementation such as ``backend="threading"`` in the
 call to :class:`joblib.Parallel` but this is now considered a bad pattern
 (when done in a library) as it does not make it possible to override that
-choice with the :func:`~joblib.parallel_backend` context manager.
+choice with the :func:`~joblib.parallel_config` context manager.
 
 
 .. topic:: The loky backend may not always be available
@@ -224,26 +224,23 @@ libraries:
 
 Since joblib 0.14, it is also possible to programmatically override the default
 number of threads using the ``inner_max_num_threads`` argument of the
-:func:`~joblib.parallel_backend` function as follows:
+:func:`~joblib.parallel_config` function as follows:
 
 .. code-block:: python
 
-    from joblib import Parallel, delayed, parallel_backend
+    from joblib import Parallel, delayed, parallel_config
 
-    with parallel_backend("loky", inner_max_num_threads=2):
+    with parallel_config("loky", inner_max_num_threads=2):
         results = Parallel(n_jobs=4)(delayed(func)(x, y) for x, y in data)
 
 In this example, 4 Python worker processes will be allowed to use 2 threads
 each, meaning that this program will be able to use up to 8 CPUs concurrently.
 
 
-Custom backend API (experimental)
-=================================
+Custom backend API
+==================
 
 .. versionadded:: 0.10
-
-.. warning:: The custom backend API is experimental and subject to change
-    without going through a deprecation cycle.
 
 User can provide their own implementation of a parallel processing
 backend in addition to the ``'loky'``, ``'threading'``,
@@ -274,9 +271,9 @@ for a remote cluster computing service::
     register_parallel_backend('custom', MyCustomBackend)
 
 The connection parameters can then be passed to the
-:func:`joblib.parallel_backend` context manager::
+:func:`~joblib.parallel_config` context manager::
 
-    with parallel_backend('custom', endpoint='http://compute', api_key='42'):
+    with parallel_config('custom', endpoint='http://compute', api_key='42'):
         Parallel()(delayed(some_function)(i) for i in range(10))
 
 Using the context manager can be helpful when using a third-party library that
@@ -288,13 +285,13 @@ A problem exists that external packages that register new parallel backends
 must now be imported explicitly for their backends to be identified by joblib::
 
    >>> import joblib
-   >>> with joblib.parallel_backend('custom'):  # doctest: +SKIP
+   >>> with joblib.parallel_config('custom'):  # doctest: +SKIP
    ...     ...  # this fails
    KeyError: 'custom'
 
    # Import library to register external backend
    >>> import my_custom_backend_library  # doctest: +SKIP
-   >>> with joblib.parallel_backend('custom'):  # doctest: +SKIP
+   >>> with joblib.parallel_config('custom'):  # doctest: +SKIP
    ...     ... # this works
 
 This can be confusing for users.  To resolve this, external packages can
@@ -403,15 +400,11 @@ does not exist (but multiprocessing has more overhead).
 
 .. autofunction:: joblib.delayed
 
-.. autofunction:: joblib.register_parallel_backend
-
-.. autofunction:: joblib.parallel_backend
+.. autofunction:: joblib.parallel_config
 
 .. autofunction:: joblib.wrap_non_picklable_objects
 
-.. autofunction:: joblib.parallel.register_parallel_backend
-
-.. autoclass:: joblib.parallel.parallel_config
+.. autofunction:: joblib.register_parallel_backend
 
 .. autoclass:: joblib.parallel.ParallelBackendBase
 

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -76,7 +76,7 @@ The :func:`~joblib.parallel_config` context manager helps selecting
 a specific backend implementation or setting the default number of jobs:
 
     >>> from joblib import parallel_config
-    >>> with parallel_config('threading', n_jobs=2):
+    >>> with parallel_config(backend='threading', n_jobs=2):
     ...    Parallel()(delayed(sqrt)(i ** 2) for i in range(10))
     [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 
@@ -273,7 +273,8 @@ for a remote cluster computing service::
 The connection parameters can then be passed to the
 :func:`~joblib.parallel_config` context manager::
 
-    with parallel_config('custom', endpoint='http://compute', api_key='42'):
+    with parallel_config(backend='custom', endpoint='http://compute',
+                         api_key='42'):
         Parallel()(delayed(some_function)(i) for i in range(10))
 
 Using the context manager can be helpful when using a third-party library that
@@ -285,13 +286,13 @@ A problem exists that external packages that register new parallel backends
 must now be imported explicitly for their backends to be identified by joblib::
 
    >>> import joblib
-   >>> with joblib.parallel_config('custom'):  # doctest: +SKIP
+   >>> with joblib.parallel_config(backend='custom'):  # doctest: +SKIP
    ...     ...  # this fails
    KeyError: 'custom'
 
    # Import library to register external backend
    >>> import my_custom_backend_library  # doctest: +SKIP
-   >>> with joblib.parallel_config('custom'):  # doctest: +SKIP
+   >>> with joblib.parallel_config(backend='custom'):  # doctest: +SKIP
    ...     ... # this works
 
 This can be confusing for users.  To resolve this, external packages can

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -402,6 +402,7 @@ does not exist (but multiprocessing has more overhead).
 .. autofunction:: joblib.delayed
 
 .. autofunction:: joblib.parallel_config
+   :noindex:
 
 .. autofunction:: joblib.wrap_non_picklable_objects
 

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -274,7 +274,7 @@ The connection parameters can then be passed to the
 :func:`~joblib.parallel_config` context manager::
 
     with parallel_config(backend='custom', endpoint='http://compute',
-                        api_key='42'):
+                         api_key='42'):
         Parallel()(delayed(some_function)(i) for i in range(10))
 
 Using the context manager can be helpful when using a third-party library that

--- a/examples/parallel/distributed_backend_simple.py
+++ b/examples/parallel/distributed_backend_simple.py
@@ -49,7 +49,7 @@ def long_running_function(i):
 ###############################################################################
 # The verbose messages below show that the backend is indeed the
 # dask.distributed one
-with joblib.parallel_backend("dask"):
+with joblib.parallel_config("dask"):
     joblib.Parallel(verbose=100)(
         joblib.delayed(long_running_function)(i) for i in range(10)
     )

--- a/examples/parallel/distributed_backend_simple.py
+++ b/examples/parallel/distributed_backend_simple.py
@@ -49,7 +49,7 @@ def long_running_function(i):
 ###############################################################################
 # The verbose messages below show that the backend is indeed the
 # dask.distributed one
-with joblib.parallel_config("dask"):
+with joblib.parallel_config(backend="dask"):
     joblib.Parallel(verbose=100)(
         joblib.delayed(long_running_function)(i) for i in range(10)
     )

--- a/examples/serialization_and_wrappers.py
+++ b/examples/serialization_and_wrappers.py
@@ -15,7 +15,7 @@ import sys
 import time
 import traceback
 from joblib.externals.loky import set_loky_pickler
-from joblib import parallel_backend
+from joblib import parallel_config
 from joblib import Parallel, delayed
 from joblib import wrap_non_picklable_objects
 
@@ -65,7 +65,7 @@ if sys.platform != 'win32':
     def func_async(i, *args):
         return 2 * i
 
-    with parallel_backend('multiprocessing'):
+    with parallel_config('multiprocessing'):
         t_start = time.time()
         Parallel(n_jobs=2)(
             delayed(func_async)(21, large_list) for _ in range(1))
@@ -117,10 +117,10 @@ except Exception:
 
 ###############################################################################
 # To have both fast pickling, safe process creation and serialization of
-# interactive functions, ``loky`` provides a wrapper function
-# :func:`wrap_non_picklable_objects` to wrap the non-picklable function and
-# indicate to the serialization process that this specific function should be
-# serialized using ``cloudpickle``. This changes the serialization behavior
+# interactive functions, ``joblib`` provides a wrapper function
+# :func:`~joblib.wrap_non_picklable_objects` to wrap the non-picklable function
+# and indicate to the serialization process that this specific function should
+# be serialized using ``cloudpickle``. This changes the serialization behavior
 # only for this function and keeps using ``pickle`` for all other objects. The
 # drawback of this solution is that it modifies the object. This should not
 # cause many issues with functions but can have side effects with object

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -8,7 +8,7 @@ import time
 from uuid import uuid4
 import weakref
 
-from .parallel import parallel_backend
+from .parallel import parallel_config
 from .parallel import AutoBatchingMixin, ParallelBackendBase
 
 try:
@@ -121,7 +121,7 @@ class Batch:
 
     def __call__(self, tasks=None):
         results = []
-        with parallel_backend('dask'):
+        with parallel_config('dask'):
             for func, args, kwargs in tasks:
                 results.append(func(*args, **kwargs))
             return results
@@ -250,7 +250,7 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
                 "Make sure that workers are started and can properly connect "
                 "to the scheduler and increase the joblib/dask connection "
                 "timeout with:\n\n"
-                "parallel_backend('dask', wait_for_workers_timeout={})"
+                "parallel_config('dask', wait_for_workers_timeout={})"
             ).format(self.wait_for_workers_timeout,
                      max(10, 2 * self.wait_for_workers_timeout))
             raise TimeoutError(error_msg) from e

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -142,6 +142,7 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
     MIN_IDEAL_BATCH_DURATION = 0.2
     MAX_IDEAL_BATCH_DURATION = 1.0
     supports_timeout = True
+    default_n_jobs = -1
 
     def __init__(self, scheduler_host=None, scatter=None,
                  client=None, loop=None, wait_for_workers_timeout=10,
@@ -243,7 +244,8 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
         # task might cause the cluster to provision some workers.
         try:
             self.client.submit(_joblib_probe_task).result(
-                timeout=self.wait_for_workers_timeout)
+                timeout=self.wait_for_workers_timeout
+            )
         except _TimeoutError as e:
             error_msg = (
                 "DaskDistributedBackend has no worker after {} seconds. "

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -121,7 +121,7 @@ class Batch:
 
     def __call__(self, tasks=None):
         results = []
-        with parallel_config('dask'):
+        with parallel_config(backend='dask'):
             for func, args, kwargs in tasks:
                 results.append(func(*args, **kwargs))
             return results
@@ -252,7 +252,7 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
                 "Make sure that workers are started and can properly connect "
                 "to the scheduler and increase the joblib/dask connection "
                 "timeout with:\n\n"
-                "parallel_config('dask', wait_for_workers_timeout={})"
+                "parallel_config(backend='dask', wait_for_workers_timeout={})"
             ).format(self.wait_for_workers_timeout,
                      max(10, 2 * self.wait_for_workers_timeout))
             raise TimeoutError(error_msg) from e

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -28,6 +28,7 @@ class ParallelBackendBase(metaclass=ABCMeta):
 
     supports_inner_max_num_threads = False
     supports_retrieve_callback = False
+    default_n_jobs = 1
 
     @property
     def supports_return_generator(self):

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -450,8 +450,8 @@ class parallel_config:
 class parallel_backend(parallel_config):
     """Change the default backend used by Parallel inside a with block.
 
-    It is advised to use the :class:`~joblib.parallel.parallel_config` context
-    manager instead, which allows more fine-grained control over the backend
+    It is advised to use the :class:`~joblib.parallel_config` context manager
+    instead, which allows more fine-grained control over the backend
     configuration.
 
     If ``backend`` is a string it must match a previously registered
@@ -524,8 +524,8 @@ class parallel_backend(parallel_config):
 
     See Also
     --------
-    joblib.parallel.parallel_config : context manager to change the backend
-                                      configuration
+    joblib.parallel_config : context manager to change the backend
+        configuration.
     """
     def __init__(self, backend, n_jobs=-1, inner_max_num_threads=None,
                  **backend_params):

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -72,7 +72,7 @@ _backend = threading.local()
 
 
 def _register_dask():
-    """ Register Dask Backend if called with parallel_config("dask") """
+    """Register Dask Backend if called with parallel_config(backend="dask")"""
     try:
         from ._dask import DaskDistributedBackend
         register_parallel_backend('dask', DaskDistributedBackend)
@@ -345,7 +345,7 @@ class parallel_config:
 
     >>> from ray.util.joblib import register_ray  # doctest: +SKIP
     >>> register_ray()  # doctest: +SKIP
-    >>> with parallel_config("ray"):  # doctest: +SKIP
+    >>> with parallel_config(backend="ray"):  # doctest: +SKIP
     ...     print(Parallel()(delayed(neg)(i + 1) for i in range(5)))
     [-1, -2, -3, -4, -5]
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -363,6 +363,10 @@ class parallel_config:
             _backend, "config", default_parallel_config
         )
 
+        backend = self._check_backend(
+            backend, inner_max_num_threads, **backend_params
+        )
+
         new_config = {
             "n_jobs": n_jobs,
             "verbose": verbose,
@@ -371,6 +375,7 @@ class parallel_config:
             "mmap_mode": mmap_mode,
             "prefer": prefer,
             "require": require,
+            "backend": backend
         }
         self.parallel_config = self.old_parallel_config.copy()
         self.parallel_config.update({
@@ -378,11 +383,6 @@ class parallel_config:
             if not isinstance(v, _Sentinel)
         })
 
-        backend = self._check_backend(
-            backend, inner_max_num_threads, **backend_params
-        )
-
-        self.parallel_config["backend"] = backend
         setattr(_backend, "config", self.parallel_config)
 
     def _check_backend(self, backend, inner_max_num_threads, **backend_params):

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -1,0 +1,112 @@
+import os
+
+from joblib.parallel import parallel_config
+from joblib.parallel import parallel_backend
+from joblib.parallel import Parallel, delayed
+
+from joblib.parallel import BACKENDS
+from joblib.parallel import DEFAULT_BACKEND
+from joblib.parallel import EXTERNAL_BACKENDS
+
+from joblib._parallel_backends import LokyBackend
+from joblib._parallel_backends import ThreadingBackend
+from joblib._parallel_backends import MultiprocessingBackend
+
+from joblib.testing import parametrize, raises
+from joblib.test.common import np, with_numpy
+from joblib.test.common import with_multiprocessing
+from joblib.test.test_parallel import check_memmap
+
+
+@parametrize("context", [parallel_config, parallel_backend])
+def test_global_parallel_backend(context):
+    default = Parallel()._backend
+
+    pb = context('threading')
+    assert isinstance(Parallel()._backend, ThreadingBackend)
+
+    pb.unregister()
+    assert type(Parallel()._backend) is type(default)
+
+
+@parametrize("context", [parallel_config, parallel_backend])
+def test_external_backends(context):
+    def register_foo():
+        BACKENDS['foo'] = ThreadingBackend
+
+    EXTERNAL_BACKENDS['foo'] = register_foo
+
+    with context('foo'):
+        assert isinstance(Parallel()._backend, ThreadingBackend)
+
+
+@with_numpy
+@with_multiprocessing
+def test_parallel_config_no_backend(tmpdir):
+    # Check that parallel_config allows to change the config
+    # even if no backend is set.
+    with parallel_config(n_jobs=2, max_nbytes=1, temp_folder=tmpdir):
+        with Parallel(prefer="processes") as p:
+            assert isinstance(p._backend, LokyBackend)
+            assert p.n_jobs == 2
+
+            # Checks that memmapping is enabled
+            p(delayed(check_memmap)(a) for a in [np.random.random(10)] * 2)
+            assert len(os.listdir(tmpdir)) > 0
+
+
+@with_numpy
+@with_multiprocessing
+def test_parallel_config_params_explicit_set(tmpdir):
+    with parallel_config(n_jobs=3, max_nbytes=1, temp_folder=tmpdir):
+        with Parallel(n_jobs=2, prefer="processes", max_nbytes='1M') as p:
+            assert isinstance(p._backend, LokyBackend)
+            assert p.n_jobs == 2
+
+            # Checks that memmapping is disabled
+            with raises(TypeError, match="Expected np.memmap instance"):
+                p(delayed(check_memmap)(a) for a in [np.random.random(10)] * 2)
+
+
+@parametrize("param", ["prefer", "require"])
+def test_parallel_config_bad_params(param):
+    # Check that an error is raised when setting a wrong backend
+    # hint or constraint
+    with raises(ValueError, match=f"{param}=wrong is not a valid"):
+        with parallel_config(**{param: "wrong"}):
+            Parallel()
+
+
+def test_parallel_config_constructor_params():
+    # Check that an error is raised when backend is None
+    # but backend constructor params are given
+    with raises(ValueError, match="only supported when backend is not None"):
+        with parallel_config(inner_max_num_threads=1):
+            pass
+
+
+def test_parallel_config_nested():
+    # Check that an error is raised when backend is None
+    # but backend constructor params are given
+
+    with parallel_config(n_jobs=2):
+        p = Parallel()
+        isinstance(p._backend, BACKENDS[DEFAULT_BACKEND])
+        assert p.n_jobs == 2
+
+    with parallel_config(backend='threading'):
+        with parallel_config(n_jobs=2):
+            p = Parallel()
+            isinstance(p._backend, ThreadingBackend)
+            assert p.n_jobs == 2
+
+@with_numpy
+@with_multiprocessing
+@parametrize('backend', ['multiprocessing', 'threading',
+                         MultiprocessingBackend(), ThreadingBackend()])
+@parametrize("context", [parallel_config, parallel_backend])
+def test_threadpool_limitation_in_child_context_error(context, backend):
+
+    with raises(AssertionError, match=r"does not acc.*inner_max_num_threads"):
+        context(backend, inner_max_num_threads=1)
+

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -84,10 +84,14 @@ def test_parallel_config_constructor_params():
         with parallel_config(inner_max_num_threads=1):
             pass
 
+    with raises(ValueError, match="only supported when backend is not None"):
+        with parallel_config(backend_param=1):
+            pass
+
 
 def test_parallel_config_nested():
-    # Check that an error is raised when backend is None
-    # but backend constructor params are given
+    # Check that nested configuration retrieves the info from the
+    # parent config and do not reset them.
 
     with parallel_config(n_jobs=2):
         p = Parallel()
@@ -98,6 +102,12 @@ def test_parallel_config_nested():
         with parallel_config(n_jobs=2):
             p = Parallel()
             assert isinstance(p._backend, ThreadingBackend)
+            assert p.n_jobs == 2
+
+    with parallel_config(verbose=100):
+        with parallel_config(n_jobs=2):
+            p = Parallel()
+            assert p.verbose == 100
             assert p.n_jobs == 2
 
 

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -91,13 +91,13 @@ def test_parallel_config_nested():
 
     with parallel_config(n_jobs=2):
         p = Parallel()
-        isinstance(p._backend, BACKENDS[DEFAULT_BACKEND])
+        assert isinstance(p._backend, BACKENDS[DEFAULT_BACKEND])
         assert p.n_jobs == 2
 
     with parallel_config(backend='threading'):
         with parallel_config(n_jobs=2):
             p = Parallel()
-            isinstance(p._backend, ThreadingBackend)
+            assert isinstance(p._backend, ThreadingBackend)
             assert p.n_jobs == 2
 
 

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -100,6 +100,7 @@ def test_parallel_config_nested():
             isinstance(p._backend, ThreadingBackend)
             assert p.n_jobs == 2
 
+
 @with_numpy
 @with_multiprocessing
 @parametrize('backend', ['multiprocessing', 'threading',
@@ -109,4 +110,3 @@ def test_threadpool_limitation_in_child_context_error(context, backend):
 
     with raises(AssertionError, match=r"does not acc.*inner_max_num_threads"):
         context(backend, inner_max_num_threads=1)
-

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -23,9 +23,10 @@ def test_global_parallel_backend(context):
     default = Parallel()._backend
 
     pb = context('threading')
-    assert isinstance(Parallel()._backend, ThreadingBackend)
-
-    pb.unregister()
+    try:
+        assert isinstance(Parallel()._backend, ThreadingBackend)
+    finally:
+        pb.unregister()
     assert type(Parallel()._backend) is type(default)
 
 
@@ -35,9 +36,11 @@ def test_external_backends(context):
         BACKENDS['foo'] = ThreadingBackend
 
     EXTERNAL_BACKENDS['foo'] = register_foo
-
-    with context('foo'):
-        assert isinstance(Parallel()._backend, ThreadingBackend)
+    try:
+        with context('foo'):
+            assert isinstance(Parallel()._backend, ThreadingBackend)
+    finally:
+        del EXTERNAL_BACKENDS['foo']
 
 
 @with_numpy

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -7,7 +7,7 @@ from random import random
 from uuid import uuid4
 from time import sleep
 
-from .. import Parallel, delayed, parallel_backend
+from .. import Parallel, delayed, parallel_config
 from ..parallel import ThreadingBackend, AutoBatchingMixin
 from .._dask import DaskDistributedBackend
 
@@ -42,7 +42,7 @@ def count_events(event_name, client):
 def test_simple(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 seq = Parallel()(delayed(inc)(i) for i in range(10))
                 assert seq == [inc(i) for i in range(10)]
 
@@ -60,7 +60,7 @@ def test_dask_backend_uses_autobatching(loop):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 with Parallel() as parallel:
                     # The backend should be initialized with a default
                     # batch size of 1:
@@ -85,7 +85,7 @@ def random2():
 def test_dont_assume_function_purity(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 x, y = Parallel()(delayed(random2)() for i in range(2))
                 assert x != y
 
@@ -106,7 +106,7 @@ def test_dask_funcname(loop, mixed):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 _ = Parallel(batch_size=2, pre_dispatch='all')(tasks)
 
             def f(dask_scheduler):
@@ -140,7 +140,7 @@ def test_no_undesired_distributed_cache_hit(loop):
     cluster = LocalCluster(n_workers=1, threads_per_worker=2)
     client = Client(cluster)
     try:
-        with parallel_backend('dask') as (ba, _):
+        with parallel_config('dask') as (ba, _):
             # dispatches joblib.parallel.BatchedCalls
             res = Parallel()(
                 delayed(isolated_operation)(list_) for list_ in lists
@@ -157,7 +157,7 @@ def test_no_undesired_distributed_cache_hit(loop):
         assert sum(counts.values()) == 0
         assert all([len(r) == 1 for r in res])
 
-        with parallel_backend('dask') as (ba, _):
+        with parallel_config('dask') as (ba, _):
             # Append a large array which will be scattered by dask, and
             # dispatch joblib._dask.Batch
             res = Parallel()(
@@ -199,7 +199,7 @@ def test_manual_scatter(loop):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_backend('dask', scatter=[x, y]) as (ba, _):
+            with parallel_config('dask', scatter=[x, y]) as (ba, _):
                 f = delayed(add5)
                 tasks = [f(x, y, z, d=4, e=5),
                          f(x, z, y, d=5, e=4),
@@ -211,7 +211,7 @@ def test_manual_scatter(loop):
 
             # Scatter must take a list/tuple
             with pytest.raises(TypeError):
-                with parallel_backend('dask', loop=loop, scatter=1):
+                with parallel_config('dask', loop=loop, scatter=1):
                     pass
 
     assert results == expected
@@ -237,7 +237,7 @@ def test_auto_scatter(loop_in_thread):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop_in_thread) as client:
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 # Passing the same data as arg and kwarg triggers a single
                 # scatter operation whose result is reused.
                 Parallel()(delayed(noop)(data, data, i, opt=data)
@@ -250,7 +250,7 @@ def test_auto_scatter(loop_in_thread):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop_in_thread) as client:
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 Parallel()(delayed(noop)(data1[:3], i) for i in range(5))
             # Small arrays are passed within the task definition without going
             # through a scatter operation.
@@ -272,7 +272,7 @@ def test_nested_scatter(loop, retry_no):
 
     def outer_function_joblib(array, i):
         client = get_client()  # noqa
-        with parallel_backend("dask"):
+        with parallel_config("dask"):
             results = Parallel()(
                 delayed(my_sum)(array[j:], i, j) for j in range(
                     NUM_INNER_TASKS)
@@ -281,7 +281,7 @@ def test_nested_scatter(loop, retry_no):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as _:
-            with parallel_backend("dask"):
+            with parallel_config("dask"):
                 my_array = np.ones(10000)
                 _ = Parallel()(
                     delayed(outer_function_joblib)(
@@ -297,7 +297,7 @@ def test_nested_backend_context_manager(loop_in_thread):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop_in_thread) as client:
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 pid_groups = Parallel(n_jobs=2)(
                     delayed(get_nested_pids)()
                     for _ in range(10)
@@ -307,7 +307,7 @@ def test_nested_backend_context_manager(loop_in_thread):
 
         # No deadlocks
         with Client(s['address'], loop=loop_in_thread) as client:  # noqa: F841
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 pid_groups = Parallel(n_jobs=2)(
                     delayed(get_nested_pids)()
                     for _ in range(10)
@@ -329,7 +329,7 @@ def test_nested_backend_context_manager_implicit_n_jobs(loop):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 with Parallel() as p:
                     assert _backend_type(p) == "DaskDistributedBackend"
                     assert p.n_jobs == -1
@@ -344,7 +344,7 @@ def test_nested_backend_context_manager_implicit_n_jobs(loop):
 
 def test_errors(loop):
     with pytest.raises(ValueError) as info:
-        with parallel_backend('dask'):
+        with parallel_config('dask'):
             pass
 
     assert "create a dask client" in str(info.value).lower()
@@ -354,13 +354,13 @@ def test_correct_nested_backend(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
             # No requirement, should be us
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 result = Parallel(n_jobs=2)(
                     delayed(outer)(nested_require=None) for _ in range(1))
                 assert isinstance(result[0][0][0], DaskDistributedBackend)
 
             # Require threads, should be threading
-            with parallel_backend('dask') as (ba, _):
+            with parallel_config('dask') as (ba, _):
                 result = Parallel(n_jobs=2)(
                     delayed(outer)(nested_require='sharedmem')
                     for _ in range(1))
@@ -386,7 +386,7 @@ def inner():
 def test_secede_with_no_processes(loop):
     # https://github.com/dask/distributed/issues/1775
     with Client(loop=loop, processes=False, set_as_default=True):
-        with parallel_backend('dask'):
+        with parallel_config('dask'):
             Parallel(n_jobs=4)(delayed(id)(i) for i in range(2))
 
 
@@ -398,12 +398,12 @@ def _worker_address(_):
 def test_dask_backend_keywords(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_backend('dask', workers=a['address']) as (ba, _):
+            with parallel_config('dask', workers=a['address']) as (ba, _):
                 seq = Parallel()(
                     delayed(_worker_address)(i) for i in range(10))
                 assert seq == [a['address']] * 10
 
-            with parallel_backend('dask', workers=b['address']) as (ba, _):
+            with parallel_config('dask', workers=b['address']) as (ba, _):
                 seq = Parallel()(
                     delayed(_worker_address)(i) for i in range(10))
                 assert seq == [b['address']] * 10
@@ -411,7 +411,7 @@ def test_dask_backend_keywords(loop):
 
 def test_cleanup(loop):
     with Client(processes=False, loop=loop) as client:
-        with parallel_backend('dask'):
+        with parallel_config('dask'):
             Parallel()(delayed(inc)(i) for i in range(10))
 
         start = time()
@@ -438,7 +438,7 @@ def test_wait_for_workers(cluster_strategy):
         # to schedule work.
         cluster.scale(2)
     try:
-        with parallel_backend('dask'):
+        with parallel_config('dask'):
             # The following should wait a bit for at least one worker to
             # become available.
             Parallel()(delayed(inc)(i) for i in range(10))
@@ -452,13 +452,13 @@ def test_wait_for_workers_timeout():
     cluster = LocalCluster(n_workers=0, processes=False, threads_per_worker=2)
     client = Client(cluster)
     try:
-        with parallel_backend('dask', wait_for_workers_timeout=0.1):
+        with parallel_config('dask', wait_for_workers_timeout=0.1):
             # Short timeout: DaskDistributedBackend
             msg = "DaskDistributedBackend has no worker after 0.1 seconds."
             with pytest.raises(TimeoutError, match=msg):
                 Parallel()(delayed(inc)(i) for i in range(10))
 
-        with parallel_backend('dask', wait_for_workers_timeout=0):
+        with parallel_config('dask', wait_for_workers_timeout=0):
             # No timeout: fallback to generic joblib failure:
             msg = "DaskDistributedBackend has no active worker"
             with pytest.raises(RuntimeError, match=msg):

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -42,7 +42,7 @@ def count_events(event_name, client):
 def test_simple(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 seq = Parallel()(delayed(inc)(i) for i in range(10))
                 assert seq == [inc(i) for i in range(10)]
 
@@ -60,7 +60,7 @@ def test_dask_backend_uses_autobatching(loop):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 with Parallel() as parallel:
                     # The backend should be initialized with a default
                     # batch size of 1:
@@ -85,7 +85,7 @@ def random2():
 def test_dont_assume_function_purity(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 x, y = Parallel()(delayed(random2)() for i in range(2))
                 assert x != y
 
@@ -106,7 +106,7 @@ def test_dask_funcname(loop, mixed):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 _ = Parallel(batch_size=2, pre_dispatch='all')(tasks)
 
             def f(dask_scheduler):
@@ -140,7 +140,7 @@ def test_no_undesired_distributed_cache_hit(loop):
     cluster = LocalCluster(n_workers=1, threads_per_worker=2)
     client = Client(cluster)
     try:
-        with parallel_config('dask'):
+        with parallel_config(backend='dask'):
             # dispatches joblib.parallel.BatchedCalls
             res = Parallel()(
                 delayed(isolated_operation)(list_) for list_ in lists
@@ -157,7 +157,7 @@ def test_no_undesired_distributed_cache_hit(loop):
         assert sum(counts.values()) == 0
         assert all([len(r) == 1 for r in res])
 
-        with parallel_config('dask'):
+        with parallel_config(backend='dask'):
             # Append a large array which will be scattered by dask, and
             # dispatch joblib._dask.Batch
             res = Parallel()(
@@ -199,7 +199,7 @@ def test_manual_scatter(loop):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_config('dask', scatter=[x, y]):
+            with parallel_config(backend='dask', scatter=[x, y]):
                 f = delayed(add5)
                 tasks = [f(x, y, z, d=4, e=5),
                          f(x, z, y, d=5, e=4),
@@ -211,7 +211,7 @@ def test_manual_scatter(loop):
 
             # Scatter must take a list/tuple
             with pytest.raises(TypeError):
-                with parallel_config('dask', loop=loop, scatter=1):
+                with parallel_config(backend='dask', loop=loop, scatter=1):
                     pass
 
     assert results == expected
@@ -237,7 +237,7 @@ def test_auto_scatter(loop_in_thread):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop_in_thread) as client:
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 # Passing the same data as arg and kwarg triggers a single
                 # scatter operation whose result is reused.
                 Parallel()(delayed(noop)(data, data, i, opt=data)
@@ -250,7 +250,7 @@ def test_auto_scatter(loop_in_thread):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop_in_thread) as client:
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 Parallel()(delayed(noop)(data1[:3], i) for i in range(5))
             # Small arrays are passed within the task definition without going
             # through a scatter operation.
@@ -272,7 +272,7 @@ def test_nested_scatter(loop, retry_no):
 
     def outer_function_joblib(array, i):
         client = get_client()  # noqa
-        with parallel_config("dask"):
+        with parallel_config(backend="dask"):
             results = Parallel()(
                 delayed(my_sum)(array[j:], i, j) for j in range(
                     NUM_INNER_TASKS)
@@ -281,7 +281,7 @@ def test_nested_scatter(loop, retry_no):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as _:
-            with parallel_config("dask"):
+            with parallel_config(backend="dask"):
                 my_array = np.ones(10000)
                 _ = Parallel()(
                     delayed(outer_function_joblib)(
@@ -297,7 +297,7 @@ def test_nested_backend_context_manager(loop_in_thread):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop_in_thread) as client:
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 pid_groups = Parallel(n_jobs=2)(
                     delayed(get_nested_pids)()
                     for _ in range(10)
@@ -307,7 +307,7 @@ def test_nested_backend_context_manager(loop_in_thread):
 
         # No deadlocks
         with Client(s['address'], loop=loop_in_thread) as client:  # noqa: F841
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 pid_groups = Parallel(n_jobs=2)(
                     delayed(get_nested_pids)()
                     for _ in range(10)
@@ -329,7 +329,7 @@ def test_nested_backend_context_manager_implicit_n_jobs(loop):
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 with Parallel() as p:
                     assert _backend_type(p) == "DaskDistributedBackend"
                     assert p.n_jobs == -1
@@ -344,7 +344,7 @@ def test_nested_backend_context_manager_implicit_n_jobs(loop):
 
 def test_errors(loop):
     with pytest.raises(ValueError) as info:
-        with parallel_config('dask'):
+        with parallel_config(backend='dask'):
             pass
 
     assert "create a dask client" in str(info.value).lower()
@@ -354,13 +354,13 @@ def test_correct_nested_backend(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
             # No requirement, should be us
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 result = Parallel(n_jobs=2)(
                     delayed(outer)(nested_require=None) for _ in range(1))
                 assert isinstance(result[0][0][0], DaskDistributedBackend)
 
             # Require threads, should be threading
-            with parallel_config('dask'):
+            with parallel_config(backend='dask'):
                 result = Parallel(n_jobs=2)(
                     delayed(outer)(nested_require='sharedmem')
                     for _ in range(1))
@@ -386,7 +386,7 @@ def inner():
 def test_secede_with_no_processes(loop):
     # https://github.com/dask/distributed/issues/1775
     with Client(loop=loop, processes=False, set_as_default=True):
-        with parallel_config('dask'):
+        with parallel_config(backend='dask'):
             Parallel(n_jobs=4)(delayed(id)(i) for i in range(2))
 
 
@@ -398,12 +398,12 @@ def _worker_address(_):
 def test_dask_backend_keywords(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
-            with parallel_config('dask', workers=a['address']):
+            with parallel_config(backend='dask', workers=a['address']):
                 seq = Parallel()(
                     delayed(_worker_address)(i) for i in range(10))
                 assert seq == [a['address']] * 10
 
-            with parallel_config('dask', workers=b['address']):
+            with parallel_config(backend='dask', workers=b['address']):
                 seq = Parallel()(
                     delayed(_worker_address)(i) for i in range(10))
                 assert seq == [b['address']] * 10
@@ -411,7 +411,7 @@ def test_dask_backend_keywords(loop):
 
 def test_cleanup(loop):
     with Client(processes=False, loop=loop) as client:
-        with parallel_config('dask'):
+        with parallel_config(backend='dask'):
             Parallel()(delayed(inc)(i) for i in range(10))
 
         start = time()
@@ -438,7 +438,7 @@ def test_wait_for_workers(cluster_strategy):
         # to schedule work.
         cluster.scale(2)
     try:
-        with parallel_config('dask'):
+        with parallel_config(backend='dask'):
             # The following should wait a bit for at least one worker to
             # become available.
             Parallel()(delayed(inc)(i) for i in range(10))
@@ -452,13 +452,13 @@ def test_wait_for_workers_timeout():
     cluster = LocalCluster(n_workers=0, processes=False, threads_per_worker=2)
     client = Client(cluster)
     try:
-        with parallel_config('dask', wait_for_workers_timeout=0.1):
+        with parallel_config(backend='dask', wait_for_workers_timeout=0.1):
             # Short timeout: DaskDistributedBackend
             msg = "DaskDistributedBackend has no worker after 0.1 seconds."
             with pytest.raises(TimeoutError, match=msg):
                 Parallel()(delayed(inc)(i) for i in range(10))
 
-        with parallel_config('dask', wait_for_workers_timeout=0):
+        with parallel_config(backend='dask', wait_for_workers_timeout=0):
             # No timeout: fallback to generic joblib failure:
             msg = "DaskDistributedBackend has no active worker"
             with pytest.raises(RuntimeError, match=msg):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -66,7 +66,7 @@ from joblib.parallel import parallel_backend
 from joblib.parallel import register_parallel_backend
 from joblib.parallel import effective_n_jobs, cpu_count
 
-from joblib.parallel import mp, BACKENDS, DEFAULT_BACKEND, EXTERNAL_BACKENDS
+from joblib.parallel import mp, BACKENDS, DEFAULT_BACKEND
 
 
 RETURN_GENERATOR_BACKENDS = BACKENDS.copy()

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -594,11 +594,11 @@ def test_invalid_backend():
         Parallel(backend='unit-testing')
 
     with raises(ValueError, match="Invalid backend:"):
-        with parallel_config('unit-testing'):
+        with parallel_config(backend='unit-testing'):
             pass
 
     with raises(ValueError, match="Invalid backend:"):
-        with parallel_config('unit-testing'):
+        with parallel_config(backend='unit-testing'):
             pass
 
 
@@ -637,7 +637,7 @@ def test_backend_no_multiprocessing():
         Parallel(backend='loky')(delayed(square)(i) for i in range(3))
 
     # The below should now work without problems
-    with parallel_config('loky'):
+    with parallel_config(backend='loky'):
         Parallel()(delayed(square)(i) for i in range(3))
 
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -61,8 +61,9 @@ from joblib._parallel_backends import ParallelBackendBase
 from joblib._parallel_backends import LokyBackend
 
 from joblib.parallel import Parallel, delayed
-from joblib.parallel import register_parallel_backend, parallel_backend
 from joblib.parallel import parallel_config
+from joblib.parallel import parallel_backend
+from joblib.parallel import register_parallel_backend
 from joblib.parallel import effective_n_jobs, cpu_count
 
 from joblib.parallel import mp, BACKENDS, DEFAULT_BACKEND, EXTERNAL_BACKENDS
@@ -593,7 +594,7 @@ def test_invalid_backend():
         Parallel(backend='unit-testing')
 
     with raises(ValueError, match="Invalid backend:"):
-        with parallel_backend('unit-testing'):
+        with parallel_config('unit-testing'):
             pass
 
     with raises(ValueError, match="Invalid backend:"):
@@ -636,7 +637,7 @@ def test_backend_no_multiprocessing():
         Parallel(backend='loky')(delayed(square)(i) for i in range(3))
 
     # The below should now work without problems
-    with parallel_backend('loky'):
+    with parallel_config'loky'):
         Parallel()(delayed(square)(i) for i in range(3))
 
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1550,7 +1550,7 @@ def test_backend_hinting_and_constraints_with_custom_backends(
         assert type(p._backend) == ThreadingBackend
 
         out, err = capsys.readouterr()
-        expected = ("Using ThreadingBackend as joblib.Parallel backend "
+        expected = ("Using ThreadingBackend as joblib backend "
                     "instead of MyCustomProcessingBackend as the latter "
                     "does not provide shared memory semantics.")
         assert out.strip() == expected

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -637,7 +637,7 @@ def test_backend_no_multiprocessing():
         Parallel(backend='loky')(delayed(square)(i) for i in range(3))
 
     # The below should now work without problems
-    with parallel_config'loky'):
+    with parallel_config('loky'):
         Parallel()(delayed(square)(i) for i in range(3))
 
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1581,28 +1581,6 @@ def test_invalid_backend_hinting_and_constraints():
             Parallel(backend='multiprocessing', require='sharedmem')
 
 
-@parametrize("context", [parallel_config, parallel_backend])
-def test_global_parallel_backend(context):
-    default = Parallel()._backend
-
-    pb = context('threading')
-    assert isinstance(Parallel()._backend, ThreadingBackend)
-
-    pb.unregister()
-    assert type(Parallel()._backend) is type(default)
-
-
-@parametrize("context", [parallel_config, parallel_backend])
-def test_external_backends(context):
-    def register_foo():
-        BACKENDS['foo'] = ThreadingBackend
-
-    EXTERNAL_BACKENDS['foo'] = register_foo
-
-    with context('foo'):
-        assert isinstance(Parallel()._backend, ThreadingBackend)
-
-
 def _recursive_backend_info(limit=3, **kwargs):
     """Perform nested parallel calls and introspect the backend on the way"""
 
@@ -1903,17 +1881,6 @@ def test_threadpool_limitation_in_child_override(context, n_jobs, var_name):
             os.environ[var_name] = original_var_value
 
 
-@with_numpy
-@with_multiprocessing
-@parametrize('backend', ['multiprocessing', 'threading',
-                         MultiprocessingBackend(), ThreadingBackend()])
-@parametrize("context", [parallel_config, parallel_backend])
-def test_threadpool_limitation_in_child_context_error(context, backend):
-
-    with raises(AssertionError, match=r"does not acc.*inner_max_num_threads"):
-        context(backend, inner_max_num_threads=1)
-
-
 @with_multiprocessing
 @parametrize('n_jobs', [2, 4, -1])
 def test_loky_reuse_workers(n_jobs):
@@ -1934,48 +1901,3 @@ def test_loky_reuse_workers(n_jobs):
         parallel_call(n_jobs)
         executor = get_reusable_executor(reuse=True)
         assert executor == first_executor
-
-
-@with_numpy
-@with_multiprocessing
-def test_parallel_config_no_backend(tmpdir):
-    # Check that parallel_config allows to change the config
-    # even if no backend is set.
-    with parallel_config(n_jobs=2, max_nbytes=1, temp_folder=tmpdir):
-        with Parallel(prefer="processes") as p:
-            assert isinstance(p._backend, LokyBackend)
-            assert p.n_jobs == 2
-
-            # Checks that memmapping is enabled
-            p(delayed(check_memmap)(a) for a in [np.random.random(10)] * 2)
-            assert len(os.listdir(tmpdir)) > 0
-
-
-@with_numpy
-@with_multiprocessing
-def test_parallel_config_params_explicit_set(tmpdir):
-    with parallel_config(n_jobs=3, max_nbytes=1, temp_folder=tmpdir):
-        with Parallel(n_jobs=2, prefer="processes", max_nbytes='1M') as p:
-            assert isinstance(p._backend, LokyBackend)
-            assert p.n_jobs == 2
-
-            # Checks that memmapping is disabled
-            with raises(TypeError, match="Expected np.memmap instance"):
-                p(delayed(check_memmap)(a) for a in [np.random.random(10)] * 2)
-
-
-@parametrize("param", ["prefer", "require"])
-def test_parallel_config_bad_params(param):
-    # Check that an error is raised when setting a wrong backend
-    # hint or constraint
-    with raises(ValueError, match=f"{param}=wrong is not a valid"):
-        with parallel_config(**{param: "wrong"}):
-            Parallel()
-
-
-def test_parallel_config_constructor_params():
-    # Check that an error is raised when backend is None
-    # but backend constructor params are given
-    with raises(ValueError, match="only supported when backend is not None"):
-        with parallel_config(inner_max_num_threads=1):
-            pass


### PR DESCRIPTION
Follow up for #1451 to use `parallel_config` as much as possible in examples and in the tests.

In doing so, I realized that it actually has a different behavior than `parallel_backend`.
This PR does:
- make it possible to specify the `default_n_jobs` per backend (in particular to have default `n_jobs=-1` for dask).
- Fix the nested `parallel_config` usage. Calling the two following examples is equivalent while the first one would give `LokyBackend` with `2` jobs with the current version on `master`.
```python
with parallel_config(backend='threading'):
    with parallel_config(n_jobs=2):
        p = Parallel()

with parallel_config(backend='loky', n_jobs=2):
        p = Parallel()
```