### PR TITLE
n_jobs parameter in instantiation of Parallel should be an integer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Latest changes
 In development
 --------------
 
+- Try to cast ``n_jobs`` to int in parallel and raise an error if
+  it fails. This means that ``n_jobs=2.3`` will now result in
+  ``effective_n_jobs=2`` instead of failing.
+  https://github.com/joblib/joblib/pull/1539
+
 - Ensure that errors in the task generator given to Parallel's call
   are raised in the results consumming thread.
   https://github.com/joblib/joblib/pull/1491

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1287,6 +1287,8 @@ class Parallel(Logger):
             # No specific context override and no specific value request:
             # default to the default of the backend.
             n_jobs = backend.default_n_jobs
+        if not isinstance(n_jobs, int):
+            raise ValueError("n_jobs is required to be an int")
         self.n_jobs = n_jobs
 
         if (require == 'sharedmem' and

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1287,8 +1287,10 @@ class Parallel(Logger):
             # No specific context override and no specific value request:
             # default to the default of the backend.
             n_jobs = backend.default_n_jobs
-        if not isinstance(n_jobs, int):
-            raise ValueError("n_jobs is required to be an int")
+        try:
+            n_jobs = int(n_jobs)
+        except ValueError:
+            raise ValueError("n_jobs could not be converted to int")
         self.n_jobs = n_jobs
 
         if (require == 'sharedmem' and

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -2009,3 +2009,10 @@ def test_loky_reuse_workers(n_jobs):
         parallel_call(n_jobs)
         executor = get_reusable_executor(reuse=True)
         assert executor == first_executor
+
+
+def test_n_jobs_int_required():
+    # For issue 1539
+
+    with pytest.raises(ValueError):
+        Parallel(n_jobs=10.0)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -646,6 +646,7 @@ def test_invalid_njobs(backend):
     assert "n_jobs could not be converted to int" in str(excinfo.value)
 
 
+@with_multiprocessing
 @parametrize('backend', PARALLEL_BACKENDS)
 @parametrize('n_jobs', ['2', 2.3, 2])
 def test_njobs_converted_to_int(backend, n_jobs):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -2031,10 +2031,3 @@ def test_loky_reuse_workers(n_jobs):
         parallel_call(n_jobs)
         executor = get_reusable_executor(reuse=True)
         assert executor == first_executor
-
-
-def test_n_jobs_int_required():
-    # For issue 1539
-
-    with pytest.raises(ValueError):
-        Parallel(n_jobs=10.0)

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -633,6 +633,28 @@ def test_invalid_njobs(backend):
         Parallel(n_jobs=0, backend=backend)._initialize_backend()
     assert "n_jobs == 0 in Parallel has no meaning" in str(excinfo.value)
 
+    with raises(ValueError) as excinfo:
+        Parallel(n_jobs=0.5, backend=backend)._initialize_backend()
+    assert "n_jobs == 0 in Parallel has no meaning" in str(excinfo.value)
+
+    with raises(ValueError) as excinfo:
+        Parallel(n_jobs="2.3", backend=backend)._initialize_backend()
+    assert "n_jobs could not be converted to int" in str(excinfo.value)
+
+    with raises(ValueError) as excinfo:
+        Parallel(n_jobs="invalid_str", backend=backend)._initialize_backend()
+    assert "n_jobs could not be converted to int" in str(excinfo.value)
+
+
+@parametrize('backend', PARALLEL_BACKENDS)
+@parametrize('n_jobs', ['2', 2.3, 2])
+def test_njobs_converted_to_int(backend, n_jobs):
+    p = Parallel(n_jobs=n_jobs, backend=backend)
+    assert p._effective_n_jobs() == 2
+
+    res = p(delayed(square)(i) for i in range(10))
+    assert all(r == square(i) for i, r in enumerate(res))
+
 
 def test_register_parallel_backend():
     try:


### PR DESCRIPTION
Based on https://github.com/joblib/joblib/issues/1539