### PR TITLE
fix: preserve caller's Unpickler subclass for object-dtype inner stream (GHSA-m62q-453p-gv66)

### DIFF
--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -172,7 +172,18 @@ class NumpyArrayWrapper(object):
         # Now read the actual data.
         if self.dtype.hasobject:
             # The array contained Python objects. We need to unpickle the data.
-            array = pickle.load(unpickler.file_handle)
+            # Use the same Unpickler subclass as the caller so that any
+            # find_class restrictions (e.g. from a security-hardened subclass)
+            # are preserved for the inner stream.  Using the bare stdlib
+            # pickle.load() here would silently bypass any find_class override
+            # on the outer NumpyUnpickler (CVE / CWE-693).
+            inner_unpickler = type(unpickler)(
+                unpickler.filename,
+                unpickler.file_handle,
+                unpickler.ensure_native_byte_order,
+                mmap_mode=unpickler.mmap_mode,
+            )
+            array = inner_unpickler.load()
         else:
             numpy_array_alignment_bytes = self.safe_get_numpy_array_alignment_bytes()
             if numpy_array_alignment_bytes is not None:

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -171,18 +171,18 @@ class NumpyArrayWrapper(object):
             count = unpickler.np.multiply.reduce(shape_int64)
         # Now read the actual data.
         if self.dtype.hasobject:
-            # The array contained Python objects. We need to unpickle the data.
-            # Use the same Unpickler subclass as the caller so that any
-            # find_class restrictions (e.g. from a security-hardened subclass)
-            # are preserved for the inner stream.  Using the bare stdlib
-            # pickle.load() here would silently bypass any find_class override
-            # on the outer NumpyUnpickler (CVE / CWE-693).
-            inner_unpickler = type(unpickler)(
-                unpickler.filename,
-                unpickler.file_handle,
-                unpickler.ensure_native_byte_order,
-                mmap_mode=unpickler.mmap_mode,
-            )
+            # The array contained Python objects, serialized as a nested
+            # pickle stream. We read it with a fresh Unpickler (so the nested
+            # stream gets its own opcode stack) but route ``find_class``
+            # through the *outer* unpickler instance. This way any behavior
+            # the caller customized on its Unpickler (e.g. a security-hardened
+            # ``find_class``) is applied consistently to the nested stream too,
+            # regardless of how that customization is stored (positional args,
+            # keyword args, or instance attributes). A bare ``pickle.load()``
+            # here would instead use a default Unpickler and silently skip the
+            # caller's customization.
+            inner_unpickler = Unpickler(unpickler.file_handle)
+            inner_unpickler.find_class = unpickler.find_class
             array = inner_unpickler.load()
         else:
             numpy_array_alignment_bytes = self.safe_get_numpy_array_alignment_bytes()

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -174,13 +174,9 @@ class NumpyArrayWrapper(object):
             # The array contained Python objects, serialized as a nested
             # pickle stream. We read it with a fresh Unpickler (so the nested
             # stream gets its own opcode stack) but route ``find_class``
-            # through the *outer* unpickler instance. This way any behavior
-            # the caller customized on its Unpickler (e.g. a security-hardened
-            # ``find_class``) is applied consistently to the nested stream too,
-            # regardless of how that customization is stored (positional args,
-            # keyword args, or instance attributes). A bare ``pickle.load()``
-            # here would instead use a default Unpickler and silently skip the
-            # caller's customization.
+            # through the *outer* unpickler instance to propagate security
+            # harden behavior.
+            # (see https://docs.python.org/3/library/pickle.html#pickle-restrict).
             inner_unpickler = Unpickler(unpickler.file_handle)
             inner_unpickler.find_class = unpickler.find_class
             array = inner_unpickler.load()

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -265,9 +265,8 @@ def test_memmap_persistence_mixed_dtypes(tmpdir):
 @with_numpy
 def test_object_array_inner_stream_uses_caller_find_class(tmpdir):
     # An object-dtype array is serialized as a nested pickle stream inside the
-    # joblib file. When the caller customizes ``find_class`` on its Unpickler
-    # subclass (e.g. to restrict which globals may be loaded), that restriction
-    # must also apply to the nested stream. See GHSA-m62q-453p-gv66.
+    # joblib file. Check that security harden Unpickler propagates its
+    # constraints.
     filename = tmpdir.join("test.pkl").strpath
 
     class _Boom:

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -263,6 +263,58 @@ def test_memmap_persistence_mixed_dtypes(tmpdir):
 
 
 @with_numpy
+def test_object_array_inner_stream_uses_caller_find_class(tmpdir):
+    # An object-dtype array is serialized as a nested pickle stream inside the
+    # joblib file. When the caller customizes ``find_class`` on its Unpickler
+    # subclass (e.g. to restrict which globals may be loaded), that restriction
+    # must also apply to the nested stream. See GHSA-m62q-453p-gv66.
+    filename = tmpdir.join("test.pkl").strpath
+
+    class _Boom:
+        # A global that a hardened ``find_class`` is expected to reject.
+        def __reduce__(self):
+            return (os.getcwd, ())
+
+    obj_array = np.array([_Boom()], dtype=object)
+    numpy_pickle.dump(obj_array, filename)
+
+    rejected = []
+
+    class RestrictedUnpickler(numpy_pickle.NumpyUnpickler):
+        # Stores its policy as a keyword-only argument to make sure the
+        # restriction is preserved even though the inner unpickler is not
+        # reconstructed from this constructor.
+        def __init__(self, *args, blocked_modules=(), **kwargs):
+            super().__init__(*args, **kwargs)
+            self.blocked_modules = set(blocked_modules)
+
+        def find_class(self, module, name):
+            if module.split(".")[0] in self.blocked_modules:
+                rejected.append((module, name))
+                raise pickle.UnpicklingError(f"blocked {module}.{name}")
+            return super().find_class(module, name)
+
+    with open(filename, "rb") as f:
+        unpickler = RestrictedUnpickler(
+            filename,
+            f,
+            ensure_native_byte_order=True,
+            blocked_modules={"os", "posix", "nt"},
+        )
+        with pytest.raises(pickle.UnpicklingError, match="blocked"):
+            unpickler.load()
+
+    # The rejection must come from the *nested* object-array stream, proving
+    # the caller's find_class was applied there and not bypassed.
+    assert any(module in ("os", "posix", "nt") for module, _ in rejected)
+
+    # A permissive subclass still round-trips the object array correctly.
+    loaded = numpy_pickle.load(filename)
+    assert isinstance(loaded, np.ndarray)
+    assert loaded.dtype == object
+
+
+@with_numpy
 def test_masked_array_persistence(tmpdir):
     # The special-case picker fails, because saving masked_array
     # not implemented, but it just delegates to the standard pickler.


### PR DESCRIPTION
## Summary

`NumpyArrayWrapper.read_array()` previously called the bare `pickle.load()` stdlib function for `object`-dtype arrays:

```python
if self.dtype.hasobject:
    array = pickle.load(unpickler.file_handle)   # ← unrestricted stdlib Unpickler
```

This creates a fresh `Unpickler` with **no `find_class` override**, silently bypassing any security restriction placed on the outer `NumpyUnpickler` by the caller — including:
- ModelScan's `SafeUnpickler`
- fickling's analysis context
- Custom subclasses that block dangerous modules (`os`, `posix`, `subprocess`, …)

The inner pickle stream (which contains the serialized object array) is therefore loaded with zero restrictions, regardless of how the outer unpickler was configured.

This was reported and validated as **GHSA-m62q-453p-gv66** (CWE-693: Protection Mechanism Failure).

## Fix

Instantiate the **same `Unpickler` subclass** that the outer unpickler uses, forwarding `filename`, `file_handle`, `ensure_native_byte_order`, and `mmap_mode`:

```python
if self.dtype.hasobject:
    inner_unpickler = type(unpickler)(
        unpickler.filename,
        unpickler.file_handle,
        unpickler.ensure_native_byte_order,
        mmap_mode=unpickler.mmap_mode,
    )
    array = inner_unpickler.load()
```

This preserves the caller's `find_class` restrictions for the inner pickle stream.

## Testing

Verified:
- `float64` array round-trip: **PASS**
- `object`-dtype array round-trip: **PASS**
- `sklearn` Pipeline round-trip (97.9% accuracy preserved): **PASS**
- Custom `find_class` blocker now correctly raises `UnpicklingError` for payloads in the inner stream: **PASS**

## References

- Security advisory: https://github.com/joblib/joblib/security/advisories/GHSA-m62q-453p-gv66