### PR TITLE
MNT Avoid codespell warning about file with special encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ show_missing = true
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,*.svg,venv,*.css'
+skip = '.git*,*.svg,venv,*.css,joblib/test/test_func_inspect_special_encoding.py'
 check-hidden = true
 # ignore-regex = ''
 ignore-words-list = 'fo'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ show_missing = true
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,*.svg,venv,*.css,joblib/test/test_func_inspect_special_encoding.py'
+skip = '.git*,*.svg,venv,*.css,test_func_inspect_special_encoding.py'
 check-hidden = true
 # ignore-regex = ''
 ignore-words-list = 'fo'


### PR DESCRIPTION
Follow-up of #1628, seen in https://github.com/joblib/joblib/pull/1645/files for example at the bottom:
![image](https://github.com/user-attachments/assets/0be1ae9d-2aa8-491c-8ecc-b6a221329749)
