### PR TITLE
MNT-Fix-numpy-2.5-warnings

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -200,11 +200,7 @@ class NumpyArrayWrapper(object):
                 )
                 del data
 
-            if self.order == "F":
-                array.shape = self.shape[::-1]
-                array = array.transpose()
-            else:
-                array.shape = self.shape
+            array = array.reshape(self.shape, order=self.order)
 
         if ensure_native_byte_order:
             # Detect byte order mismatch and swap as needed.

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -200,7 +200,11 @@ class NumpyArrayWrapper(object):
                 )
                 del data
 
-            array = array.reshape(self.shape, order=self.order)
+            if self.order == "F":
+                array = array.reshape(self.shape[::-1])
+                array = array.transpose()
+            else:
+                array = array.reshape(self.shape)
 
         if ensure_native_byte_order:
             # Detect byte order mismatch and swap as needed.


### PR DESCRIPTION
Fix the new numpy 2.5 warning about setting the shape of an array.

Closes: #1772