### PR TITLE
Check that dask backend serializes same amount of time than native dask.

### DIFF
--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -322,7 +322,6 @@ def test_manual_scatter(loop):
             ]
             assert results_native == expected
 
-
     # Now check that the number of serialization steps is the same for joblib
     # and native dask calls.
     n_serialization_scatter_native = w.count


### PR DESCRIPTION
Still investigating, because the test is still red at the moment:

>      assert z.count == n_serialization_with_parallel
> E       assert 46 == 43
> E        +  where 46 = <joblib.test.test_dask.CountSerialized object at 0x79f2d0620e90>.count
