### PR TITLE
Prefer https:// links in the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,8 +67,8 @@ Workflow to contribute
 ======================
 
 To contribute to joblib, first create an account on `github
-<http://github.com/>`_. Once this is done, fork the `joblib repository
-<http://github.com/joblib/joblib>`_ to have your own repository,
+<https://github.com/>`_. Once this is done, fork the `joblib repository
+<https://github.com/joblib/joblib>`_ to have your own repository,
 clone it using 'git clone' on the computers where you want to work. Make
 your changes in your clone, push them to your github account, test them
 on several computers, and when you are happy with them, send a pull

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -13,7 +13,7 @@
     <hr/>
     <div>
 	<h3>Mailing list</h3>
-	<a href="http://librelist.com/browser/joblib/">joblib@librelist.com</a>
+	<a href="https://librelist.com/browser/joblib/">joblib@librelist.com</a>
     <p class="searchtip" style="font-size: 80%">
     Send an email to subscribe</p>
     </div>

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -34,7 +34,7 @@ The manual way
 ---------------
 
 To install joblib first download the latest tarball (follow the link on
-the bottom of http://pypi.python.org/pypi/joblib) and expand it.
+the bottom of https://pypi.org/project/joblib/) and expand it.
 
 Installing in a local environment
 ..................................

--- a/doc/memory.rst
+++ b/doc/memory.rst
@@ -63,7 +63,7 @@ A simple example:
 Comparison with `memoize`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `memoize` decorator (http://code.activestate.com/recipes/52201/)
+The `memoize` decorator (https://code.activestate.com/recipes/52201/)
 caches in memory all the inputs and outputs of a function call. It can
 thus avoid running twice the same function, with a very small
 overhead. However, it compares input objects with those in cache on each

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -69,7 +69,7 @@ of Python processes as concurrent workers. For instance this is the case
 if you write the CPU intensive part of your code inside a `with nogil`_
 block of a Cython function.
 
-.. _`with nogil`: http://docs.cython.org/src/userguide/external_C_code.html#acquiring-and-releasing-the-gil
+.. _`with nogil`: https://docs.cython.org/src/userguide/external_C_code.html#acquiring-and-releasing-the-gil
 
 To hint that your code can efficiently use threads, just pass
 ``prefer="threads"`` as parameter of the :class:`joblib.Parallel` constructor.


### PR DESCRIPTION
All the changed urls are available by way of https://, and they all already had some form of redirect in place.