### PR TITLE
Fix two flaky tests

### DIFF
--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -386,6 +386,8 @@ def test_argument_change(tmpdir):
     # the second time the argument is x=[None], which is not cached
     # yet, so the functions should be called a second time
     assert func() == 1
+    # set the default argument back to [] to avoid side effects to the subsequent tests
+    count_and_append.__defaults__ = ([],)
 
 
 @with_numpy
@@ -802,6 +804,8 @@ def test_memory_file_modification(capsys, tmpdir, monkeypatch):
 
     out, err = capsys.readouterr()
     assert out == '1\n2\nReloading\nx=1\n'
+    
+    del sys.modules['tmp_joblib_']
 
 
 def _function_to_cache(a, b):


### PR DESCRIPTION
## Description
This PR fixes the flaky errors in the following tests functions:
```shell
joblib/test/test_memory.py::test_argument_change
joblib/test/test_memory.py::test_memory_file_modification
```

The flakiness was caused by the possibility of multiple calls of the same functions. Python caches intermediates, leading to unexpected variable pollution when the function is executed repeatedly.


While those functions are typically called only once during each test run, relying on this behavior makes debugging failures more difficult and reduces the robustness of the tests.

To reproduce the issue, run the following command with [pytest-flakefinder](https://pypi.org/project/pytest-flakefinder/)

```shell
pytest  joblib/test/test_memory.py::test_argument_change --flake-finder --flake-runs=2
pytest  joblib/test/test_memory.py::test_memory_file_modification --flake-finder --flake-runs=2
```

## Key Changes
For `test_argument_change`, set the default parameter of `count_and_append` back to `[]` at the end of the function. This ensures that each execution of `test_argument_change` is independent, preventing changes made to the parameters of `count_and_append` from affecting subsequent executions.

For `test_memory_file_modification`, delete the imported module `tmp_joblib_` at the end of the function. This ensures that each execution of the function reloads the module instead of using the cached version.