### PR TITLE
Fix CI failures caused by an incompatibility with pytest 9

### DIFF
--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -1,15 +1,19 @@
 import faulthandler
 
+import pytest
+
 from joblib.parallel import mp
 from joblib.test.common import np
-from joblib.testing import fixture, skipif
+from joblib.testing import fixture
 
 
 @fixture(scope="module")
-@skipif(np is None or mp is None, "Numpy or Multiprocessing not available")
 def parallel_numpy_fixture(request):
     """Fixture to skip memmapping test if numpy or multiprocessing is not
     installed"""
+
+    if np is None or mp is None:
+        pytest.skip("Numpy or Multiprocessing not available")
 
     def setup(module):
         faulthandler.dump_traceback_later(timeout=300, exit=True)


### PR DESCRIPTION
Examples of recent failures: 
https://github.com/joblib/joblib/actions/runs/19674131375/job/56350507944

```
...
+ make test-doc
pytest doc/_templates/class.rst doc/_templates/function.rst doc/custom_parallel_backend.rst doc/developing.rst doc/index.rst doc/installing.rst doc/memory.rst doc/parallel.rst doc/parallel_numpy.rst doc/persistence.rst doc/why.rst
ImportError while loading conftest '/home/runner/work/joblib/joblib/doc/conftest.py'.
doc/conftest.py:8: in <module>
    @fixture(scope="module")
     ^^^^^^^^^^^^^^^^^^^^^^^
E   pytest.PytestRemovedIn9Warning: Marks applied to fixtures have no effect
E   See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
make: *** [Makefile:12: test-doc] Error 4
...
```


Applying the mark to the fixture never had any effect apparently [source](https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function).

## note: 

I'm not sure in which conditions the skip is needed (or if it's needed at all) - however to be as less intrusive as possible, i've tried to move the skip into the fixture.
That said - based on the above pytest documentation  - the skip so far never actually applied - so it might be just as safe to remove it completely (please let me know if you'd prefer me to remove this).

