### PR TITLE
CI hide codecov token in secrets settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,3 @@
-codecov:
-  token: 1b7eb264-fd77-469a-829a-e9cd5efd7cef
 coverage:
   status:
     project:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,3 +130,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This hides the codecov token away behind the gitbub secrets.
Working on it with @lesteve.