### PR TITLE
MNT Minor CI clean-up

### DIFF
--- a/.readthedocs-requirements.txt
+++ b/.readthedocs-requirements.txt
@@ -1,8 +1,6 @@
 sphinx
-docutils<0.18
 numpy
 matplotlib
-pillow
 sphinx-gallery
 numpydoc
 pandas

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -28,9 +28,7 @@ if [[ "$SKLEARN_TESTS" != "true" ]]; then
 else
     # Install the nightly build of scikit-learn and test against the installed
     # development version of joblib.
-    # TODO: unpin pip once either https://github.com/pypa/pip/issues/10825
-    # accepts invalid HTML or Anaconda is fixed.
-    conda install -y -c conda-forge cython pillow numpy scipy "pip<22"
+    conda install -y -c conda-forge cython numpy scipy
     pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scikit-learn
     python -c "import sklearn; print('Testing scikit-learn', sklearn.__version__)"
 
@@ -41,17 +39,5 @@ else
     cd $NEW_TEST_DIR
 
     pytest -vl --maxfail=5 -p no:doctest \
-        -k "not test_import_is_deprecated" \
-        -k "not test_check_memory" \
         --pyargs sklearn
-
-    # Justification for skipping some tests:
-    #
-    # test_import_is_deprecated: Don't worry about deprecated imports: this is
-    # tested for real in upstream scikit-learn and this is not joblib's
-    # responsibility. Let's skip this test to avoid false positives in joblib's
-    # CI.
-    #
-    # test_check_memory: scikit-learn test need to be updated to avoid using
-    # cachedir: https://github.com/scikit-learn/scikit-learn/pull/22365
 fi


### PR DESCRIPTION
It started by looking at whether we actually needed pillow for something and then cleaning up a few things that I noticed ...

Let's see what the CI has to say.

Context: I was looking at https://deps.dev/pypi/joblib that claims that joblib has 66 vulnerabilities (bottom right).
![image](https://github.com/user-attachments/assets/6acf2f74-02c2-4c44-bc7f-da768e72cb92)


I looked at a few of them and they were all coming from Pillow ...