### PR TITLE
Fix test failure related to numpy 2.4 warning

### DIFF
--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -428,10 +428,7 @@ def _check_pickle(filename, expected_list, mmap_mode=None):
                 version_index = filename_base.find(prefix) + len(prefix)
                 joblib_version = filename_base[version_index:]
 
-                def check_version(v):
-                    return joblib_version.startswith(v)
-
-                if check_version("0.9."):
+                if joblib_version.startswith("0.9."):
                     expected_nb_user_warnings += 1
                     if "compressed" in filename_base:
                         expected_nb_user_warnings += 2

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -452,12 +452,6 @@ def _check_pickle(filename, expected_list, mmap_mode=None):
                         "version less than 0.10. Please regenerate this "
                         "pickle file.".format(filename)
                     )
-                elif issubclass(w.category, UserWarning):
-                    escaped_filename = re.escape(filename)
-                    assert re.search(
-                        f"memmapped.+{escaped_filename}.+segmentation fault",
-                        str(w.message),
-                    )
                 elif check_numpy_depreciation_warning and issubclass(
                     w.category, np.exceptions.VisibleDeprecationWarning
                 ):
@@ -466,6 +460,12 @@ def _check_pickle(filename, expected_list, mmap_mode=None):
                         == "dtype(): align should be passed as Python or NumPy "
                         "boolean but got `align=0`. Did you mean to pass a tuple "
                         "to create a subarray type? (Deprecated NumPy 2.4)"
+                    )
+                elif issubclass(w.category, UserWarning):
+                    escaped_filename = re.escape(filename)
+                    assert re.search(
+                        f"memmapped.+{escaped_filename}.+segmentation fault",
+                        str(w.message),
                     )
                 else:
                     raise Exception(f"No warning of type {w.category} is expected")

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -405,7 +405,7 @@ def _check_pickle(filename, expected_list, mmap_mode=None):
         try:
             with warnings.catch_warnings(record=True) as warninfo:
                 warnings.simplefilter("always")
-                # Ignore numpy >= 2.4 warning when load old pickle where
+                # Ignore numpy >= 2.4 warning when loading old pickles, where
                 # align=0 but it should be a Python or Numpy boolean
                 warnings.filterwarnings(
                     "ignore", message=".+align should be passed.+boolean.+align=0"


### PR DESCRIPTION
As mentioned in https://github.com/joblib/joblib/pull/1768#issuecomment-3723153945 there is a recent numpy version 2.4.0 added a new warning when `align=` is not passed as boolean to `np.dtype()`.
This warning should be handled in the pickle test across python versions.