### PR TITLE
Add invalidate_cache function to Memory public interface

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -685,6 +685,11 @@ class MemorizedFunc(Logger):
         func_id, args_id = self._get_output_identifiers(*args, **kwargs)
         return self.store_backend.contains_item((func_id, args_id))
 
+    def invalidate_cache(self, *args, **kwargs):
+        """Removes this call from the cache"""
+        identifier = self._get_output_identifiers(*args, **kwargs)
+        return self.store_backend.clear_item(identifier)
+
     # ------------------------------------------------------------------------
     # Private interface
     # ------------------------------------------------------------------------


### PR DESCRIPTION
Adds a simple function to the public interface for a Memory-ized function that allows the user to clear just one value from the cache.  Luckily, the store_backend already has the functionality to do this, it just needs to be exposed.