### PR TITLE
MNT add isort PR to be ignored in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,3 +10,6 @@
 
 # PR 1673: enable ruff formatting
 6066109bf0c2ea018aaf528aa1cff2cff6dca2cd
+
+# MNT Add isort to linting rules (#1679)
+17414db5183daa12157992834954d7a02dc00b63


### PR DESCRIPTION
cc @glemaitre this should cleanup the git blame.