### PR TITLE
DOC: Best randomness with Parallel generators

### DIFF
--- a/examples/parallel_random_state.py
+++ b/examples/parallel_random_state.py
@@ -113,18 +113,20 @@ if mp.get_start_method() != "spawn":
 # Fixing the random state to obtain deterministic results
 #########################################################
 #
-# The pattern of ``stochastic_function_seeded`` has another advantage: it
-# allows to control the random_state by passing a known seed. So for instance,
-# we can replicate the same generation of vectors by passing a fixed state as
-# follows.
+# The pattern of ``stochastic_function_seeded`` has another advantage: it allows
+# to control the random_state by passing a known seed. For best results [1]_, the
+# random state is initialized by a sequence based on a root seed and a job
+# identifier. So for instance, we can replicate the same generation of vectors
+# by passing a fixed state as follows.
+#
+# .. [1] https://numpy.org/doc/stable/reference/random/parallel.html
 
 if mp.get_start_method() != "spawn":
-    random_state = np.random.randint(np.iinfo(np.int32).max, size=n_vectors)
-
+    root_seed = 42
     random_vector = Parallel(n_jobs=2, backend=backend)(delayed(
-        stochastic_function_seeded)(10, rng) for rng in random_state)
+        stochastic_function_seeded)(10, [root_seed, i]) for i in range(n_vectors))
     print_vector(random_vector, backend)
 
     random_vector = Parallel(n_jobs=2, backend=backend)(delayed(
-        stochastic_function_seeded)(10, rng) for rng in random_state)
+        stochastic_function_seeded)(10, [root_seed, i]) for i in range(n_vectors))
     print_vector(random_vector, backend)

--- a/examples/parallel_random_state.py
+++ b/examples/parallel_random_state.py
@@ -113,20 +113,20 @@ if mp.get_start_method() != "spawn":
 # Fixing the random state to obtain deterministic results
 #########################################################
 #
-# The pattern of ``stochastic_function_seeded`` has another advantage: it allows
-# to control the random_state by passing a known seed. For best results [1]_, the
-# random state is initialized by a sequence based on a root seed and a job
-# identifier. So for instance, we can replicate the same generation of vectors
-# by passing a fixed state as follows.
+# The pattern of ``stochastic_function_seeded`` has another advantage: it
+# allows to control the random_state by passing a known seed. For best results
+# [1]_, the random state is initialized by a sequence based on a root seed and
+# a job identifier. So for instance, we can replicate the same generation of
+# vectors by passing a fixed state as follows.
 #
-# .. [1] https://numpy.org/doc/stable/reference/random/parallel.html
+# .. [1]  https://numpy.org/doc/stable/reference/random/parallel.html
 
 if mp.get_start_method() != "spawn":
-    root_seed = 42
+    seed = 42
     random_vector = Parallel(n_jobs=2, backend=backend)(delayed(
-        stochastic_function_seeded)(10, [root_seed, i]) for i in range(n_vectors))
+        stochastic_function_seeded)(10, [seed, i]) for i in range(n_vectors))
     print_vector(random_vector, backend)
 
     random_vector = Parallel(n_jobs=2, backend=backend)(delayed(
-        stochastic_function_seeded)(10, [root_seed, i]) for i in range(n_vectors))
+        stochastic_function_seeded)(10, [seed, i]) for i in range(n_vectors))
     print_vector(random_vector, backend)

--- a/examples/parallel_random_state.py
+++ b/examples/parallel_random_state.py
@@ -124,9 +124,9 @@ if mp.get_start_method() != "spawn":
 if mp.get_start_method() != "spawn":
     seed = 42
     random_vector = Parallel(n_jobs=2, backend=backend)(delayed(
-        stochastic_function_seeded)(10, [seed, i]) for i in range(n_vectors))
+        stochastic_function_seeded)(10, [i, seed]) for i in range(n_vectors))
     print_vector(random_vector, backend)
 
     random_vector = Parallel(n_jobs=2, backend=backend)(delayed(
-        stochastic_function_seeded)(10, [seed, i]) for i in range(n_vectors))
+        stochastic_function_seeded)(10, [i, seed]) for i in range(n_vectors))
     print_vector(random_vector, backend)


### PR DESCRIPTION
Hi, 

I found a small imprecision in the parallel random state example [^1], as using iterative seed is not recommended as per [^2]. This PR update the example to the best practice, and add a reference to  the Numpy documentation for the curious reader.

[^1]: https://joblib.readthedocs.io/en/latest/auto_examples/parallel_random_state.html#sphx-glr-auto-examples-parallel-random-state-py

[^2]: https://numpy.org/doc/stable/reference/random/parallel.html#sequence-of-integer-seeds
