### PR TITLE
CI Use 30 minutes timeout for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
   testing:
     name: Testing
     needs: linting
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In the context of the timeout in https://github.com/joblib/joblib/issues/1639, the default timeout is 6 hours. In normal conditions, the longer CI job is the scikit-learn tests one and takes less than 15 minutes, so I used 30 minutes to have some kind of margin.