### PR TITLE
Enable accurate torch hashing

### DIFF
--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -243,10 +243,10 @@ class NumpyHasher(Hasher):
 
 class TorchHasher(NumpyHasher):
     """ Special case for the hasher for when torch is loaded.
-        
-        This class extends the NumpyHasher class to handle torch tensors and torch modules.
-        It converts torch tensors and torch modules to numpy arrays for deterministic hashing.
 
+        This class extends the NumpyHasher class to handle torch tensors and
+        torch modules. It converts torch tensors and torch modules to numpy
+        arrays for deterministic hashing.
     """
 
     def __init__(self, hash_name="md5", coerce_mmap=False):
@@ -264,24 +264,23 @@ class TorchHasher(NumpyHasher):
                 obj[key] = self._convert_tensors_to_numpy(value)
         if isinstance(obj, self.torch_nnModule):
             state_dict = obj.state_dict()
-            obj = {key: self._convert_tensors_to_numpy(value) for key, value in state_dict.items()}
-            return obj 
+            obj = {key: self._convert_tensors_to_numpy(value)
+                   for key, value in state_dict.items()}
+            return obj
         if isinstance(obj, self.torch_Tensor):
             obj_as_numpy = obj.cpu().detach().numpy()
             return obj_as_numpy
         return obj
 
     def save(self, obj):
-        """ Convert torch tensors and torch modules to numpy arrays for deterministic hashing.
-            
-            Torch tensors do not have deterministic pickle representations and therefore hashing
-            them is not reliable. This function converts torch tensors and torch modules to numpy
-            arrays for deterministic hashing.
+        """ Subclass again to convert torch tensors and torch modules to numpy
+            arrays for deterministic hashing. Torch tensors do not have
+            deterministic pickle representations and therefore hashing them is
+            not reliable. 
 
-            Torch tensors are converted to numpy arrays directly, and torch modules are converted
-            to dictionaries of numpy arrays corresponding to each component in the state_dict.
-
-            See issue: <https://github.com/pytorch/pytorch/issues/32165>
+            Torch tensors are converted to numpy arrays directly, and torch
+            modules are converted to dictionaries of numpy arrays
+            corresponding to each component in the state_dict.
         """
         obj = self._convert_tensors_to_numpy(obj)
         NumpyHasher.save(self, obj)

--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -242,13 +242,11 @@ class NumpyHasher(Hasher):
 
 
 class TorchHasher(NumpyHasher):
-    """Special case the hasher for when numpy is loaded.
+    """ Special case for the hasher for when torch is loaded.
+        
+        This class extends the NumpyHasher class to handle torch tensors and torch modules.
+        It converts torch tensors and torch modules to numpy arrays for deterministic hashing.
 
-    Under the hood this uses the new implementation of `torch.save` to serialize the model.
-    This produces consistent output.
-
-    This class is adapted from GitHub user AKuerderle who suggested it in the following issue:
-    https://github.com/joblib/joblib/issues/1282
     """
 
     def __init__(self, hash_name="md5", coerce_mmap=False):

--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -276,7 +276,7 @@ class TorchHasher(NumpyHasher):
         """ Subclass again to convert torch tensors and torch modules to numpy
             arrays for deterministic hashing. Torch tensors do not have
             deterministic pickle representations and therefore hashing them is
-            not reliable. 
+            not reliable.
 
             Torch tensors are converted to numpy arrays directly, and torch
             modules are converted to dictionaries of numpy arrays

--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -253,21 +253,39 @@ class TorchHasher(NumpyHasher):
 
     def __init__(self, hash_name="md5", coerce_mmap=False):
         super().__init__(hash_name, coerce_mmap)
-        from torch import save as torch_save  # noqa: import-outside-toplevel
         from torch.nn import Module as torch_nnModule  # noqa: import-outside-toplevel
         from torch import Tensor as torch_Tensor  # noqa: import-outside-toplevel
 
-        self.torch_save = torch_save
         self.torch_nnModule = torch_nnModule
         self.torch_Tensor = torch_Tensor
 
+    def _convert_tensors_to_numpy(self, obj):
+        # Recursively convert torch tensors in obj to numpy arrays
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                obj[key] = self._convert_tensors_to_numpy(value)
+        if isinstance(obj, self.torch_nnModule):
+            state_dict = obj.state_dict()
+            obj = {key: self._convert_tensors_to_numpy(value) for key, value in state_dict.items()}
+            return obj 
+        if isinstance(obj, self.torch_Tensor):
+            obj_as_numpy = obj.cpu().detach().numpy()
+            return obj_as_numpy
+        return obj
+
     def save(self, obj):
-        if isinstance(obj, (self.torch_nnModule, self.torch_Tensor)):
-            b = bytes()
-            buffer = io.BytesIO(b)
-            self.torch_save(obj, buffer)
-            self._hash.update(b)
-            return
+        """ Convert torch tensors and torch modules to numpy arrays for deterministic hashing.
+            
+            Torch tensors do not have deterministic pickle representations and therefore hashing
+            them is not reliable. This function converts torch tensors and torch modules to numpy
+            arrays for deterministic hashing.
+
+            Torch tensors are converted to numpy arrays directly, and torch modules are converted
+            to dictionaries of numpy arrays corresponding to each component in the state_dict.
+
+            See issue: <https://github.com/pytorch/pytorch/issues/32165>
+        """
+        obj = self._convert_tensors_to_numpy(obj)
         NumpyHasher.save(self, obj)
 
 


### PR DESCRIPTION
As described in the [docs](https://joblib.readthedocs.io/en/latest/memory.html#memory), torch tensors have non-deterministic pickle representations. This makes it impossible to accurately hash & cache when torch tensors are involved. 

This is described in issue #1282. 

This PR solves the problem by converting torch tensors to numpy arrays before hashing. It is built to handle torch tensors or torch modules, which it handles by converting the state_dict to a dictionary of {key: numpy_array} pairs. 

Test for hashing : 
```python
from joblib import hash
import torch, torchvision

net1 = torchvision.models.alexnet(weights=torchvision.models.AlexNet_Weights.DEFAULT)
net2 = torchvision.models.alexnet(weights=torchvision.models.AlexNet_Weights.DEFAULT)
net3 = torchvision.models.alexnet()

print(hash(net1)) # 0e8b7766fbc3f36ecd92377e02868999
print(hash(net2)) # 0e8b7766fbc3f36ecd92377e02868999
print(hash(net3)) # f784717a3920ef6dd166d6b018419ac8

t1 = torch.tensor(1.5)
t2 = torch.tensor(1.5)
t3 = torch.tensor(2.5)

print(hash(t1)) # 9293bd3ea4c30e5e1ef0881447869946
print(hash(t2)) # 9293bd3ea4c30e5e1ef0881447869946
print(hash(t3)) # 441a82b6cc7a97f60693ed5344a8e5bc
```

Test for caching:
```python
import time
from joblib import Memory
import torch, torchvision

memory = Memory(location='.cache', verbose=0)

@memory.cache
def check_torch_cache(tensor, module, string):
    time.sleep(1)
    return tensor

t = torch.tensor(1.5)
m = torchvision.models.alexnet()
s = 'hello'

t_alt = torch.tensor(2.5)
m_alt = torchvision.models.alexnet(weights=torchvision.models.AlexNet_Weights.DEFAULT)
s_alt = 'world'

# initialize cache
t0 = time.time()
print(check_torch_cache(t, m, s))
print(time.time() - t0)

# should use cache and be very fast
t1 = time.time()
print(check_torch_cache(t, m, s))
print(time.time() - t1)

# changing tensor should prevent use of the cache
t2 = time.time()
print(check_torch_cache(t_alt, m, s))
print(time.time() - t2)

# changing model should prevent use of the cache
t3 = time.time()
print(check_torch_cache(t, m_alt, s))
print(time.time() - t3)

# changing string should prevent use of the cache
t4 = time.time()
print(check_torch_cache(t_alt, m, s_alt))
print(time.time() - t4)


# returns:
# tensor(1.5000)
# 1.245258092880249
# tensor(1.5000)
# 0.27921152114868164
# tensor(2.5000)
# 1.263361930847168
# tensor(1.5000)
# 1.2799842357635498
# tensor(2.5000)
# 1.271822452545166
```