### PR TITLE
DOC include cpu_count in build docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -63,6 +63,7 @@ Module reference
    :toctree: generated/
    :template: function.rst
 
+   cpu_count
    dump
    load
    hash

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -642,8 +642,11 @@ def cpu_count(only_physical_cores=False):
     runtimes such as docker) and CPU affinity (for instance using the taskset
     command on Linux).
 
-    If only_physical_cores is True, do not take hyperthreading / SMT logical
-    cores into account.
+    Parameters
+    ----------
+    only_physical_cores : boolean, default=False
+        If True, does not take hyperthreading / SMT logical cores into account.
+
     """
     if mp is None:
         return 1


### PR DESCRIPTION
Closes issue #1654

This PR makes that parallel.cpu_count() to be included in the sphinx build.