### PR TITLE
MNT Replace asyncio.iscoroutinefunction that is deprecated in Python 3.14

### DIFF
--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -1101,7 +1101,7 @@ class Memory(Logger):
         if self.store_backend is None:
             cls = (
                 AsyncNotMemorizedFunc
-                if asyncio.iscoroutinefunction(func)
+                if inspect.iscoroutinefunction(func)
                 else NotMemorizedFunc
             )
             return cls(func)
@@ -1111,7 +1111,7 @@ class Memory(Logger):
             mmap_mode = self.mmap_mode
         if isinstance(func, MemorizedFunc):
             func = func.func
-        cls = AsyncMemorizedFunc if asyncio.iscoroutinefunction(func) else MemorizedFunc
+        cls = AsyncMemorizedFunc if inspect.iscoroutinefunction(func) else MemorizedFunc
         return cls(
             func,
             location=self.store_backend,


### PR DESCRIPTION
`asyncio.iscoroutinefunction` is deprecated in Python 3.14 and the warning advises to use `inspect.iscoroutinefunction` instead:

```
DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
```

I noticed when trying to run the scikit-learn tests with Python 3.14rc2.