### PR TITLE
Add public method to upfront check if call in cache and valid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ In development
   be passed directly to ``Memory.reduce_size``.
   https://github.com/joblib/joblib/pull/1569
 
+- Extend functionality of the ``check_call_in_cache`` method to now also
+  check against cache validity. Before, it would only check for a given call
+  if it is in cache memory.
+  https://github.com/joblib/joblib/pull/1584
+
 Release 1.4.2 -- 2024/05/02
 ---------------------------
 

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -605,7 +605,7 @@ class MemorizedFunc(Logger):
 
         Returns
         -------
-        bool:
+        is_call_in_cache: bool
             Whether or not the function call is in cache and can be used.
         """
         call_id = (self.func_id, self._get_args_id(*args, **kwargs))

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -599,7 +599,7 @@ class MemorizedFunc(Logger):
         and argument hashing.
 
         - Compare the function code with the one from the cached function,
-        asserting if it has changed.
+          asserting if it has changed.
         - Check if the function call is present in the cache.
         - Call `cache_validation_callback` for user define cache validation.
 

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -327,6 +327,9 @@ class NotMemorizedFunc(object):
     def check_call_in_cache(self, *args, **kwargs):
         return False
 
+    def is_call_in_cache_and_valid(self, *args, **kwargs) -> bool:
+        return False
+
 
 ###############################################################################
 # class `AsyncNotMemorizedFunc`
@@ -606,6 +609,25 @@ class MemorizedFunc(Logger):
         """
         call_id = (self.func_id, self._get_args_id(*args, **kwargs))
         return self.store_backend.contains_item(call_id)
+
+    def is_call_in_cache_and_valid(self, *args, **kwargs) -> bool:
+        """Check if the function call is cached and valid for given arguments.
+
+        Does not call the function or do any work besides function inspection
+        and argument hashing.
+
+        - Compare the function code with the one from the cached function,
+        asserting if it has changed.
+        - Check if the function call is present in the cache.
+        - Call `cache_validation_callback` for user define cache validation.
+
+        Returns
+        -------
+        bool:
+            Whether or not the function call is in cache and can be used.
+        """
+        call_id = (self.func_id, self._get_args_id(*args, **kwargs))
+        return self._is_in_cache_and_valid(call_id)
 
     # ------------------------------------------------------------------------
     # Private interface

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -327,9 +327,6 @@ class NotMemorizedFunc(object):
     def check_call_in_cache(self, *args, **kwargs):
         return False
 
-    def is_call_in_cache_and_valid(self, *args, **kwargs) -> bool:
-        return False
-
 
 ###############################################################################
 # class `AsyncNotMemorizedFunc`
@@ -596,21 +593,6 @@ class MemorizedFunc(Logger):
         return state
 
     def check_call_in_cache(self, *args, **kwargs):
-        """Check if function call is in the memory cache.
-
-        Does not call the function or do any work besides func inspection
-        and arg hashing.
-
-        Returns
-        -------
-        is_call_in_cache: bool
-            Whether or not the result of the function has been cached
-            for the input arguments that have been passed.
-        """
-        call_id = (self.func_id, self._get_args_id(*args, **kwargs))
-        return self.store_backend.contains_item(call_id)
-
-    def is_call_in_cache_and_valid(self, *args, **kwargs) -> bool:
         """Check if the function call is cached and valid for given arguments.
 
         Does not call the function or do any work besides function inspection

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -615,6 +615,32 @@ def test_check_call_in_cache(tmpdir):
         func.clear()
 
 
+@pytest.mark.parametrize("consider_cache_valid", [True, False])
+def test_is_call_in_cache_and_valid(tmpdir, consider_cache_valid):
+    for func in (
+        MemorizedFunc(
+            f,
+            tmpdir.strpath,
+            cache_validation_callback=lambda _: consider_cache_valid
+        ),
+        Memory(location=tmpdir.strpath, verbose=0).cache(
+            f,
+            cache_validation_callback=lambda _: consider_cache_valid
+        )
+    ):
+        result = func.is_call_in_cache_and_valid(2)
+        assert isinstance(result, bool)
+        assert not result
+        assert func(2) == 5
+        result = func.is_call_in_cache_and_valid(2)
+        assert isinstance(result, bool)
+        assert result == consider_cache_valid
+        func.clear()
+
+    func = NotMemorizedFunc(f)
+    assert not func.is_call_in_cache_and_valid(2)
+
+
 def test_call_and_shelve(tmpdir):
     # Test MemorizedFunc outputting a reference to cache.
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -614,6 +614,9 @@ def test_check_call_in_cache(tmpdir):
         assert isinstance(result, bool)
         func.clear()
 
+    func = NotMemorizedFunc(f)
+    assert not func.check_call_in_cache(2)
+
 
 @pytest.mark.parametrize("consider_cache_valid", [True, False])
 def test_is_call_in_cache_and_valid(tmpdir, consider_cache_valid):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -602,24 +602,8 @@ def test_persistence(tmpdir):
     gp(1)
 
 
-def test_check_call_in_cache(tmpdir):
-    for func in (MemorizedFunc(f, tmpdir.strpath),
-                 Memory(location=tmpdir.strpath, verbose=0).cache(f)):
-        result = func.check_call_in_cache(2)
-        assert not result
-        assert isinstance(result, bool)
-        assert func(2) == 5
-        result = func.check_call_in_cache(2)
-        assert result
-        assert isinstance(result, bool)
-        func.clear()
-
-    func = NotMemorizedFunc(f)
-    assert not func.check_call_in_cache(2)
-
-
 @pytest.mark.parametrize("consider_cache_valid", [True, False])
-def test_is_call_in_cache_and_valid(tmpdir, consider_cache_valid):
+def test_check_call_in_cache(tmpdir, consider_cache_valid):
     for func in (
         MemorizedFunc(
             f,
@@ -631,17 +615,17 @@ def test_is_call_in_cache_and_valid(tmpdir, consider_cache_valid):
             cache_validation_callback=lambda _: consider_cache_valid
         )
     ):
-        result = func.is_call_in_cache_and_valid(2)
+        result = func.check_call_in_cache(2)
         assert isinstance(result, bool)
         assert not result
         assert func(2) == 5
-        result = func.is_call_in_cache_and_valid(2)
+        result = func.check_call_in_cache(2)
         assert isinstance(result, bool)
         assert result == consider_cache_valid
         func.clear()
 
     func = NotMemorizedFunc(f)
-    assert not func.is_call_in_cache_and_valid(2)
+    assert not func.check_call_in_cache(2)
 
 
 def test_call_and_shelve(tmpdir):


### PR DESCRIPTION
Following the reasoning and implementation behind #820, this PR adds a public method to check if a given cached function call is in cache and valid (=meets the cache validation callback function).