### PR TITLE
Use protocol=5 for pickling arrays with dtype=object

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -125,9 +125,9 @@ class NumpyArrayWrapper(object):
         buffersize = max(16 * 1024**2 // array.itemsize, 1)
         if array.dtype.hasobject:
             # We contain Python objects so we cannot write out the data
-            # directly. Instead, we will pickle it out with version 2 of the
+            # directly. Instead, we will pickle it out with version 5 of the
             # pickle protocol.
-            pickle.dump(array, pickler.file_handle, protocol=2)
+            pickle.dump(array, pickler.file_handle, protocol=5)
         else:
             numpy_array_alignment_bytes = self.safe_get_numpy_array_alignment_bytes()
             if numpy_array_alignment_bytes is not None:


### PR DESCRIPTION
Not sure if there is a better way than hardcoding the protocol here.

Not quite sure why it was protocol=2, maybe because at the time compatibility between Python 2 and Python 3 was important? I did not find an explanation looking at https://github.com/joblib/joblib/pull/260.

Quick benchmark for an array with object dtype:
```py
%load_ext memory_profiler
import pickle
import numpy as np

arr = np.array(['a'*1000 for _ in range(100_000)])

for protocol in [2, 4, 5]:
    print(f"{protocol=}")
    %timeit pickle.dumps(arr, protocol=protocol)
    %memit pickle.dumps(arr, protocol=protocol)
```

Output:
```
protocol=2
360 ms ± 58.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
peak memory: 1291.32 MiB, increment: 827.67 MiB
protocol=4
194 ms ± 9.19 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
peak memory: 845.16 MiB, increment: 381.47 MiB
protocol=5
93.5 ms ± 2.24 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
peak memory: 801.47 MiB, increment: 337.77 MiB
```
