### PR TITLE
Update dask backend for compatibility with return_as=generator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ In development
 - Ensure that errors in the task generator given to Parallel's call
   are raised in the results consumming thread.
   https://github.com/joblib/joblib/pull/1491
-  
+
 - Adjust codebase to NumPy 2.0 by changing ``np.NaN`` to ``np.nan``
   and importing ``byte_bounds`` from ``np.lib.array_utils``.
   https://github.com/joblib/joblib/pull/1501
@@ -16,6 +16,10 @@ In development
   ``generator_unordered``. In this case the results will be returned in the
   order of task completion rather than the order of submission.
   https://github.com/joblib/joblib/pull/1463
+
+- dask backend now supports ``return_as=generator`` and
+  ``return_as=generator_unordered``.
+  https://github.com/joblib/joblib/pull/1520
 
 - Vendor cloudpickle 3.0.0 and drop support for Python 3.7.
   https://github.com/joblib/joblib/pull/1515

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,11 +55,11 @@ jobs:
         # dependencies.
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.10"
-        EXTRA_CONDA_PACKAGES: "numpy=1.23 distributed=2022.2.0"
+        EXTRA_CONDA_PACKAGES: "numpy=1.23 distributed=2023.10.1"
       linux_py38_distributed:
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.8"
-        EXTRA_CONDA_PACKAGES: "numpy=1.18.5 distributed=2021.1.1"
+        EXTRA_CONDA_PACKAGES: "numpy=1.18.5 distributed=2021.5.0"
       linux_py311_cython:
         imageName: 'ubuntu-latest'
         PYTHON_VERSION: "3.11"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,6 +127,36 @@ jobs:
     displayName: 'Publish Test Results'
     condition: and(succeededOrFailed(), ne(variables['SKIP_TESTS'], 'true'))
 
-  - bash: curl -s https://codecov.io/bash | bash
-    displayName: 'Upload to codecov'
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: .coverage
+    displayName: 'Create coverage artifact data'
     condition: and(succeeded(), ne(variables['SKIP_TESTS'], 'true'), eq(variables['COVERAGE'], 'true'))
+
+- job: coverage
+  displayName: Coverage
+  dependsOn: testing
+
+  pool:
+    vmImage: ubuntu-latest
+
+  steps:
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
+  - bash: sudo chown -R $USER $CONDA
+    displayName: Take ownership of conda installation
+  - bash: conda create --name coverage_env --yes coverage
+    displayName: Install coverage
+
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      targetPath: ./
+    displayName: 'Gather coverage artifact data'
+
+  - bash: |
+      source activate coverage_env
+      coverage combine **/.coverage
+      coverage xml
+      curl -s https://codecov.io/bash | bash
+    displayName: 'Upload to codecov'
+    condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,12 +151,14 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       targetPath: ./
-    displayName: 'Gather coverage artifact data'
+    displayName: 'Gather coverage data'
 
   - bash: |
       source activate coverage_env
       coverage combine **/.coverage
       coverage xml
-      curl -s https://codecov.io/bash | bash
+    displayName: 'Consolidate coverage data'
+
+  - bash: curl -s https://codecov.io/bash | bash
     displayName: 'Upload to codecov'
     condition: succeeded()

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -17,7 +17,7 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
     if [ "$COVERAGE" == "true" ]; then
         # Enable coverage-related options. --cov-append is needed to combine
         # the test run and the test-doc run coverage.
-        export PYTEST_ADDOPTS="--cov=joblib --cov-append"
+        export PYTEST_ADDOPTS="--cov=joblib --cov-append --cov-report=xml"
     fi
 
     pytest joblib -vl --timeout=120 --junitxml="${JUNITXML}"
@@ -56,14 +56,6 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
 fi
 
 if [[ "$SKIP_TESTS" != "true" && "$COVERAGE" == "true" ]]; then
-    echo "Deleting empty coverage files:"
-    # the "|| echo" is to avoid having 0 return states that terminate the
-    # script when the find uncounters permission denied
-    find . -name ".coverage.*" -size  0 -print -delete || echo
-    echo "Combining .coverage.* files..."
-    coverage combine --append  || echo "Found invalid coverage files."
-    echo "Generating XML Coverage report..."
-    coverage xml # language agnostic report for the codecov upload script
     echo "XML Coverage report written in $PWD:"
     ls -la .coverage*
     ls -la coverage.xml

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -17,7 +17,7 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
     if [ "$COVERAGE" == "true" ]; then
         # Enable coverage-related options. --cov-append is needed to combine
         # the test run and the test-doc run coverage.
-        export PYTEST_ADDOPTS="--cov=joblib --cov-append --cov-report=xml"
+        export PYTEST_ADDOPTS="--cov=joblib --cov-append"
     fi
 
     pytest joblib -vl --timeout=120 --junitxml="${JUNITXML}"
@@ -53,10 +53,4 @@ if [[ "$SKLEARN_TESTS" == "true" ]]; then
     #
     # test_check_memory: scikit-learn test need to be updated to avoid using
     # cachedir: https://github.com/scikit-learn/scikit-learn/pull/22365
-fi
-
-if [[ "$SKIP_TESTS" != "true" && "$COVERAGE" == "true" ]]; then
-    echo "XML Coverage report written in $PWD:"
-    ls -la .coverage*
-    ls -la coverage.xml
 fi

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -11,6 +11,8 @@ import weakref
 from .parallel import parallel_config
 from .parallel import AutoBatchingMixin, ParallelBackendBase
 
+from ._utils import _WrapFuncCall, _retrieve_wrapped_call
+
 try:
     import dask
     import distributed
@@ -141,7 +143,7 @@ def _joblib_probe_task():
 class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
     MIN_IDEAL_BATCH_DURATION = 0.2
     MAX_IDEAL_BATCH_DURATION = 1.0
-    supports_timeout = True
+    supports_retrieve_callback = True
     default_n_jobs = -1
 
     def __init__(self, scheduler_host=None, scatter=None,
@@ -329,7 +331,10 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
             key = f'{repr(batch)}-{uuid4().hex}'
 
             dask_future = self.client.submit(
-                batch, tasks=tasks, key=key, **self.submit_kwargs
+                _WrapFuncCall(batch),
+                tasks=tasks,
+                key=key,
+                **self.submit_kwargs
             )
             self.waiting_futures.add(dask_future)
             self._callbacks[dask_future] = callback
@@ -338,6 +343,9 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
         self.client.loop.add_callback(f, func, callback)
 
         return cf_future
+
+    def retrieve_result_callback(self, out):
+        return _retrieve_wrapped_call(out)
 
     def abort_everything(self, ensure_ready=True):
         """ Tell the client to cancel any task submitted via this instance

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -11,7 +11,10 @@ import weakref
 from .parallel import parallel_config
 from .parallel import AutoBatchingMixin, ParallelBackendBase
 
-from ._utils import _WrapFuncCall, _retrieve_wrapped_call
+from ._utils import (
+    _TracebackCapturingWrapper,
+    _retrieve_traceback_capturing_wrapped_call
+)
 
 try:
     import dask
@@ -331,7 +334,7 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
             key = f'{repr(batch)}-{uuid4().hex}'
 
             dask_future = self.client.submit(
-                _WrapFuncCall(batch),
+                _TracebackCapturingWrapper(batch),
                 tasks=tasks,
                 key=key,
                 **self.submit_kwargs
@@ -345,7 +348,7 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
         return cf_future
 
     def retrieve_result_callback(self, out):
-        return _retrieve_wrapped_call(out)
+        return _retrieve_traceback_capturing_wrapped_call(out)
 
     def abort_everything(self, ensure_ready=True):
         """ Tell the client to cancel any task submitted via this instance

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -9,8 +9,10 @@ import threading
 import contextlib
 from abc import ABCMeta, abstractmethod
 
-
-from ._utils import _WrapFuncCall, _retrieve_wrapped_call
+from ._utils import (
+    _TracebackCapturingWrapper,
+    _retrieve_traceback_capturing_wrapped_call
+)
 
 from ._multiprocessing_helpers import mp
 
@@ -271,13 +273,13 @@ class PoolManagerMixin(object):
         # We also call the callback on error, to make sure the pool does not
         # wait on crashed jobs.
         return self._get_pool().apply_async(
-            _WrapFuncCall(func), (),
+            _TracebackCapturingWrapper(func), (),
             callback=callback, error_callback=callback
         )
 
     def retrieve_result_callback(self, out):
         """Mimic concurrent.futures results, raising an error if needed."""
-        return _retrieve_wrapped_call(out)
+        return _retrieve_traceback_capturing_wrapped_call(out)
 
     def abort_everything(self, ensure_ready=True):
         """Shutdown the pool and restart a new one with the same parameters"""

--- a/joblib/_utils.py
+++ b/joblib/_utils.py
@@ -61,7 +61,7 @@ class _Sentinel:
         return f"default({self.default_value!r})"
 
 
-class _WrapFuncCall:
+class _TracebackCapturingWrapper:
     """Protect function call and return error with traceback."""
 
     def __init__(self, func):
@@ -74,7 +74,7 @@ class _WrapFuncCall:
             return _ExceptionWithTraceback(e)
 
 
-def _retrieve_wrapped_call(out):
+def _retrieve_traceback_capturing_wrapped_call(out):
     if isinstance(out, _ExceptionWithTraceback):
         rebuild, args = out.__reduce__()
         out = rebuild(*args)

--- a/joblib/_utils.py
+++ b/joblib/_utils.py
@@ -4,6 +4,13 @@ import ast
 from dataclasses import dataclass
 import operator as op
 
+
+from ._multiprocessing_helpers import mp
+
+if mp is not None:
+    from .externals.loky.process_executor import _ExceptionWithTraceback
+
+
 # supported operators
 operators = {
     ast.Add: op.add,
@@ -52,3 +59,25 @@ class _Sentinel:
 
     def __repr__(self):
         return f"default({self.default_value!r})"
+
+
+class _WrapFuncCall:
+    """Protect function call and return error with traceback."""
+
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, **kwargs):
+        try:
+            return self.func(**kwargs)
+        except BaseException as e:
+            return _ExceptionWithTraceback(e)
+
+
+def _retrieve_wrapped_call(out):
+    if isinstance(out, _ExceptionWithTraceback):
+        rebuild, args = out.__reduce__()
+        out = rebuild(*args)
+    if isinstance(out, BaseException):
+        raise out
+    return out

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1289,7 +1289,7 @@ def test_parallel_unordered_generator_returns_fastest_first(backend, n_jobs):
     _test_parallel_unordered_generator_returns_fastest_first(backend, n_jobs)
 
 
-@pytest.mark.parametrize('n_jobs', [2, 4])
+@pytest.mark.parametrize('n_jobs', [2, -1])
 @skipif(distributed is None, reason='This test requires dask')
 @parametrize("context", [parallel_config, parallel_backend])
 def test_parallel_unordered_generator_returns_fastest_first_with_dask(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,11 +88,15 @@ testpaths = "joblib"
 norecursedirs = "joblib/externals/*"
 
 [tool.coverage.run]
+source = [
+    "joblib"
+]
 omit = [
     "joblib/test/data/*",
     "joblib/test/_openmp_test_helper/setup.py",
     "*/joblib/externals/*",
 ]
+relative_files = true
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
Reasonably simple changes, it seems to be just working as intended. Let's see if the CI agrees.

Are there particular tests to add on top ? the code paths for return_as=generator are the same than for return_as=list so test_dask already tests most of it.