### PR TITLE
Add Python 3.14 to the testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         name: [default]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - name: test-sklearn
             os: ubuntu-latest
@@ -89,9 +89,12 @@ jobs:
             os: ubuntu-latest
             PYTHON_VERSION: "3.9"
             JOBLIB_TESTS_DEFAULT_PARALLEL_BACKEND: "threading"
-          - name: python-free-threaded
+          - name: python3.13-free-threaded
             os: 'ubuntu-latest'
             PYTHON_VERSION: "free-threaded-3.13"
+          - name: python3.14-free-threaded
+            os: 'ubuntu-latest'
+            PYTHON_VERSION: "free-threaded-3.14"
 
     env: ${{ matrix }}
 


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3140/

https://py-free-threading.github.io/porting

Blocked by:
* python-lz4/python-lz4#302 -->
    * python-lz4/python-lz4#303
* https://docs.python.org/3.14/whatsnew/3.14.html#porting-to-python-3-14
    * https://docs.python.org/3.14/whatsnew/3.14.html#pickle
> If you encounter [NameError](https://docs.python.org/3.14/library/exceptions.html#NameError)s or ___pickling errors___ coming out of [multiprocessing](https://docs.python.org/3.14/library/multiprocessing.html#module-multiprocessing) or [concurrent.futures](https://docs.python.org/3.14/library/concurrent.futures.html#module-concurrent.futures), see the [forkserver restrictions](https://docs.python.org/3.14/library/multiprocessing.html#multiprocessing-programming-forkserver).
* python-lz4/python-lz4#316 (cp314t wheels)