### PR TITLE
FIX forward mmap_mode to store backend in MemorizedResult

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Release Notes
 In development
 --------------
 
+- ``MemorizedResult`` now forwards ``mmap_mode`` to its store backend, so a
+  cached array reconstructed from a location is memory-mapped as requested
+  instead of being loaded fully into memory.
+  https://github.com/joblib/joblib/pull/1799
+
 - Unvendor cloudpickle to more quickly benefit from maintenance releases
   of cloudpickle
   https://github.com/joblib/joblib/pull/1775

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -207,7 +207,12 @@ class MemorizedResult(Logger):
     ):
         Logger.__init__(self)
         self._call_id = call_id
-        self.store_backend = _store_backend_factory(backend, location, verbose=verbose)
+        self.store_backend = _store_backend_factory(
+            backend,
+            location,
+            verbose=verbose,
+            backend_options=dict(mmap_mode=mmap_mode),
+        )
         self.mmap_mode = mmap_mode
 
         if metadata is not None:

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -456,6 +456,28 @@ def test_memory_numpy_check_mmap_mode(tmpdir, monkeypatch):
     assert d.mode == "r"
 
 
+@with_numpy
+def test_memorized_result_forwards_mmap_mode(tmpdir):
+    """MemorizedResult must forward mmap_mode to its store backend.
+
+    Reconstructing a MemorizedResult from a location (as when loading a cached
+    result in a fresh process) previously dropped mmap_mode, so the array was
+    loaded into memory instead of being memory-mapped.
+    """
+    memory = Memory(location=tmpdir.strpath, verbose=0)
+
+    @memory.cache
+    def f():
+        return np.ones(3)
+
+    cached = f.call_and_shelve()
+    direct = MemorizedResult(
+        cached.store_backend.location, cached._call_id, mmap_mode="r"
+    )
+    assert direct.store_backend.mmap_mode == "r"
+    assert isinstance(direct.get(), np.memmap)
+
+
 def test_memory_exception(tmpdir):
     """Smoketest the exception handling of Memory."""
     memory = Memory(location=tmpdir.strpath, verbose=0)


### PR DESCRIPTION
`MemorizedResult` takes an `mmap_mode` argument but never passes it to its store backend. `_store_backend_factory` is called without `backend_options`, so the backend keeps `mmap_mode=None` and `load_item` loads arrays fully into memory even when `mmap_mode="r"` was requested. `MemorizedFunc` already forwards it the same way (via `backend_options`).

So reconstructing a cached result from a location and asking for mmap gives you a plain array instead of a memmap:

```python
cached = f.call_and_shelve()
direct = MemorizedResult(cached.store_backend.location, cached._call_id, mmap_mode="r")
direct.store_backend.mmap_mode   # None, should be "r"
type(direct.get())               # ndarray, should be memmap
```

The fix forwards `mmap_mode` to the factory, matching `MemorizedFunc`. Added a regression test. Full `test_memory.py` passes (68), `ruff` clean.
