### PR TITLE
MAINT: Cleanup expired ndarray methods

### DIFF
--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -69,7 +69,7 @@ def _ensure_native_byte_order(array):
     Does nothing if array already uses the system byte order.
     """
     if _is_numpy_array_byte_order_mismatch(array):
-        array = array.byteswap().newbyteorder('=')
+        array = array.byteswap().view(array.dtype.newbyteorder('='))
     return array
 
 


### PR DESCRIPTION
Hi!
This PR reflects changes introduced in https://github.com/numpy/numpy/pull/24682.