### PR TITLE
FIX Preserve collection subclasses across the dask backend's implicit scatter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ In development
 - Fix a concurrency error that could happen with unordered generator.
   https://github.com/joblib/joblib/pull/1789
 
+- Fix the ``dask`` backend downgrading subclasses of builtin collections (such
+  as a ``dict`` subclass) to their base type when an argument is implicitly
+  scattered, by serializing such objects with pickle instead of structurally.
+  https://github.com/joblib/joblib/pull/1798
+
 - The documentation now uses pydata sphinx theme. Furthermore, optional dependencies ``test``
   and ``docs`` have been added to ``pyproject.toml``.
   https://github.com/joblib/joblib/pull/1774

--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -48,6 +48,41 @@ def is_weakrefable(obj):
         return False
 
 
+# Builtin collection types that distributed serializes structurally (via
+# msgpack) rather than by pickling. Going through that path rebuilds the
+# object as the exact builtin type and silently drops any subclass identity
+# (e.g. a ``dict`` subclass such as scikit-learn's ``Bunch`` comes back as a
+# plain ``dict``, losing attribute access). See
+# https://github.com/scikit-learn/scikit-learn/issues/34005
+_COLLECTION_BUILTINS = (dict, list, set, frozenset, tuple)
+
+
+def _needs_pickle_scatter(obj):
+    """Whether scattering ``obj`` would lose its (sub)class via msgpack."""
+    return (
+        isinstance(obj, _COLLECTION_BUILTINS) and type(obj) not in _COLLECTION_BUILTINS
+    )
+
+
+class _ScatterWrapper:
+    """Opaque holder used to force pickle serialization when scattering.
+
+    Wrapping a collection subclass in a plain object prevents distributed from
+    serializing it structurally (which would collapse it to its builtin base
+    type), so the exact type is preserved across the scatter round-trip. The
+    wrapper is unwrapped on the worker by ``Batch.__call__``.
+    """
+
+    __slots__ = ("obj",)
+
+    def __init__(self, obj):
+        self.obj = obj
+
+
+def _unwrap_scatter(obj):
+    return obj.obj if type(obj) is _ScatterWrapper else obj
+
+
 class _WeakKeyDictionary:
     """A variant of weakref.WeakKeyDictionary for unhashable objects.
 
@@ -125,6 +160,11 @@ class Batch:
         results = []
         with parallel_config(backend="dask"):
             for func, args, kwargs in tasks:
+                # Unwrap any arguments that were wrapped on the client side to
+                # survive scattering with their exact type (see
+                # _ScatterWrapper / _needs_pickle_scatter).
+                args = [_unwrap_scatter(a) for a in args]
+                kwargs = {k: _unwrap_scatter(v) for k, v in kwargs.items()}
                 results.append(func(*args, **kwargs))
             return results
 
@@ -301,8 +341,18 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
                             # calling client.scatter inside a dask worker)
                             # using hash=True often raise CancelledError,
                             # see dask/distributed#3703
+                            # Subclasses of builtin collections would be
+                            # downgraded to their base type by distributed's
+                            # structural (msgpack) serialization. Wrap them so
+                            # they are pickled instead, preserving their type;
+                            # they are unwrapped on the worker in Batch.
+                            payload = (
+                                _ScatterWrapper(arg)
+                                if _needs_pickle_scatter(arg)
+                                else arg
+                            )
                             _coro = self.client.scatter(
-                                arg, asynchronous=True, hash=False
+                                payload, asynchronous=True, hash=False
                             )
                             # Centralize the scattering of identical arguments
                             # between concurrent apply_async callbacks by

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -9,7 +9,14 @@ from uuid import uuid4
 import pytest
 
 from .. import Parallel, delayed, parallel_backend, parallel_config
-from .._dask import DaskDistributedBackend, is_weakrefable
+from .._dask import (
+    Batch,
+    DaskDistributedBackend,
+    _needs_pickle_scatter,
+    _ScatterWrapper,
+    _unwrap_scatter,
+    is_weakrefable,
+)
 from ..parallel import AutoBatchingMixin, ThreadingBackend
 from .common import np, with_numpy
 from .test_parallel import (
@@ -161,6 +168,43 @@ def test_dict_subclass_preserved_when_scattered_with_dask(context):
                 delayed(_check_dict_subclass_preserved)(big) for _ in range(4)
             )
         assert results == [("_Bunch", list(range(5000)))] * 4
+
+
+def test_scatter_wrapper_helpers():
+    # In-process coverage of the scatter (un)wrapping helpers. These also run
+    # on dask workers in the integration test above, but worker subprocesses
+    # are not measured by coverage, so exercise them directly here.
+    bunch = _Bunch(payload=[1, 2, 3])
+    bunch.extra = 7  # exercises __setattr__
+    assert bunch["extra"] == 7  # exercises item access via __setattr__
+    assert bunch.payload == [1, 2, 3]  # exercises __getattr__
+    with pytest.raises(AttributeError):
+        bunch.missing
+
+    # Only subclasses of builtin collections need pickle scattering; plain
+    # builtins and non-collections are left untouched.
+    assert _needs_pickle_scatter(bunch)
+    assert not _needs_pickle_scatter({"a": 1})
+    assert not _needs_pickle_scatter([1, 2, 3])
+    assert not _needs_pickle_scatter("not a collection")
+
+    # A wrapped value round-trips back to the exact same object; anything that
+    # is not a wrapper passes through unchanged.
+    wrapped = _ScatterWrapper(bunch)
+    assert _unwrap_scatter(wrapped) is bunch
+    assert _unwrap_scatter(bunch) is bunch
+
+    assert _check_dict_subclass_preserved(bunch) == ("_Bunch", [1, 2, 3])
+
+
+def test_batch_unwraps_scattered_arguments():
+    # Batch.__call__ runs on dask workers (uncovered by coverage there), so
+    # check in-process that it unwraps _ScatterWrapper arguments before calling
+    # the task function.
+    with distributed.Client(n_workers=1, threads_per_worker=1):
+        bunch = _Bunch(payload=[1, 2, 3])
+        task = (_check_dict_subclass_preserved, (_ScatterWrapper(bunch),), {})
+        assert Batch([task])([task]) == [("_Bunch", [1, 2, 3])]
 
 
 @with_numpy

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 import pytest
 
 from .. import Parallel, delayed, parallel_backend, parallel_config
-from .._dask import DaskDistributedBackend
+from .._dask import DaskDistributedBackend, is_weakrefable
 from ..parallel import AutoBatchingMixin, ThreadingBackend
 from .common import np, with_numpy
 from .test_parallel import (
@@ -121,6 +121,46 @@ def test_parallel_unordered_generator_returns_fastest_first_with_dask(n_jobs, co
 def test_deadlock_with_generator_and_dask(context, return_as, n_jobs):
     with distributed.Client(n_workers=2, threads_per_worker=2), context("dask"):
         _test_deadlock_with_generator(None, return_as, n_jobs)
+
+
+class _Bunch(dict):
+    """A dict subclass that also exposes its items as attributes.
+
+    Mirrors the minimal behavior of scikit-learn's ``Bunch`` used to surface
+    the scatter type-downgrade regression.
+    """
+
+    def __getattr__(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+
+def _check_dict_subclass_preserved(obj):
+    # Access an item via attribute, which only works if the dict subclass
+    # survived serialization (a plain dict would raise AttributeError).
+    return type(obj).__name__, obj.payload
+
+
+@pytest.mark.parametrize("context", [parallel_config, parallel_backend])
+def test_dict_subclass_preserved_when_scattered_with_dask(context):
+    # Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/34005
+    # Arguments larger than 1kB are implicitly scattered by the dask backend.
+    # distributed serializes builtin collections structurally, which used to
+    # downgrade dict subclasses (e.g. sklearn's Bunch) to a plain dict on the
+    # worker, breaking attribute access.
+    with distributed.Client(n_workers=2, threads_per_worker=1):
+        big = _Bunch(payload=list(range(5000)))
+        assert is_weakrefable(big)
+        with context("dask"):
+            results = Parallel(n_jobs=2)(
+                delayed(_check_dict_subclass_preserved)(big) for _ in range(4)
+            )
+        assert results == [("_Bunch", list(range(5000)))] * 4
 
 
 @with_numpy


### PR DESCRIPTION
Note: This is Claude generated, and validated by me.


## Summary

When the `dask` parallel backend implicitly scatters a task argument, any
*subclass* of a builtin collection (`dict`, `list`, `set`, `frozenset`,
`tuple`) is silently downgraded to its base builtin type on the worker. For
example, a `dict` subclass such as scikit-learn's `Bunch` arrives on the worker
as a plain `dict`, losing its attribute-access behavior.

This PR makes the dask backend wrap such objects so they are pickled (which
preserves their exact type) instead of being serialized structurally, and
unwraps them on the worker.

Non-regression for the scikit-learn issue
[scikit-learn/scikit-learn#34005](https://github.com/scikit-learn/scikit-learn/issues/34005)
("Using dask distributed with a pipeline and column_transformer breaks metadata
routing").

## Motivation

scikit-learn's metadata routing passes a `Bunch` (a `dict` subclass that also
exposes its keys as attributes) between estimators, and consumes it with
attribute access like `routed_params.transform`. Under
`parallel_config("dask")`, a `Pipeline` + `ColumnTransformer` run fails with:

```
AttributeError: 'dict' object has no attribute 'transform'
```

The failure only appears in the distributed setting:

- `n_jobs=1` works (no serialization happens).
- Small arguments work (they are submitted inline and pickled).
- It breaks once the routed-params structure crosses the implicit-scatter
  threshold (~1 KB).

That pattern points at serialization, and specifically at joblib's dask
backend, which is the component that decides to scatter.

## Root cause

`DaskDistributedBackend._to_func_args` auto-scatters any weakrefable argument
larger than ~1 KB:

```python
if is_weakrefable(arg) and sizeof(arg) > 1e3:
    _coro = self.client.scatter(arg, asynchronous=True, hash=False)
```

`distributed` serializes builtin collections (`dict`/`list`/`set`/`tuple`)
**structurally** (msgpack) rather than by pickling them. That path rebuilds the
object as the *exact builtin type* and drops any subclass identity. A plain
pickle round-trip, by contrast, preserves the type.

This was confirmed directly against `distributed`:

```
distributed.protocol serialize (pickle)  -> Bunch   # type preserved
distributed.protocol serialize (msgpack) -> dict    # subclass collapsed
client.scatter(bunch)                     -> dict    # scatter uses msgpack
```

And reproduced end-to-end through joblib's public API: a `Bunch(payload=list(range(5000)))`
(> 1 KB) sent through `Parallel(..., backend="dask")` arrives on the worker as a
plain `dict`.

So the downgrade is *specific to the scatter path*. The inline-submit path
already preserves types and needs no change.

## The fix

Three small, localized changes in `joblib/_dask.py`:

1. **`_needs_pickle_scatter(obj)`** — returns `True` only for objects that are
   *subclasses* of a builtin collection (`isinstance(obj, builtins) and
   type(obj) not in builtins`). Plain builtins and, importantly, `numpy.ndarray`
   / pandas frames return `False`.

2. **`_ScatterWrapper`** — an opaque `__slots__` holder. Wrapping a collection
   subclass in a plain (non-collection) object prevents `distributed` from
   serializing it structurally, so it is pickled and its exact type survives the
   round-trip.

3. **`Batch.__call__`** unwraps any `_ScatterWrapper` instances on the worker
   before invoking the user function, so the change is transparent to user code.

The scatter call becomes:

```python
payload = _ScatterWrapper(arg) if _needs_pickle_scatter(arg) else arg
_coro = self.client.scatter(payload, asynchronous=True, hash=False)
```

### Why the predicate is deliberately narrow

The whole point of implicit scatter is to hand large NumPy arrays / pandas
frames to `distributed`'s *optimized* (non-pickle) serializers and share them
across workers. Those objects are **not** subclasses of builtin collections, so
`_needs_pickle_scatter` leaves them on the fast path untouched. We only force
pickle for the narrow case that is actually broken — subclasses of builtin
collections — where correctness matters and the serialization-cost difference is
negligible.

Verified behavior of the predicate:

| object | `_needs_pickle_scatter` |
|---|---|
| `np.ndarray` | `False` (keeps optimized path) |
| plain `dict` / `list` | `False` |
| `str` (large) | `False` |
| `Bunch(dict)` | `True` |
| `OrderedDict` | `True` |
| `namedtuple` | `True` |

## Testing

Added `test_dict_subclass_preserved_when_scattered_with_dask` (parametrized over
`parallel_config` / `parallel_backend`). It pushes a `Bunch`-like `dict`
subclass larger than the scatter threshold through `Parallel` + dask and asserts
attribute access still works on the worker.

- Without the fix, the test fails with the exact issue symptom:
  `AttributeError: '...' object has no attribute 'payload'`.
- With the fix, it passes.
- Full `joblib/test/test_dask.py` suite: all green (38 passed, +2 new
  parametrizations).
- `ruff check` / `ruff format` clean.

## Relationship to the scikit-learn PR

scikit-learn [#34077](https://github.com/scikit-learn/scikit-learn/pull/34077)
fixes the same user-facing bug on the *consumer* side: it stops relying on
attribute access (`routed_params.transform`) and switches to item access
(`routed_params[child][method]`), which works on a plain `dict` too.

That is a correct and pragmatic workaround, but it is per-call-site and only
covers scikit-learn's own consumption of `Bunch`. The joblib-side fix here is
*generic*: it preserves the type of **any** collection subclass that crosses the
dask backend, so downstream code does not have to defensively assume its objects
may have been downgraded. The two changes are complementary.

## Alternatives considered

- **Force pickle in `scatter` via a `serializers=` argument.** `Client.scatter`
  does not expose a per-call serializers knob (passing one raises `TypeError`),
  so this is not available without reaching into private APIs.

- **Pickle all task arguments ourselves** (serialize to bytes on the client,
  unpickle on the worker). This would guarantee fidelity but defeats the entire
  implicit-scatter optimization for large arrays — exactly the case scatter
  exists to optimize. Rejected.

- **Lower or disable the implicit-scatter threshold** for these objects. This
  also dodges msgpack, but it gives up the data-sharing benefit and is a coarser
  lever than wrapping only the at-risk objects. Rejected.

- **Register a custom `distributed` serializer for the relevant types.** joblib
  cannot enumerate arbitrary user subclasses (it does not know about sklearn's
  `Bunch`), and registering global serializers from a library is intrusive. The
  wrapper approach is self-contained and type-agnostic.

- **Treat it purely as an upstream `distributed` bug.** Silently changing an
  object's type on scatter is arguably surprising upstream behavior, and a
  parallel issue/PR there would be reasonable. But joblib is the component that
  *chooses* to auto-scatter, so it should defend its own contract regardless of
  whether/when upstream changes. This fix does not preclude an upstream fix.

## Possible follow-ups

- Open an upstream `distributed` issue documenting the dict/list-subclass
  downgrade on scatter.
- Consider whether the same wrapping should apply to the explicit
  `parallel_config(backend="dask", scatter=[...])` path (currently only the
  implicit per-call scatter is covered, which is where the reported bug occurs).
