### PR TITLE
CI Restore codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,6 @@ jobs:
       - name: Upload to Codecov
         # always upload coverage even if tests fail
         if: ${{ matrix.SKLEARN_TESTS != 'true' && (success() || failure()) }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: .coverage
+          files: test-data.xml


### PR DESCRIPTION
We have lost the coverage following the move to Github Actions #1623. 
https://app.codecov.io/gh/joblib/joblib/tree/main

![image](https://github.com/user-attachments/assets/9054f2b5-4e08-47c3-9c97-ec8d6b65588b)
