### PR TITLE
Avoid using deprecated ast.Num and node.n

### DIFF
--- a/joblib/_utils.py
+++ b/joblib/_utils.py
@@ -35,8 +35,8 @@ def eval_expr(expr):
 
 
 def eval_(node):
-    if isinstance(node, ast.Num):  # <number>
-        return node.n
+    if isinstance(node, ast.Constant):  # <number>
+        return node.value
     elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
         return operators[type(node.op)](eval_(node.left), eval_(node.right))
     elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1


### PR DESCRIPTION
Markign this as a **draft**, as I have only tested it on Python 3.12. An `if` might be needed to support some older Pythons.  