### PR TITLE
Introducing joblib Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|PyPi| |Azure| |ReadTheDocs| |Codecov| 
+|PyPi| |Azure| |ReadTheDocs| |Codecov| |Gurubase|
 
 .. |PyPi| image:: https://badge.fury.io/py/joblib.svg
    :target: https://badge.fury.io/py/joblib
@@ -15,6 +15,10 @@
 .. |Codecov| image:: https://codecov.io/gh/joblib/joblib/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/joblib/joblib
    :alt: Codecov coverage
+
+.. |Gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20joblib%20Guru-006BFF
+   :target: https://gurubase.io/g/joblib
+   :alt: Gurubase
 
 
 The homepage of joblib with user documentation is located on:


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [joblib Guru](https://gurubase.io/g/joblib) to Gurubase. joblib Guru uses the data from this repo and data from the [docs](https://joblib.readthedocs.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "joblib Guru", which highlights that joblib now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable joblib Guru in Gurubase, just let me know that's totally fine.
