### PR TITLE
Add patches to prevent warning when wmic files are not found

### DIFF
--- a/joblib/externals/loky/backend/context.py
+++ b/joblib/externals/loky/backend/context.py
@@ -254,7 +254,7 @@ def _count_physical_cores():
             cpu_info = {line for line in cpu_info if not line.startswith("#")}
             cpu_count_physical = len(cpu_info)
         elif sys.platform == "win32":
-             try:
+            try:
                 cpu_info = subprocess.run(
                 "wmic CPU Get NumberOfCores /Format:csv".split(),
                 capture_output=True,


### PR DESCRIPTION
 Windows 11 24H2: WMIC will be completely removed.
 
 Reference：
 https://learn.microsoft.com/zh-cn/windows/whats-new/deprecated-features
 
 
![{9A2BEE7F-D51F-43F1-AB4E-D91723C2F7EB}](https://github.com/user-attachments/assets/7a1232be-f91c-4348-a7a7-2eff51e41eb5)
