### PR TITLE
Fix timeout not working with `return_as=generator_unordered`

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -832,7 +832,6 @@ class BatchCompletionCallBack(object):
             # a new batch if needed.
             job_succeeded = self._retrieve_result(out)
 
-
         if job_succeeded:
             self._dispatch_new()
 
@@ -905,7 +904,6 @@ class BatchCompletionCallBack(object):
             # Append the job to the queue in the order of completion
             # instead of submission.
             self.parallel._jobs.append(self)
-
 
 
 ###############################################################################

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -448,14 +448,15 @@ def test_parallel_timeout_fail(backend):
 @parametrize('backend', set(RETURN_GENERATOR_BACKENDS) - {"sequential"})
 @parametrize('return_as', ["generator", "generator_unordered"])
 def test_parallel_timeout_fail_with_generator(backend, return_as):
-    # Check that timeout properly fails when function is too slow
+    # Check that timeout properly fails when function is too slow with
+    # return_as=generator
     with raises(TimeoutError):
         list(
             Parallel(
                 n_jobs=2,
                 backend=backend,
                 return_as=return_as,
-                timeout=0.01
+                timeout=0.2
             )(delayed(sleep)(10) for x in range(10))
         )
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -437,6 +437,7 @@ def test_parallel_timeout_success(backend):
 
 @with_multiprocessing
 @parametrize('backend', PARALLEL_BACKENDS)
+@parameterize('return_as', ["generator", "generator_unordered", "list"]):
 def test_parallel_timeout_fail(backend):
     # Check that timeout properly fails when function is too slow
     with raises(TimeoutError):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -437,12 +437,21 @@ def test_parallel_timeout_success(backend):
 
 @with_multiprocessing
 @parametrize('backend', PARALLEL_BACKENDS)
-@parameterize('return_as', ["generator", "generator_unordered", "list"]):
 def test_parallel_timeout_fail(backend):
     # Check that timeout properly fails when function is too slow
     with raises(TimeoutError):
         Parallel(n_jobs=2, backend=backend, timeout=0.01)(
             delayed(sleep)(10) for x in range(10))
+
+
+@with_multiprocessing
+@parametrize('backend', set(RETURN_GENERATOR_BACKENDS) - {"sequential"})
+@parametrize('return_as', ["generator", "generator_unordered"])
+def test_parallel_timeout_fail_with_generator(backend, return_as):
+    # Check that timeout properly fails when function is too slow
+    with raises(TimeoutError):
+        list(Parallel(n_jobs=2, backend=backend, return_as=return_as, timeout=0.01)(
+            delayed(sleep)(10) for x in range(10)))
 
 
 @with_multiprocessing

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -456,9 +456,19 @@ def test_parallel_timeout_fail_with_generator(backend, return_as):
                 n_jobs=2,
                 backend=backend,
                 return_as=return_as,
-                timeout=0.2
+                timeout=0.1
             )(delayed(sleep)(10) for x in range(10))
         )
+
+    # Fast tasks and high timeout should not raise
+    list(
+        Parallel(
+            n_jobs=2,
+            backend=backend,
+            return_as=return_as,
+            timeout=10
+        )(delayed(sleep)(0.01) for x in range(10))
+    )
 
 
 @with_multiprocessing

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -450,8 +450,14 @@ def test_parallel_timeout_fail(backend):
 def test_parallel_timeout_fail_with_generator(backend, return_as):
     # Check that timeout properly fails when function is too slow
     with raises(TimeoutError):
-        list(Parallel(n_jobs=2, backend=backend, return_as=return_as, timeout=0.01)(
-            delayed(sleep)(10) for x in range(10)))
+        list(
+            Parallel(
+                n_jobs=2,
+                backend=backend,
+                return_as=return_as,
+                timeout=0.01
+            )(delayed(sleep)(10) for x in range(10))
+        )
 
 
 @with_multiprocessing


### PR DESCRIPTION
Fixes https://github.com/joblib/joblib/issues/1586

This is an instance of "all the code was covered but didn't test for all the possible combination of parameters". I have added relevant additional parameters to timeout tests.

A note on the proposed fix. Unfortunately the change is not as simple as adding "if timeout is not None then raise TimeoutError" somewhere. The `parallel.py` code is quite hard to browse, one reason might be that it has to deal with ordered and unordered cases with "if/else" blocks with strategies that can be very different at times but it still tries to re-use common logic.

More specifically, some of those differences are:

- **ordered case**: when a batch of task is dispatched, the reference to the task is added to `self._jobs` _before_ the dispatch. This enables the `get_status(self.timeout)` call to be immediately used in the retrieval loop to control the timeout.

- **unordered case**: a given batch of tasks is only added to `self._jobs` _after_ it has been completed, in the callback completion function. So, the main retrieval loop can _only_ see a task once it's been completed (be it successfully or not). It's too late to control the timeout. If tasks _never terminate_ the retrieval loop would just wait forever.

**Proposed fix**: some of the timeout control code for a given batch can still be re-used between the ordered and un-ordered cases, as long as the retrieval loop can access references to ongoing batch tasks even in the unordered case. So I add a new internal `self._jobs_set` registry of ongoing, not yet retrieved batch of tasks. Now, in the unordered case, the retrieval loop can apply the following logic:

- either `self._jobs` is non empty, it means that a batch of tasks is completed (successfully or with error). No timeout control is required in this case. The result is ready to be fetched and returned.

- either it's empty, meaning all dispatched tasks are still ongoing. In this case an ongoing task is arbitrarily picked, and the timeout countdown is done using this particular task, until it raises a TimeoutError or until `self._jobs` is not empty anymore (meaning another task has completed).

**Additional note on the documentation of the _timeout_ parameter**: I think I had mentioned that before, but it seems it was never addressed. It applies to all cases (list, ordered or unordered generator). If I understand that correctly, the `timeout` that the user can set does **not** set an upper bound on the duration of tasks. It sets an upper bound on **the amount of time when retrieving the result of the next task**. It enforces that:
  + the maximum waited time in `list` case is `nb_tasks * timeout`
  + for generator cases, it only enforces that the maximum waited time when calling equivalents of `next(results)` is `timeout`.
  + in any case, the first task to be retrieved must necessarily complete in less than `timeout` seconds
but it does not enforce that all the following individual tasks will complete in less than that. It depends on a lot of other factors: the time of dispatch, the speed of retrieval, etc.

I don't think that is an issue, for instance it is also [the meaning of `timeout` in the standard library `concurrent.futures`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.result). And if you think about it, setting upper bounds on tasks durations rather than on retrieval waiting times would be much harder. But joblib documentation states:

```
timeout: float or None, default=None

    Timeout limit for each task to complete. If any task takes longer a TimeOutError will be raised. Only applied when n_jobs != 1
```

It is easy to understand but inexact. Should we word it differently ?