### PR TITLE
ENH `return_as="generator"` for `backend="multiprocessing"`

### DIFF
--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -517,7 +517,7 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin, ParallelBacken
     """
 
     supports_retrieve_callback = True
-    supports_return_generator = False
+    supports_return_generator = True
 
     def effective_n_jobs(self, n_jobs):
         """Determine the number of jobs which are going to run in parallel.
@@ -570,6 +570,11 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin, ParallelBacken
             return 1
 
         return super(MultiprocessingBackend, self).effective_n_jobs(n_jobs)
+
+    def retrieve_result_callback(self, future):
+        if isinstance(future, BaseException):
+            raise future
+        return future
 
     def configure(
         self,

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -492,7 +492,7 @@ def test_error_capture(backend):
     if mp is not None:
         with raises(ZeroDivisionError):
             Parallel(n_jobs=2, backend=backend)(
-                [delayed(division)(x, y) for x, y in zip((0, 1), (1, 0))]
+                [delayed(division)(x, y) for x, y in ((0, 1), (1, 0))]
             )
 
         with raises(KeyboardInterrupt):


### PR DESCRIPTION
Issue #1735 asked for the support of `return_as="generator"` for `backend="multiprocessing"`. This PR is an attempt to support it. Let me know if I'm missing something.

Closes: #1735