### PR TITLE
MNT Use explicit permissions in GHA workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: CI
 permissions:
-  contents: none
+  contents: read
 
 # Define scheduling for the workflow
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: CI
 permissions:
-  contents: read
+  contents: none
 
 # Define scheduling for the workflow
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 # Define scheduling for the workflow
 on:


### PR DESCRIPTION
Github actions code scanning nudges us towards explicit permissions. Reported in https://github.com/joblib/joblib/security/code-scanning/4.