### PR TITLE
MNT Remove deprecated functions

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -211,15 +211,6 @@ class MemorizedResult(Logger):
     def args_id(self):
         return self._call_id[1]
 
-    @property
-    def argument_hash(self):
-        warnings.warn(
-            "The 'argument_hash' attribute has been deprecated in version "
-            "0.12 and will be removed in version 0.14.\n"
-            "Use `args_id` attribute instead.",
-            DeprecationWarning, stacklevel=2)
-        return self.args_id
-
     def get(self):
         """Read value from cache and return it."""
         try:

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -444,7 +444,7 @@ class NumpyUnpickler(Unpickler):
 # Utility functions
 
 
-def dump(value, filename, compress=0, protocol=None, cache_size=None):
+def dump(value, filename, compress=0, protocol=None):
     """Persist an arbitrary Python object into one file.
 
     Read more in the :ref:`User Guide <persistence>`.

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -445,8 +445,6 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
         to the compression level.
     protocol: int, optional
         Pickle protocol, see pickle.dump documentation for more details.
-    cache_size: positive int, optional
-        This option is deprecated in 0.10 and has no effect.
 
     Returns
     -------
@@ -534,13 +532,6 @@ def dump(value, filename, compress=0, protocol=None, cache_size=None):
             # we choose the default compress_level in case it was not given
             # as an argument (using compress).
             compress_level = None
-
-    if cache_size is not None:
-        # Cache size is deprecated starting from version 0.10
-        warnings.warn("Please do not set 'cache_size' in joblib.dump, "
-                      "this parameter has no effect and will be removed. "
-                      "You used 'cache_size={}'".format(cache_size),
-                      DeprecationWarning, stacklevel=2)
 
     if compress_level != 0:
         with _write_fileobject(filename, compress=(compress_method,

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -293,12 +293,7 @@ class MemmappingPool(PicklingPool):
 
     def __init__(self, processes=None, temp_folder=None, max_nbytes=1e6,
                  mmap_mode='r', forward_reducers=None, backward_reducers=None,
-                 verbose=0, context_id=None, prewarm=False, **kwargs):
-
-        if context_id is not None:
-            warnings.warn('context_id is deprecated and ignored in joblib'
-                          ' 0.9.4 and will be removed in 0.11',
-                          DeprecationWarning)
+                 verbose=0, prewarm=False, **kwargs):
 
         manager = TemporaryResourcesManager(temp_folder)
         self._temp_folder_manager = manager

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -655,19 +655,6 @@ def test_call_and_shelve(tmpdir):
         result.clear()  # Do nothing if there is no cache.
 
 
-def test_call_and_shelve_argument_hash(tmpdir):
-    # Verify that a warning is raised when accessing arguments_hash
-    # attribute from MemorizedResult
-    func = Memory(location=tmpdir.strpath, verbose=0).cache(f)
-    result = func.call_and_shelve(2)
-    assert isinstance(result, MemorizedResult)
-    with warns(DeprecationWarning) as w:
-        assert result.argument_hash == result.args_id
-    assert len(w) == 1
-    assert "The 'argument_hash' attribute has been deprecated" \
-        in str(w[-1].message)
-
-
 def test_call_and_shelve_lazily_load_stored_result(tmpdir):
     """Check call_and_shelve only load stored data if needed."""
     test_access_time_file = tmpdir.join('test_access')

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -291,27 +291,6 @@ def test_compress_mmap_mode_warning(tmpdir):
 
 
 @with_numpy
-@parametrize('cache_size', [None, 0, 10])
-def test_cache_size_warning(tmpdir, cache_size):
-    # Check deprecation warning raised when cache size is not None
-    filename = tmpdir.join('test.pkl').strpath
-    rnd = np.random.RandomState(0)
-    a = rnd.random_sample((10, 2))
-
-    warnings.simplefilter("always")
-    with warnings.catch_warnings(record=True) as warninfo:
-        numpy_pickle.dump(a, filename, cache_size=cache_size)
-    expected_nb_warnings = 1 if cache_size is not None else 0
-    assert len(warninfo) == expected_nb_warnings
-    for w in warninfo:
-        assert w.category is DeprecationWarning
-        assert (str(w.message) ==
-                "Please do not set 'cache_size' in joblib.dump, this "
-                "parameter has no effect and will be removed. You "
-                "used 'cache_size={0}'".format(cache_size))
-
-
-@with_numpy
 @with_memory_profiler
 @parametrize('compress', [True, False])
 def test_memory_usage(tmpdir, compress):
@@ -379,9 +358,6 @@ def _check_pickle(filename, expected_list, mmap_mode=None):
         try:
             with warnings.catch_warnings(record=True) as warninfo:
                 warnings.simplefilter('always')
-                warnings.filterwarnings(
-                    'ignore', module='numpy',
-                    message='The compiler package is deprecated')
                 result_list = numpy_pickle.load(filename, mmap_mode=mmap_mode)
             filename_base = os.path.basename(filename)
             expected_nb_deprecation_warnings = 1 if (


### PR DESCRIPTION
Those have been deprecated for quite a long time and we never removed them ...

- `Memory` `argument_hash` should have been removed in 0.14 released in 2019
- `cache_size` `dump` argument deprecated since 0.10 released in 2016
- `context_id` in `joblib.pool` should have been removed in 0.11 released in 2017