### PR TITLE
FIX Init logger parent class in Parallel

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1188,6 +1188,9 @@ class Parallel(Logger):
         prefer=default_parallel_config["prefer"],
         require=default_parallel_config["require"],
     ):
+        # Initiate parent Logger class state
+        super().__init__()
+
         # Interpret n_jobs=None as 'unset'
         if n_jobs is None:
             n_jobs = default_parallel_config["n_jobs"]


### PR DESCRIPTION
Some further discussion could take place in https://github.com/joblib/joblib/issues/1483 regarding deprecating inheritance to Logger, in the meantime it doesn't cost much to properly init it so it can keep working as it used to.