### PR TITLE
MNT Specify explicitly configuration following ReadTheDocs deprecation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,4 +16,4 @@ python:
 
 sphinx:
   fail_on_warning: true
-
+  configuration: doc/conf.py


### PR DESCRIPTION
I received an email about this, see [blog post](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/). It seems like specifying the `conf.py` is enough.