### PR TITLE
Remove an unnecessary lock

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1744,11 +1744,7 @@ class Parallel(Logger):
                 time.sleep(0.01)
                 continue
 
-            # We need to be careful: the job list can be filling up as
-            # we empty it and Python list are not thread-safe by
-            # default hence the use of the lock
-            with self._lock:
-                batched_results = self._jobs.popleft()
+            batched_results = self._jobs.popleft()
 
             # Flatten the batched results to output one output at a time
             batched_results = batched_results.get_result(self.timeout)


### PR DESCRIPTION
I think this lock isn't necessary anymore now that `self._jobs` is a deque, since `popleft` and `append` are atomic:

> [Deques support **thread-safe** [...] appends and pops **from either side of the deque**](https://docs.python.org/3/library/collections.html#collections.deque)
