### PR TITLE
feat: avoid polluting memory namespace when caching functions in jupyter notebooks

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -143,12 +143,12 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
                 splitted = parts[-1].split('-')
                 parts[-1] = '-'.join(splitted[:2] + splitted[3:])
             elif len(parts) > 2 and parts[-2].startswith('ipykernel_'):
-                # In a notebook session (ipykernel). Filename seems to be 'xyz'
-                # of above. parts[-2] has the structure ipykernel_XXXXXX where
-                # XXXXXX is a six-digit number identifying the current run (?).
-                # If we split it off, the function again has the same
-                # identifier across runs.
-                parts[-2] = 'ipykernel'
+                # In a notebook session, filename is dynamically generated as
+                # /tmp/ipykernel_{pid}/{code_hash}.py where pid changes between
+                # runs, and code_hash changes when the function code changes.
+                # We remove both to avoid polluting the Memory namespace on
+                # each restart or function code change.
+                parts = ['ipykernel']
             filename = '-'.join(parts)
             if filename.endswith('.py'):
                 filename = filename[:-3]


### PR DESCRIPTION
while joblib previously correctly identified that part of the dynamically generated folder name for functions defined in a notebook depended on the pid and should be cut, it has missed that the filename was dynamically generated too and depended on the murmur2 hash of the function code.

this has lead to pollution of memory namespace on each function change. instead, we collapse the ipykernel namespace to a single static part and let joblib.Memory handle the invalidation on code changes as it's supposed to do.

you can learn more here https://github.com/ipython/ipykernel/blob/main/ipykernel/compiler.py#L90