### PR TITLE
Update API and usage of _batch_setitems() to allow more arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,10 @@ Maintenance:
   the warnings that are emitted in this case.
   https://github.com/joblib/joblib/pull/1681
 
+- Fix support for python 3.14 in ``hashing``, with the addition of
+  an extra argument in ``Pickler._batch_setitems``.
+  https://github.com/joblib/joblib/pull/1688
+
 
 Release 1.4.2 -- 2024/05/02
 ---------------------------

--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -131,22 +131,19 @@ class Hasher(Pickler):
     # function
     dispatch[type(pickle.dump)] = save_global
 
-    def _batch_setitems(self, items, obj=None):
-        # Python 3.14 _batch_setitems has an additional obj argument, see
-        # https://github.com/python/cpython/pull/122214
-        additional_args = [] if obj is None else [obj]
+    def _batch_setitems(self, items, *args):
         # forces order of keys in dict to ensure consistent hash.
         try:
             # Trying first to compare dict assuming the type of keys is
             # consistent and orderable.
             # This fails on python 3 when keys are unorderable
             # but we keep it in a try as it's faster.
-            Pickler._batch_setitems(self, iter(sorted(items)), *additional_args)
+            Pickler._batch_setitems(self, iter(sorted(items)), *args)
         except TypeError:
             # If keys are unorderable, sorting them using their hash. This is
             # slower but works in any case.
             Pickler._batch_setitems(
-                self, iter(sorted((hash(k), v) for k, v in items)), *additional_args
+                self, iter(sorted((hash(k), v) for k, v in items)), *args
             )
 
     def save_set(self, set_items):

--- a/joblib/hashing.py
+++ b/joblib/hashing.py
@@ -131,18 +131,20 @@ class Hasher(Pickler):
     # function
     dispatch[type(pickle.dump)] = save_global
 
-    def _batch_setitems(self, items):
+    def _batch_setitems(self, items, *args):
         # forces order of keys in dict to ensure consistent hash.
         try:
             # Trying first to compare dict assuming the type of keys is
             # consistent and orderable.
             # This fails on python 3 when keys are unorderable
             # but we keep it in a try as it's faster.
-            Pickler._batch_setitems(self, iter(sorted(items)))
+            Pickler._batch_setitems(self, iter(sorted(items)), *args)
         except TypeError:
             # If keys are unorderable, sorting them using their hash. This is
             # slower but works in any case.
-            Pickler._batch_setitems(self, iter(sorted((hash(k), v) for k, v in items)))
+            Pickler._batch_setitems(
+                self, iter(sorted((hash(k), v) for k, v in items)), *args
+            )
 
     def save_set(self, set_items):
         # forces order of items in Set to ensure consistent hash


### PR DESCRIPTION
Python 3.14 added the obj argument.
This way, the code should work on both 3.13 and 3.14.

Fixes https://github.com/joblib/joblib/issues/1658