### PR TITLE
FIX py:module in doc

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,8 @@
 Joblib documentation
 ====================
 
+.. py:module:: joblib
+
 Joblib is a package for **parallel computing** and **disk-based caching** in Python.
 It is optimized to be **fast** and **robust** on large data in particular
 and has specific optimizations for `numpy` arrays.


### PR DESCRIPTION
As noticed in #1796, ``.. automodule:: joblib`` has been removed. I just added back ``.. py:module:: joblib`` for intersphinx-links.

Closes: #1796