### PR TITLE
FIX treat n_jobs=None as if left to its default value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Latest changes
 ==============
 
+Release 1.3.2 -- In developpement
+---------------------------------
+
+- Fix a regression in ``joblib.Parallel`` introduced in 1.3.0 where explicitely
+  setting ``n_jobs=None`` was not interpreted as "unset".
+  https://github.com/joblib/joblib/pull/1475
+
 Release 1.3.1 -- 2023/06/29
 ---------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Latest changes
 Release 1.3.2 -- In developpement
 ---------------------------------
 
-- Fix a regression in ``joblib.Parallel`` introduced in 1.3.0 where explicitely
-  setting ``n_jobs=None`` was not interpreted as "unset".
+- Fix a regression in ``joblib.Parallel`` introduced in 1.3.0 where
+  explicitly setting ``n_jobs=None`` was not interpreted as "unset".
   https://github.com/joblib/joblib/pull/1475
 
 Release 1.3.1 -- 2023/06/29

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1253,6 +1253,7 @@ class Parallel(Logger):
             backend = MultiprocessingBackend(nesting_level=nesting_level)
 
         elif backend not in BACKENDS and backend in MAYBE_AVAILABLE_BACKENDS:
+            print("### DEBUG ###")
             warnings.warn(
                 f"joblib backend '{backend}' is not available on "
                 f"your system, falling back to {DEFAULT_BACKEND}.",

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -113,8 +113,9 @@ def _get_config_param(param, context_config, key):
     Explicitly setting it in Parallel has priority over setting in a
     parallel_(config/backend) context manager.
     """
-    if param is not default_parallel_config[key]:
+    if param is not default_parallel_config[key] and not (key == "n_jobs" and param is None):
         # param is explicitely set, return it
+        # unless it is n_jobs=None, which we still want to interpret as unset.
         return param
 
     if context_config[key] is not default_parallel_config[key]:

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -113,12 +113,8 @@ def _get_config_param(param, context_config, key):
     Explicitly setting it in Parallel has priority over setting in a
     parallel_(config/backend) context manager.
     """
-    if (
-        param is not default_parallel_config[key]
-        and not (key == "n_jobs" and param is None)
-    ):
+    if param is not default_parallel_config[key]:
         # param is explicitely set, return it
-        # unless it is n_jobs=None, which we still want to interpret as unset.
         return param
 
     if context_config[key] is not default_parallel_config[key]:
@@ -370,6 +366,10 @@ class parallel_config:
         backend = self._check_backend(
             backend, inner_max_num_threads, **backend_params
         )
+
+        # Interpret n_jobs=None as 'unset'
+        if n_jobs is None:
+            n_jobs = default_parallel_config["n_jobs"]
 
         new_config = {
             "n_jobs": n_jobs,
@@ -1191,6 +1191,10 @@ class Parallel(Logger):
         prefer=default_parallel_config["prefer"],
         require=default_parallel_config["require"],
     ):
+        # Interpret n_jobs=None as 'unset'
+        if n_jobs is None:
+            n_jobs = default_parallel_config["n_jobs"]
+
         active_backend, context_config = _get_active_backend(
             prefer=prefer, require=require, verbose=verbose
         )

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1236,6 +1236,8 @@ class Parallel(Logger):
         elif hasattr(mp, "get_context"):
             self._backend_args['context'] = mp.get_context()
 
+        print("backend", backend)
+
         if backend is default_parallel_config['backend'] or backend is None:
             backend = active_backend
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -367,10 +367,6 @@ class parallel_config:
             backend, inner_max_num_threads, **backend_params
         )
 
-        # Interpret n_jobs=None as 'unset'
-        if n_jobs is None:
-            n_jobs = default_parallel_config["n_jobs"]
-
         new_config = {
             "n_jobs": n_jobs,
             "verbose": verbose,

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1237,6 +1237,8 @@ class Parallel(Logger):
             self._backend_args['context'] = mp.get_context()
 
         print("backend", backend)
+        print("BACKENDS", BACKENDS)
+        print("MAYBE_AVAILABLE_BACKENDS", MAYBE_AVAILABLE_BACKENDS)
 
         if backend is default_parallel_config['backend'] or backend is None:
             backend = active_backend

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -113,9 +113,12 @@ def _get_config_param(param, context_config, key):
     Explicitly setting it in Parallel has priority over setting in a
     parallel_(config/backend) context manager.
     """
-    if param is not default_parallel_config[key] and not (key == "n_jobs" and param is None):
+    if (
+        param is not default_parallel_config[key]
+        and not (key == "n_jobs" and param is None)
+    ):
         # param is explicitely set, return it
-        # unless it is n_jobs=None, which we still want to interpret as unset.
+        # unless it is n_jobs=None, which we still want to interpret as unset.
         return param
 
     if context_config[key] is not default_parallel_config[key]:

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1236,10 +1236,6 @@ class Parallel(Logger):
         elif hasattr(mp, "get_context"):
             self._backend_args['context'] = mp.get_context()
 
-        print("backend", backend)
-        print("BACKENDS", BACKENDS)
-        print("MAYBE_AVAILABLE_BACKENDS", MAYBE_AVAILABLE_BACKENDS)
-
         if backend is default_parallel_config['backend'] or backend is None:
             backend = active_backend
 
@@ -1257,7 +1253,6 @@ class Parallel(Logger):
             backend = MultiprocessingBackend(nesting_level=nesting_level)
 
         elif backend not in BACKENDS and backend in MAYBE_AVAILABLE_BACKENDS:
-            print("### DEBUG ###")
             warnings.warn(
                 f"joblib backend '{backend}' is not available on "
                 f"your system, falling back to {DEFAULT_BACKEND}.",

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -133,3 +133,8 @@ def test_parallel_config_n_jobs_none(context):
     with context(backend="loky", n_jobs=2):
         with Parallel(n_jobs=None) as p:
             assert p.n_jobs == 2
+
+    with context(backend="loky", n_jobs=2):
+        with context(backend="loky", n_jobs=None):
+            with Parallel() as p:
+                assert p.n_jobs == 2

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -126,15 +126,25 @@ def test_threadpool_limitation_in_child_context_error(context, backend):
 
 
 @parametrize("context", [parallel_config, parallel_backend])
-def test_parallel_config_n_jobs_none(context):
-    # Check that n_jobs=None is interpreted as "unset" and treated as if left
-    # to its default value.
+def test_parallel_n_jobs_none(context):
+    # Check that n_jobs=None is interpreted as "unset" in Parallel
     # non regression test for #1473
     with context(backend="loky", n_jobs=2):
         with Parallel(n_jobs=None) as p:
             assert p.n_jobs == 2
 
+    with context(backend="loky"):
+        default_n_jobs = Parallel().n_jobs
+        with Parallel(n_jobs=None) as p:
+            assert p.n_jobs == default_n_jobs
+
+
+@parametrize("context", [parallel_config, parallel_backend])
+def test_parallel_config_n_jobs_none(context):
+    # Check that n_jobs=None is interpreted as "explicitly set" in
+    # parallel_(config/backend)
+    # non regression test for #1473
     with context(backend="loky", n_jobs=2):
-        with context(backend="loky", n_jobs=None):
+        with context(backend="loky", n_jobs=None):  # resets n_jobs to backend default
             with Parallel() as p:
-                assert p.n_jobs == 2
+                assert p.n_jobs == 1

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -145,6 +145,7 @@ def test_parallel_config_n_jobs_none(context):
     # parallel_(config/backend)
     # non regression test for #1473
     with context(backend="loky", n_jobs=2):
-        with context(backend="loky", n_jobs=None):  # resets n_jobs to backend default
+        with context(backend="loky", n_jobs=None):
+            # n_jobs=None resets n_jobs to backend's default
             with Parallel() as p:
                 assert p.n_jobs == 1

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -129,11 +129,11 @@ def test_threadpool_limitation_in_child_context_error(context, backend):
 def test_parallel_n_jobs_none(context):
     # Check that n_jobs=None is interpreted as "unset" in Parallel
     # non regression test for #1473
-    with context(backend="loky", n_jobs=2):
+    with context(backend="threading", n_jobs=2):
         with Parallel(n_jobs=None) as p:
             assert p.n_jobs == 2
 
-    with context(backend="loky"):
+    with context(backend="threading"):
         default_n_jobs = Parallel().n_jobs
         with Parallel(n_jobs=None) as p:
             assert p.n_jobs == default_n_jobs
@@ -144,8 +144,8 @@ def test_parallel_config_n_jobs_none(context):
     # Check that n_jobs=None is interpreted as "explicitly set" in
     # parallel_(config/backend)
     # non regression test for #1473
-    with context(backend="loky", n_jobs=2):
-        with context(backend="loky", n_jobs=None):
+    with context(backend="threading", n_jobs=2):
+        with context(backend="threading", n_jobs=None):
             # n_jobs=None resets n_jobs to backend's default
             with Parallel() as p:
                 assert p.n_jobs == 1

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -123,3 +123,13 @@ def test_threadpool_limitation_in_child_context_error(context, backend):
 
     with raises(AssertionError, match=r"does not acc.*inner_max_num_threads"):
         context(backend, inner_max_num_threads=1)
+
+
+@parametrize("context", [parallel_config, parallel_backend])
+def test_parallel_config_n_jobs_none(context):
+    # Check that n_jobs=None is interpreted as "unset" and treated as if left
+    # to its default value.
+    # non regression test for #1473
+    with context(backend="loky", n_jobs=2):
+        with Parallel(n_jobs=None) as p:
+            assert p.n_jobs == 2


### PR DESCRIPTION
Fixes #1473 

Even if the new default value of `n_jobs` is a sentinel object, I think that we should not interpret `n_jobs=None` as explicitely set because it used to mean 'unset'. Instead we should treat it identically as if it were left to its default value.