### PR TITLE
BUG: Avoid division by zero

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1579,7 +1579,7 @@ class Parallel(Logger):
             # We are finished dispatching
             total_tasks = self.n_dispatched_tasks
             # We always display the first loop
-            if not index == 0:
+            if index != 0:
                 # Display depending on the number of remaining items
                 # A message as soon as we finish dispatching, cursor is 0
                 cursor = (total_tasks - index + 1 -
@@ -1588,7 +1588,7 @@ class Parallel(Logger):
                 is_last_item = (index + 1 == total_tasks)
                 if (is_last_item or cursor % frequency):
                     return
-            remaining_time = (elapsed_time / index) * \
+            remaining_time = (elapsed_time / max(index, 1)) * \
                              (self.n_dispatched_tasks - index * 1.0)
             # only display status if remaining time is greater or equal to 0
             self._print(

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1589,7 +1589,7 @@ class Parallel(Logger):
                 if (is_last_item or cursor % frequency):
                     return
             remaining_time = (elapsed_time / max(index, 1)) * \
-                             (self.n_dispatched_tasks - index * 1.0)
+                             (self.n_dispatched_tasks - index)
             # only display status if remaining time is greater or equal to 0
             self._print(
                 f"Done {index:3d} out of {total_tasks:3d} | elapsed: "


### PR DESCRIPTION
In [a CI run](https://github.com/mne-tools/mne-python/actions/runs/11782225929/job/32816828270?pr=12951#step:17:4834) I just got:
```python
__________________________ test_cross_val_multiscore ___________________________
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/joblib/parallel.py:1847: in _get_sequential_output
    res = func(*args, **kwargs)
mne/parallel.py:127: in run_verbose
    return func(*args, **kwargs)
mne/decoding/base.py:495: in _fit_and_score
    test_score = _score(estimator, X_test, y_test, scorer)
mne/decoding/base.py:520: in _score
    score = scorer(estimator, X_test, y_test)
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/sklearn/metrics/_scorer.py:288: in __call__
    return self._score(partial(_cached_call, None), estimator, X, y_true, **_kwargs)
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/sklearn/metrics/_scorer.py:388: in _score
    return self._sign * self._score_func(y_true, y_pred, **scoring_kwargs)
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/sklearn/utils/_param_validation.py:216: in wrapper
    return func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/sklearn/metrics/_ranking.py:630: in roc_auc_score
    raise ValueError("multi_class must be in ('ovo', 'ovr')")
E   ValueError: multi_class must be in ('ovo', 'ovr')

During handling of the above exception, another exception occurred:
mne/decoding/tests/test_base.py:444: in test_cross_val_multiscore
    pytest.raises(ValueError, cross_val_multiscore, clf, X, y, cv=cv, scoring="roc_auc")
<decorator-gen-540>:12: in cross_val_multiscore
    ???
mne/decoding/base.py:408: in cross_val_multiscore
    scores = parallel(
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/joblib/parallel.py:1918: in __call__
    return output if self.return_generator else list(output)
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/joblib/parallel.py:1861: in _get_sequential_output
    self.print_progress()
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/joblib/parallel.py:1591: in print_progress
    remaining_time = (elapsed_time / index) * \
E   ZeroDivisionError: float division by zero
```
presumably because an error was raised inside a job, `index == 0` so you get division by zero. This PR changes the code to use `max(index, 1)` to avoid this problem. It also changes a `not a == b` to a `a != b` which is hopefully safe enough.