### PR TITLE
ENH: Add function to say why a call was not in the cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Release Notes
 In development
 --------------
 
+- Add ``MemorizedFunc.check_why_call_not_in_cache``, a counterpart to
+  ``check_call_in_cache`` that returns the reason a call is not in the cache
+  instead of just whether it is.
+  https://github.com/joblib/joblib/pull/1763
+
 - Fix caching of functions whose source cannot be retrieved, such as functions
   defined in a notebook cell. Their identity fell back to
   ``str(hash(func.__code__))``, which is salted by ``PYTHONHASHSEED`` and so

--- a/doc/user_guide/memory.rst
+++ b/doc/user_guide/memory.rst
@@ -521,8 +521,18 @@ without actually needing to call the function itself::
     >>> func.check_call_in_cache(2)  # cache miss
     False
 
+When a call unexpectedly misses the cache,
+:meth:`func.check_why_call_not_in_cache
+<MemorizedFunc.check_why_call_not_in_cache>` reports the reason instead of just
+signalling the miss::
+
+    >>> func.check_why_call_not_in_cache(1)  # cache hit
+    ''
+    >>> func.check_why_call_not_in_cache(2)  # cache miss
+    'call not in cache'
+
 .. autoclass:: MemorizedFunc
-    :members: __init__, call, clear, check_call_in_cache
+    :members: __init__, call, clear, check_call_in_cache, check_why_call_not_in_cache
 
 
 ..

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -346,6 +346,9 @@ class NotMemorizedFunc(object):
     def check_call_in_cache(self, *args, **kwargs):
         return False
 
+    def check_why_call_not_in_cache(self, *args, **kwargs):
+        return "caching is disabled"
+
 
 ###############################################################################
 # class `AsyncNotMemorizedFunc`
@@ -463,24 +466,26 @@ class MemorizedFunc(Logger):
         self._func_code_info = None
         self._func_code_id = None
 
-    def _is_in_cache_and_valid(self, call_id):
-        """Check if the function call is cached and valid for given arguments.
+    def _why_not_in_cache(self, call_id):
+        """Report why the function call is not cached and valid.
 
         - Compare the function code with the one from the cached function,
         asserting if it has changed.
         - Check if the function call is present in the cache.
         - Call `cache_validation_callback` for user define cache validation.
 
-        Returns True if the function call is in cache and can be used, and
-        returns False otherwise.
+        Returns the reason the call cannot be used, or an empty string if it
+        is in cache and valid. Callers that only need a boolean negate it.
+
+        The ``stacklevel`` below assumes callers invoke this method directly.
         """
         # Check if the code of the function has changed
         if not self._check_previous_func_code(stacklevel=4):
-            return False
+            return "function code has changed"
 
         # Check if this specific call is in the cache
         if not self.store_backend.contains_item(call_id):
-            return False
+            return "call not in cache"
 
         # Call the user defined cache validation callback
         metadata = self.store_backend.get_metadata(call_id)
@@ -489,9 +494,9 @@ class MemorizedFunc(Logger):
             and not self.cache_validation_callback(metadata)
         ):
             self.store_backend.clear_item(call_id)
-            return False
+            return "user cache validation callback failed"
 
-        return True
+        return ""
 
     def _cached_call(self, args, kwargs, shelving):
         """Call wrapped function and cache result, or read cache if available.
@@ -540,7 +545,7 @@ class MemorizedFunc(Logger):
         # Compare the function code with the previous to see if the
         # function code has changed and check if the results are present in
         # the cache.
-        if self._is_in_cache_and_valid(call_id):
+        if not self._why_not_in_cache(call_id):
             if shelving:
                 return self._get_memorized_result(call_id), {}
 
@@ -646,9 +651,32 @@ class MemorizedFunc(Logger):
         -------
         is_call_in_cache: bool
             Whether or not the function call is in cache and can be used.
+
+        See Also
+        --------
+        check_why_call_not_in_cache
         """
         call_id = (self.func_id, self._get_args_id(*args, **kwargs))
-        return self._is_in_cache_and_valid(call_id)
+        return not self._why_not_in_cache(call_id)
+
+    def check_why_call_not_in_cache(self, *args, **kwargs):
+        """Check why the function call is not cached and valid.
+
+        Same as :meth:`check_call_in_cache`, but reports the reason for a
+        cache miss rather than just whether one will occur.
+
+        Returns
+        -------
+        reason: str
+            The reason why the call is not in cache, or an empty string if
+            the call is in cache and can be used.
+
+        See Also
+        --------
+        check_call_in_cache
+        """
+        call_id = (self.func_id, self._get_args_id(*args, **kwargs))
+        return self._why_not_in_cache(call_id)
 
     # ------------------------------------------------------------------------
     # Private interface

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -723,6 +723,42 @@ def test_check_call_in_cache(tmpdir, consider_cache_valid):
     assert not func.check_call_in_cache(2)
 
 
+@pytest.mark.parametrize("consider_cache_valid", [True, False])
+def test_check_why_call_not_in_cache(tmpdir, consider_cache_valid):
+    for func in (
+        MemorizedFunc(
+            f, tmpdir.strpath, cache_validation_callback=lambda _: consider_cache_valid
+        ),
+        Memory(location=tmpdir.strpath, verbose=0).cache(
+            f, cache_validation_callback=lambda _: consider_cache_valid
+        ),
+    ):
+        assert func.check_why_call_not_in_cache(2) == "call not in cache"
+        assert func(2) == 5
+        reason = func.check_why_call_not_in_cache(2)
+        if consider_cache_valid:
+            assert reason == ""
+        else:
+            assert reason == "user cache validation callback failed"
+        func.clear()
+
+    func = NotMemorizedFunc(f)
+    assert func.check_why_call_not_in_cache(2) == "caching is disabled"
+
+
+def test_check_why_call_not_in_cache_func_code_change(tmpdir):
+    memory = Memory(location=tmpdir.strpath, verbose=0)
+    func = memory.cache(f)
+    assert func(2) == 5
+    assert func.check_why_call_not_in_cache(2) == ""
+
+    # Overwrite the stored source so that the cached code no longer matches.
+    # The in-memory store short-circuits the comparison, so clear it too.
+    _FUNCTION_HASHES.clear()
+    func.store_backend.store_cached_func_code([func.func_id], "def f(x):\n    pass\n")
+    assert func.check_why_call_not_in_cache(2) == "function code has changed"
+
+
 def test_call_and_shelve(tmpdir):
     # Test MemorizedFunc outputting a reference to cache.
 


### PR DESCRIPTION
Consider this proposal-as-PR, feel free to close if out of scope or deemed not sufficiently useful. I was just using this for local debugging so thought it's possible others might need it, too.

I was getting some cache misses and didn't understand why. This adds a function to give a reason string why. I assumed it was a hash mismatch, but it's nice to know that `joblib` saw it that way so I could confidently debug the issue at my end.