### PR TITLE
Workaround for numpy.core DeprecationWarning

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -288,7 +288,7 @@ class NumpyArrayWrapper(object):
             unpickler.np.memmap,
         ):
             # We need to reconstruct another subclass
-            new_array = unpickler.np.core.multiarray._reconstruct(
+            new_array = unpickler._reconstruct(
                 self.subclass, (0,), "b"
             )
             return new_array.__array_prepare__(array)
@@ -330,6 +330,12 @@ class NumpyPickler(Pickler):
         # delayed import of numpy, to avoid tight coupling
         try:
             import numpy as np
+            np_major_version = np.__version__[:2]
+            if np_major_version == "1.":
+                from numpy.core.multiarray import _reconstruct
+            elif np_major_version == "2.":
+                from numpy._core.multiarray import _reconstruct
+            self._reconstruct = _reconstruct
         except ImportError:
             np = None
         self.np = np
@@ -432,6 +438,12 @@ class NumpyUnpickler(Unpickler):
         Unpickler.__init__(self, self.file_handle)
         try:
             import numpy as np
+            np_major_version = np.__version__[:2]
+            if np_major_version == "1.":
+                from numpy.core.multiarray import _reconstruct
+            elif np_major_version == "2.":
+                from numpy._core.multiarray import _reconstruct
+            self._reconstruct = _reconstruct
         except ImportError:
             np = None
         self.np = np

--- a/joblib/numpy_pickle_compat.py
+++ b/joblib/numpy_pickle_compat.py
@@ -115,7 +115,7 @@ class NDArrayWrapper(object):
             unpickler.np.memmap,
         ):
             # We need to reconstruct another subclass
-            new_array = unpickler.np.core.multiarray._reconstruct(
+            new_array = unpickler._reconstruct(
                 self.subclass, (0,), "b"
             )
             return new_array.__array_prepare__(array)
@@ -149,7 +149,7 @@ class ZNDArrayWrapper(NDArrayWrapper):
         # Here we a simply reproducing the unpickling mechanism for numpy
         # arrays
         filename = os.path.join(unpickler._dirname, self.filename)
-        array = unpickler.np.core.multiarray._reconstruct(*self.init_args)
+        array = unpickler._reconstruct(*self.init_args)
         with open(filename, "rb") as f:
             data = read_zfile(f)
         state = self.state + (data,)
@@ -171,6 +171,12 @@ class ZipNumpyUnpickler(Unpickler):
         Unpickler.__init__(self, self.file_handle)
         try:
             import numpy as np
+            np_major_version = np.__version__[:2]
+            if np_major_version == "1.":
+                from numpy.core.multiarray import _reconstruct
+            elif np_major_version == "2.":
+                from numpy._core.multiarray import _reconstruct
+            self._reconstruct = _reconstruct
         except ImportError:
             np = None
         self.np = np

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -421,7 +421,7 @@ def _check_pickle(filename, expected_list, mmap_mode=None):
             )
             assert len(warninfo) == expected_nb_warnings, (
                 "Did not get the expected number of warnings. Expected "
-                f"{expected_nb_warnings} but got wargnings: "
+                f"{expected_nb_warnings} but got warnings: "
                 f"{[w.message for w in warninfo]}"
             )
 


### PR DESCRIPTION
Workaround for `numpy.core` being renamed to `numpy._core` in numpy 2.*  (https://github.com/numpy/numpy/pull/24634) by adding direct importations of `_reconstruct` in `Unpickler` objects:

```python
np_major_version = np.__version__[:2]
if np_major_version == "1.":
      from numpy.core.multiarray import _reconstruct
elif np_major_version == "2.":
     from numpy._core.multiarray import _reconstruct
self._reconstruct = _reconstruct
```