### PR TITLE
Add a test that ensure conservation of byte order during IPC

### DIFF
--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -362,6 +362,27 @@ def test_parallel_pickling():
             UnpicklableObject()) for _ in range(10))
 
 
+@with_multiprocessing
+@parametrize('byteorder', ['<', '>', '='])
+def test_parallel_byteorder_corruption(byteorder):
+
+    def inspect_byteorder(x):
+        return x, x.dtype.byteorder
+
+    x = np.arange(6).reshape((2, 3)).view(f'{byteorder}i4')
+
+    initial_np_byteorder = x.dtype.byteorder
+
+    result = Parallel(n_jobs=2, backend='loky')(
+        delayed(inspect_byteorder)(x) for _ in range(3)
+    )
+
+    for x_returned, byteorder_in_worker in result:
+        assert byteorder_in_worker == initial_np_byteorder
+        assert byteorder_in_worker == x_returned.dtype.byteorder
+        np.testing.assert_array_equal(x, x_returned)
+
+
 @parametrize('backend', PARALLEL_BACKENDS)
 def test_parallel_timeout_success(backend):
     # Check that timeout isn't thrown when function is fast enough

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -362,6 +362,7 @@ def test_parallel_pickling():
             UnpicklableObject()) for _ in range(10))
 
 
+@with_numpy
 @with_multiprocessing
 @parametrize('byteorder', ['<', '>', '='])
 def test_parallel_byteorder_corruption(byteorder):


### PR DESCRIPTION
This test shows that the current behavior regarding byteorder consistency in IPC is fine, and will also show that there's no regression in https://github.com/joblib/joblib/pull/1561 .