### PR TITLE
MNT ignore formatter PR to fix git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Since git version 2.23, git-blame has a feature to ignore
+# certain commits.
+#
+# This file contains a list of commits that are not likely what
+# you are looking for in `git blame`. You can set this file as
+# a default ignore file for blame by running the following
+# command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# PR 1673: enable ruff formatting
+6066109bf0c2ea018aaf528aa1cff2cff6dca2cd


### PR DESCRIPTION
This makes the formatter commit to be ignored in `git blame`.

One needs to run

```sh
$ git config blame.ignoreRevsFile .git-blame-ignore-revs
```
to enable the ignore functionality.

cc @tomMoral @lesteve 