### PR TITLE
fix double repeated word typos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -163,7 +163,7 @@ Release 0.17.0
 Release 0.16.0
 --------------
 
-- Fix a problem in the constructors of of Parallel backends classes that
+- Fix a problem in the constructors of Parallel backends classes that
   inherit from the `AutoBatchingMixin` that prevented the dask backend to
   properly batch short tasks.
   https://github.com/joblib/joblib/pull/1062
@@ -744,7 +744,7 @@ Olivier Grisel
     Make joblib use the 'forkserver' start method by default under Python 3.4+
     to avoid causing crash with 3rd party libraries (such as Apple vecLib /
     Accelerate or the GCC OpenMP runtime) that use an internal thread pool that
-    is not not reinitialized when a ``fork`` system call happens.
+    is not reinitialized when a ``fork`` system call happens.
 
 Olivier Grisel
 

--- a/doc/parallel_numpy.rst
+++ b/doc/parallel_numpy.rst
@@ -28,7 +28,7 @@ worker processes.
 
   The following only applies with the ``"loky"` and
   ``'multiprocessing'`` process-backends. If your code can release the
-  GIL, then using a thread-based backend backend by passing
+  GIL, then using a thread-based backend by passing
   ``prefer='threads'`` is even more efficient because it makes it
   possible to avoid the communication overhead of process-based
   parallelism.

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -530,7 +530,7 @@ class TemporaryResourcesManager(object):
             # It would be safer to not assign a default context id (less silent
             # bugs), but doing this while maintaining backward compatibility
             # with the previous, context-unaware version get_memmaping_executor
-            # exposes exposes too many low-level details.
+            # exposes too many low-level details.
             context_id = uuid4().hex
         self.set_current_context(context_id)
 

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -78,7 +78,7 @@ class MemmappingExecutor(_ReusablePoolExecutor):
         # finalizer of their shared memmaps. The refcount of those memmaps may
         # be off by an unknown number, so instead of decref'ing them, we force
         # delete the whole temporary folder, and unregister them. There is no
-        # risk of PermissionError at folder deletion because because at this
+        # risk of PermissionError at folder deletion because at this
         # point, all child processes are dead, so all references to temporary
         # memmaps are closed. Otherwise, just try to delete as much as possible
         # with allow_non_empty=True but if we can't, it will be clean up later

--- a/joblib/externals/loky/reusable_executor.py
+++ b/joblib/externals/loky/reusable_executor.py
@@ -83,7 +83,7 @@ def get_reusable_executor(
     the main process. One can provide a dict ``{ENV: VAL}`` where ``ENV`` and
     ``VAL`` are string literals to overwrite the environment variable ``ENV``
     in the child processes to value ``VAL``. The environment variables are set
-    in the children before any module is loaded. This only works with with the
+    in the children before any module is loaded. This only works with the
     ``loky`` context.
     """
     _executor, _ = _ReusablePoolExecutor.get_reusable_executor(

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -219,7 +219,7 @@ class NumpyArrayWrapper(object):
                 current_pos % NUMPY_ARRAY_ALIGNMENT_BYTES != 0):
             message = (
                 f'The memmapped array {marray} loaded from the file '
-                f'{unpickler.file_handle.name} is not not bytes aligned. '
+                f'{unpickler.file_handle.name} is not byte aligned. '
                 'This may cause segmentation faults if this memmapped array '
                 'is used in some libraries like BLAS or PyTorch. '
                 'To get rid of this warning, regenerate your pickle file '
@@ -464,7 +464,7 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
     -----
     Memmapping on load cannot be used for compressed files. Thus
     using compression can significantly slow down loading. In
-    addition, compressed files take extra extra memory during
+    addition, compressed files take up extra memory during
     dump and load.
 
     """

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1688,7 +1688,7 @@ def test_thread_bomb_mitigation(context, backend):
             # pickling it to be send back to the parent process. In this
             # case the worker crashes but the original traceback is still
             # printed on stderr. This could be improved but does not seem
-            # simple to do and this is is not critical for users (as long
+            # simple to do and this is not critical for users (as long
             # as there is no process or thread bomb happening).
             pytest.xfail("Loky worker crash when serializing RecursionError")
 


### PR DESCRIPTION
Hello there, `joblib` maintainers! 

thank you for your hard work. I came here because a useful warning had a typo in it, "..loaded from the file **redacted** is not not bytes aligned." and noticed that there was another instance of a `not not` typo elsewhere in the repository. Unsatisfied to fix just those two "not not" instances, I decided to regex for others, and here's the result.

For the record, the incantation I used was `git grep -E "\b(\w+)\s+\1\b"` and the few remaining results for this are legitimate ("Matrix Matrix multiplication", for example).

Happy hacking! :bowtie: 