### PR TITLE
fix: remove Python 2 specific code and comments

### DIFF
--- a/joblib/compressor.py
+++ b/joblib/compressor.py
@@ -232,7 +232,6 @@ _BUFFER_SIZE = 8192
 class BinaryZlibFile(io.BufferedIOBase):
     """A file object providing transparent zlib (de)compression.
 
-    TODO python2_drop: is it still needed since we dropped Python 2 support A
     BinaryZlibFile can act as a wrapper for an existing file object, or refer
     directly to a named file on disk.
 

--- a/joblib/numpy_pickle_utils.py
+++ b/joblib/numpy_pickle_utils.py
@@ -234,14 +234,8 @@ BUFFER_SIZE = 2**18  # size of buffer for reading npz files in bytes
 def _read_bytes(fp, size, error_template="ran out of data"):
     """Read from file-like object until size bytes are read.
 
-    TODO python2_drop: is it still needed? The docstring mentions python 2.6
-    and it looks like this can be at least simplified ...
-
     Raises ValueError if not EOF is encountered before size bytes are read.
     Non-blocking objects only supported if they derive from io objects.
-
-    Required as e.g. ZipExtFile in python 2.6 can return less data than
-    requested.
 
     This function was taken from numpy/lib/format.py in version 1.10.2.
 

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -46,8 +46,6 @@ except ImportError:
 class CustomizablePickler(Pickler):
     """Pickler that accepts custom reducers.
 
-    TODO python2_drop : can this be simplified ?
-
     HIGHEST_PROTOCOL is selected by default as this pickler is used
     to pickle ephemeral datastructures for interprocess communication
     hence no backward compatibility is required.
@@ -61,39 +59,22 @@ class CustomizablePickler(Pickler):
 
     """
 
-    # We override the pure Python pickler as its the only way to be able to
-    # customize the dispatch table without side effects in Python 2.7
-    # to 3.2. For Python 3.3+ leverage the new dispatch_table
-    # feature from https://bugs.python.org/issue14166 that makes it possible
+    # Leverage the dispatch_table feature from
+    # https://bugs.python.org/issue14166 that makes it possible
     # to use the C implementation of the Pickler which is faster.
 
     def __init__(self, writer, reducers=None, protocol=HIGHEST_PROTOCOL):
         Pickler.__init__(self, writer, protocol=protocol)
         if reducers is None:
             reducers = {}
-        if hasattr(Pickler, "dispatch"):
-            # Make the dispatch registry an instance level attribute instead of
-            # a reference to the class dictionary under Python 2
-            self.dispatch = Pickler.dispatch.copy()
-        else:
-            # Under Python 3 initialize the dispatch table with a copy of the
-            # default registry
-            self.dispatch_table = copyreg.dispatch_table.copy()
+        # Initialize the dispatch table with a copy of the default registry
+        self.dispatch_table = copyreg.dispatch_table.copy()
         for type, reduce_func in reducers.items():
             self.register(type, reduce_func)
 
     def register(self, type, reduce_func):
         """Attach a reducer function to a given type in the dispatch table."""
-        if hasattr(Pickler, "dispatch"):
-            # Python 2 pickler dispatching is not explicitly customizable.
-            # Let us use a closure to workaround this limitation.
-            def dispatcher(self, obj):
-                reduced = reduce_func(obj)
-                self.save_reduce(obj=obj, *reduced)
-
-            self.dispatch[type] = dispatcher
-        else:
-            self.dispatch_table[type] = reduce_func
+        self.dispatch_table[type] = reduce_func
 
 
 class CustomizablePicklingQueue(object):


### PR DESCRIPTION
## Summary

This PR removes lingering Python 2 specific code and comments from the codebase, addressing issue #1079.

## Root Cause

When Python 2 support was dropped, several TODO comments (tagged `python2_drop`) were left behind, along with Python 2 compatibility branches in `CustomizablePickler`.

## Changes

### 1. `joblib/pool.py` — `CustomizablePickler`

- Removed the `TODO python2_drop` comment
- Removed Python 2 compatibility branch using `hasattr(Pickler, "dispatch")`
- Simplified `__init__` to always use `self.dispatch_table = copyreg.dispatch_table.copy()` (Python 3 path)
- Simplified `register` to always use `self.dispatch_table[type] = reduce_func` (Python 3 path)
- Updated comments referencing Python 2.7

### 2. `joblib/numpy_pickle_utils.py` — `_read_bytes` docstring

- Removed the `TODO python2_drop` comment
- Removed the Python 2.6 specific reference about `ZipExtFile` returning partial data

### 3. `joblib/compressor.py` — `BinaryZlibFile` docstring

- Removed the `TODO python2_drop` comment

## Test

- All modified modules import successfully
- `CustomizablePickler` continues to work correctly (verified via `Parallel(n_jobs=2)` integration test)
- 5 insertions, 31 deletions — net reduction in code