### PR TITLE
ENH: make it possible to use custom hash functions in `joblib.hash` and `joblib.Memory`

### DIFF
--- a/joblib/_multiprocessing_helpers.py
+++ b/joblib/_multiprocessing_helpers.py
@@ -27,6 +27,7 @@ if mp is not None:
         # _multiprocessing.SemLock to avoid spawning a resource tracker on
         # Unix system or changing the default backend.
         import tempfile
+
         from _multiprocessing import SemLock
 
         _rand = tempfile._RandomNameSequence()

--- a/joblib/_multiprocessing_helpers.py
+++ b/joblib/_multiprocessing_helpers.py
@@ -27,7 +27,6 @@ if mp is not None:
         # _multiprocessing.SemLock to avoid spawning a resource tracker on
         # Unix system or changing the default backend.
         import tempfile
-
         from _multiprocessing import SemLock
 
         _rand = tempfile._RandomNameSequence()

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -387,6 +387,12 @@ class MemorizedFunc(Logger):
         of compression. Note that compressed arrays cannot be
         read by memmapping.
 
+    hash_name: {'md5', 'sha1'}, optional
+        The name of the hash function to use to hash arguments.
+        Other hash functions can be used if they have been registered using
+        `register_hash`.
+        Defaults to 'md5'.
+
     verbose: int, optional
         The verbosity flag, controls messages that are issued as
         the function is evaluated.
@@ -411,6 +417,7 @@ class MemorizedFunc(Logger):
         ignore=None,
         mmap_mode=None,
         compress=False,
+        hash_name="md5",
         verbose=1,
         timestamp=None,
         cache_validation_callback=None,
@@ -418,6 +425,12 @@ class MemorizedFunc(Logger):
         Logger.__init__(self)
         self.mmap_mode = mmap_mode
         self.compress = compress
+        if hash_name not in hashing._HASHES:
+            raise ValueError(
+                "Valid options for 'hash_name' are {}. "
+                "Got hash_name={!r} instead.".format(hashing._HASHES, hash_name)
+            )
+        self.hash_name = hash_name
         self.func = func
         self.cache_validation_callback = cache_validation_callback
         self.func_id = _build_func_identifier(func)
@@ -650,6 +663,7 @@ class MemorizedFunc(Logger):
         return hashing.hash(
             filter_args(self.func, self.ignore, args, kwargs),
             coerce_mmap=self.mmap_mode is not None,
+            hash_name=self.hash_name,
         )
 
     def _hash_func(self):
@@ -993,6 +1007,12 @@ class Memory(Logger):
         of compression. Note that compressed arrays cannot be
         read by memmapping.
 
+    hash_name: {'md5', 'sha1'}, optional
+        The name of the hash function to use to hash arguments.
+        Other hash functions can be used if they have been registered using
+        `register_hash`.
+        Defaults to 'md5'.
+
     verbose: int, optional
         Verbosity flag, controls the debug messages that are issued
         as functions are evaluated.
@@ -1012,6 +1032,7 @@ class Memory(Logger):
         backend="local",
         mmap_mode=None,
         compress=False,
+        hash_name="md5",
         verbose=1,
         backend_options=None,
     ):
@@ -1021,6 +1042,12 @@ class Memory(Logger):
         self.timestamp = time.time()
         self.backend = backend
         self.compress = compress
+        if hash_name not in hashing._HASHES:
+            raise ValueError(
+                "Valid options for 'hash_name' are {}. "
+                "Got hash_name={!r} instead.".format(hash_name, hash_name)
+            )
+        self.hash_name = hash_name
         if backend_options is None:
             backend_options = {}
         self.backend_options = backend_options
@@ -1119,6 +1146,7 @@ class Memory(Logger):
             ignore=ignore,
             mmap_mode=mmap_mode,
             compress=self.compress,
+            hash_name=self.hash_name,
             verbose=verbose,
             timestamp=self.timestamp,
             cache_validation_callback=cache_validation_callback,

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -387,11 +387,8 @@ class MemorizedFunc(Logger):
         of compression. Note that compressed arrays cannot be
         read by memmapping.
 
-    hash_name: {'md5', 'sha1'}, optional
-        The name of the hash function to use to hash arguments.
-        Other hash functions can be used if they have been registered using
-        `register_hash`.
-        Defaults to 'md5'.
+    hash_func: string or `hashlib`-compatible hash object, optional
+        The hash to use to hash arguments. Defaults to 'md5'.
 
     verbose: int, optional
         The verbosity flag, controls messages that are issued as
@@ -417,7 +414,7 @@ class MemorizedFunc(Logger):
         ignore=None,
         mmap_mode=None,
         compress=False,
-        hash_name="md5",
+        hash_func="md5",
         verbose=1,
         timestamp=None,
         cache_validation_callback=None,
@@ -425,12 +422,7 @@ class MemorizedFunc(Logger):
         Logger.__init__(self)
         self.mmap_mode = mmap_mode
         self.compress = compress
-        if hash_name not in hashing._HASHES:
-            raise ValueError(
-                "Valid options for 'hash_name' are {}. "
-                "Got hash_name={!r} instead.".format(hashing._HASHES, hash_name)
-            )
-        self.hash_name = hash_name
+        self.hash_func = hashing._check_hash(hash_func)
         self.func = func
         self.cache_validation_callback = cache_validation_callback
         self.func_id = _build_func_identifier(func)
@@ -663,7 +655,7 @@ class MemorizedFunc(Logger):
         return hashing.hash(
             filter_args(self.func, self.ignore, args, kwargs),
             coerce_mmap=self.mmap_mode is not None,
-            hash_name=self.hash_name,
+            hash_func=self.hash_func,
         )
 
     def _hash_func(self):
@@ -1007,10 +999,8 @@ class Memory(Logger):
         of compression. Note that compressed arrays cannot be
         read by memmapping.
 
-    hash_name: {'md5', 'sha1'}, optional
-        The name of the hash function to use to hash arguments.
-        Other hash functions can be used if they have been registered using
-        `register_hash`.
+    hash_func: string or `hashlib`-compatible hash object, optional
+        The hash to use to hash arguments.
         Defaults to 'md5'.
 
     verbose: int, optional
@@ -1032,7 +1022,7 @@ class Memory(Logger):
         backend="local",
         mmap_mode=None,
         compress=False,
-        hash_name="md5",
+        hash_func="md5",
         verbose=1,
         backend_options=None,
     ):
@@ -1042,12 +1032,7 @@ class Memory(Logger):
         self.timestamp = time.time()
         self.backend = backend
         self.compress = compress
-        if hash_name not in hashing._HASHES:
-            raise ValueError(
-                "Valid options for 'hash_name' are {}. "
-                "Got hash_name={!r} instead.".format(hash_name, hash_name)
-            )
-        self.hash_name = hash_name
+        self.hash_func = hashing._check_hash(hash_func)
         if backend_options is None:
             backend_options = {}
         self.backend_options = backend_options
@@ -1146,7 +1131,7 @@ class Memory(Logger):
             ignore=ignore,
             mmap_mode=mmap_mode,
             compress=self.compress,
-            hash_name=self.hash_name,
+            hash_func=self.hash_func,
             verbose=verbose,
             timestamp=self.timestamp,
             cache_validation_callback=cache_validation_callback,

--- a/joblib/test/test_hashing.py
+++ b/joblib/test/test_hashing.py
@@ -19,7 +19,7 @@ from concurrent.futures import ProcessPoolExecutor
 from decimal import Decimal
 
 from joblib.func_inspect import filter_args
-from joblib.hashing import hash
+from joblib.hashing import _HASHES, hash, register_hash
 from joblib.memory import Memory
 from joblib.test.common import np, with_numpy
 from joblib.testing import fixture, parametrize, raises, skipif
@@ -518,3 +518,21 @@ def test_wrong_hash_name():
     with raises(ValueError, match=msg):
         data = {"foo": "bar"}
         hash(data, hash_name="invalid")
+
+
+def test_right_register_hash():
+    hash_name = "my_hash"
+    assert hash_name not in _HASHES
+    register_hash(hash_name, hashlib.sha256)
+    assert _HASHES[hash_name] == hashlib.sha256
+
+
+def test_wrong_register_hash():
+    with raises(ValueError, match="Hash name should be a string"):
+        register_hash(0, hashlib.md5)
+
+    with raises(ValueError, match="Hash function instance must implement"):
+        register_hash('test_hash', int)
+
+    with raises(ValueError, match="Hash function 'md5' already registered."):
+        register_hash('md5', hashlib.md5)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -391,6 +391,35 @@ def test_argument_change(tmpdir):
     assert func() == 1
 
 
+def test_memory_invalid_hash_name(tmpdir):
+    with raises(ValueError, match="Valid options for 'hash_name' are"):
+        Memory(tmpdir.strpath, hash_name="not_valid")
+
+
+def test_memorized_func_invalid_hash_name(tmpdir):
+    with raises(ValueError, match="Valid options for 'hash_name' are"):
+        MemorizedFunc(int, tmpdir.strpath, hash_name="not_valid")
+
+
+def test_memory_custom_hash(tmpdir):
+    "Test memory with a function with numpy arrays."
+    accumulator = list()
+
+    def n(ls=None):
+        accumulator.append(1)
+        return ls
+
+    memory = Memory(location=tmpdir.strpath, verbose=0, hash_name="sha1")
+    cached_n = memory.cache(n)
+
+    vals = (1, 2, 3)
+    for i in range(3):
+        a = vals[i - 1]
+        for _ in range(3):
+            assert cached_n(a) == a
+            assert len(accumulator) == i + 1
+
+
 @with_numpy
 @parametrize("mmap_mode", [None, "r"])
 def test_memory_numpy(tmpdir, mmap_mode):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -391,14 +391,14 @@ def test_argument_change(tmpdir):
     assert func() == 1
 
 
-def test_memory_invalid_hash_name(tmpdir):
-    with raises(ValueError, match="Valid options for 'hash_name' are"):
-        Memory(tmpdir.strpath, hash_name="not_valid")
+def test_memory_invalid_hash_func(tmpdir):
+    with raises(ValueError, match="unsupported hash type"):
+        Memory(tmpdir.strpath, hash_func="not_valid")
 
 
-def test_memorized_func_invalid_hash_name(tmpdir):
-    with raises(ValueError, match="Valid options for 'hash_name' are"):
-        MemorizedFunc(int, tmpdir.strpath, hash_name="not_valid")
+def test_memorized_func_invalid_hash_func(tmpdir):
+    with raises(ValueError, match="unsupported hash type"):
+        MemorizedFunc(int, tmpdir.strpath, hash_func="not_valid")
 
 
 def test_memory_custom_hash(tmpdir):
@@ -409,7 +409,7 @@ def test_memory_custom_hash(tmpdir):
         accumulator.append(1)
         return ls
 
-    memory = Memory(location=tmpdir.strpath, verbose=0, hash_name="sha1")
+    memory = Memory(location=tmpdir.strpath, verbose=0, hash_func="sha1")
     cached_n = memory.cache(n)
 
     vals = (1, 2, 3)


### PR DESCRIPTION
This is another attempt at making it possible to use other hash algorithms, closing https://github.com/joblib/joblib/issues/343. The PR is based off of https://github.com/joblib/joblib/pull/1232 by @judahrand.

I tried to go with the `hash_func` API per @tomMoral's [suggestion](https://github.com/joblib/joblib/pull/1232#pullrequestreview-781561101) because I like the design. Although simpler in appearance, it is harder to make it work because hash objects generated by `hashlib.new` are not pickleable, which causes problems in `joblib.Memory` (see failing tests). However the pattern does work fine for the `joblib.hash` use-case.

Also note that it might make sense to first implement @ogrisel's [algorithm prefix proposal](https://github.com/joblib/joblib/issues/343#issuecomment-212819675) before further work is done here.