### PR TITLE
Fix README archive download link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ To get the latest code using git, simply type::
 
     git clone https://github.com/joblib/joblib.git
 
-If you don't have git installed, you can download a zip or tarball
-of the latest code: http://github.com/joblib/joblib/archives/master
+If you don't have git installed, you can download a zip
+of the latest code: https://github.com/joblib/joblib/archive/refs/heads/master.zip
 
 Installing
 ==========


### PR DESCRIPTION
1. https://github.com/joblib/joblib/archives/master now returns a 404 response
2. It would appear as if GitHub now only provide ZIP archives