### PR TITLE
FIX Fix issue in memmap reducing when base array is 1d

### DIFF
--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -305,7 +305,9 @@ def _reduce_memmap_backed(a, m):
     # offset from the backing memmap
     offset += m.offset
 
-    if m.flags["F_CONTIGUOUS"] and m.ndim > 1:
+    # 1D arrays are both F and C contiguous, so only set the flag in
+    # higher dimensions. See https://github.com/joblib/joblib/pull/1704.
+    if m.ndim > 1 and m.flags["F_CONTIGUOUS"]:
         order = "F"
     else:
         # The backing memmap buffer is necessarily contiguous hence C if not

--- a/joblib/_memmapping_reducer.py
+++ b/joblib/_memmapping_reducer.py
@@ -305,7 +305,7 @@ def _reduce_memmap_backed(a, m):
     # offset from the backing memmap
     offset += m.offset
 
-    if m.flags["F_CONTIGUOUS"]:
+    if m.flags["F_CONTIGUOUS"] and m.ndim > 1:
         order = "F"
     else:
         # The backing memmap buffer is necessarily contiguous hence C if not

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -1241,3 +1241,19 @@ def test_direct_mmap(tmpdir):
 
     results = Parallel(n_jobs=2)(delayed(worker)() for _ in range(1))
     np.testing.assert_array_equal(results[0], arr)
+
+
+def test__reduce_memmap_backed(tmpdir):
+    testfile = str(tmpdir.join("arr.dat"))
+    a = np.arange(10, dtype="uint8")
+    a.tofile(testfile)
+
+    m = np.memmap(testfile, dtype="uint8")
+    a = m.reshape(2, 5)
+
+    reconstruct, args = jmr._reduce_memmap_backed(a, m)
+    reconstructed = reconstruct(*args)
+    assert (reconstructed == a).all()
+
+
+# TODO Add test with parallel as well

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -101,6 +101,9 @@ def test_memmap_based_array_reducing(tmpdir):
     # b is an memmap sliced view on an memmap instance
     b = a[1:-1, 2:-1, 2:4]
 
+    # b2 is a memmap 2d with memmap 1d as base
+    b2 = buffer.reshape(10, 50)
+
     # c and d are array views
     c = np.asarray(b)
     d = c.T
@@ -122,6 +125,11 @@ def test_memmap_based_array_reducing(tmpdir):
     b_reconstructed = reconstruct_array_or_memmap(b)
     assert has_shareable_memory(b_reconstructed)
     assert_array_equal(b_reconstructed, b)
+
+    # Reconstruct memmap 2d with memmap 1d as base
+    b2_reconstructed = reconstruct_array_or_memmap(b2)
+    assert has_shareable_memory(b2_reconstructed)
+    assert_array_equal(b2_reconstructed, b2)
 
     # Reconstruct arrays views on memmap base
     c_reconstructed = reconstruct_array_or_memmap(c)
@@ -1241,19 +1249,6 @@ def test_direct_mmap(tmpdir):
 
     results = Parallel(n_jobs=2)(delayed(worker)() for _ in range(1))
     np.testing.assert_array_equal(results[0], arr)
-
-
-def test__reduce_memmap_backed(tmpdir):
-    testfile = str(tmpdir.join("arr.dat"))
-    a = np.arange(10, dtype="uint8")
-    a.tofile(testfile)
-
-    m = np.memmap(testfile, dtype="uint8")
-    a = m.reshape(2, 5)
-
-    reconstruct, args = jmr._reduce_memmap_backed(a, m)
-    reconstructed = reconstruct(*args)
-    assert (reconstructed == a).all()
 
 
 # TODO Add test with parallel as well


### PR DESCRIPTION
Fix https://github.com/joblib/joblib/issues/1703

It looks like in #1703 case the base array is 1d (hence both Fortran-contiguous and C-contiguous) and the memmap reducing incorrectly reconstruct the array as Fortran order.