### PR TITLE
MNT Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,3 @@ This email is an alias to a subset of the joblib maintainers' team.
 If the security vulnerability is accepted, a patch will be crafted privately
 in order to prepare a dedicated bugfix release as timely as possible (depending
 on the complexity of the fix).
-
-In addition to sending the report by email, you can also report security
-vulnerabilities to [tidelift](https://tidelift.com/security).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+| Version       | Supported          |
+| ------------- | ------------------ |
+| 1.4.2         | :white_check_mark: |
+| < 1.4.2       | :x:                |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by email to `joblib-security@scikit-learn.org`.
+This email is an alias to a subset of the joblib maintainers' team.
+
+If the security vulnerability is accepted, a patch will be crafted privately
+in order to prepare a dedicated bugfix release as timely as possible (depending
+on the complexity of the fix).
+
+In addition to sending the report by email, you can also report security
+vulnerabilities to [tidelift](https://tidelift.com/security).


### PR DESCRIPTION
Close https://github.com/joblib/joblib/issues/1636.

I copied and pasted the scikit-learn `SECURITY.md` and tweaked a few places.

Not sure about the Tidelift mention, maybe just remove it for joblib? Or do we want to set things up with TideLift for joblib as well? Here is the [TideLift security process](https://support.tidelift.com/hc/en-us/articles/4406287910036-Security-process) for more context.