### PR TITLE
Use inspect.getsourcelines to get code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Latest changes
 In development
 --------------
 
+- Updating func_inspect module with a simpler means of retrieving
+  a functions code using inspect.getsourcelines
+  https://github.com/joblib/joblib/pull/1550
+
 - Ensure that errors in the task generator given to Parallel's call
   are raised in the results consumming thread.
   https://github.com/joblib/joblib/pull/1491

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -8,12 +8,8 @@ My own variation on function-specific inspect-like features.
 
 import inspect
 import warnings
-import re
 import os
 import collections
-
-from itertools import islice
-from tokenize import open as open_py_source
 
 from .logger import pformat
 
@@ -24,10 +20,6 @@ full_argspec_type = collections.namedtuple('FullArgSpec', full_argspec_fields)
 
 def get_func_code(func):
     """ Attempts to retrieve a reliable function code hash.
-
-        The reason we don't use inspect.getsource is that it caches the
-        source, whereas we want this to be modified on the fly when the
-        function is modified.
 
         Returns
         -------
@@ -45,25 +37,9 @@ def get_func_code(func):
     """
     source_file = None
     try:
-        code = func.__code__
-        source_file = code.co_filename
-        if not os.path.exists(source_file):
-            # Use inspect for lambda functions and functions defined in an
-            # interactive shell, or in doctests
-            source_code = ''.join(inspect.getsourcelines(func)[0])
-            line_no = 1
-            if source_file.startswith('<doctest '):
-                source_file, line_no = re.match(
-                    r'\<doctest (.*\.rst)\[(.*)\]\>', source_file).groups()
-                line_no = int(line_no)
-                source_file = '<doctest %s>' % source_file
-            return source_code, source_file, line_no
-        # Try to retrieve the source code.
-        with open_py_source(source_file) as source_file_obj:
-            first_line = code.co_firstlineno
-            # All the lines after the function definition:
-            source_lines = list(islice(source_file_obj, first_line - 1, None))
-        return ''.join(inspect.getblock(source_lines)), source_file, first_line
+        source_file = inspect.getsourcefile(func)
+        code, first_line = inspect.getsourcelines(func)
+        return ''.join(code), source_file, first_line
     except:  # noqa: E722
         # If the source code fails, we use the hash. This is fragile and
         # might change from one session to another.


### PR DESCRIPTION
Fixing the bug outstanding in https://github.com/joblib/joblib/pull/1234. All credit to the original author as this is just rounding out that change