### PR TITLE
FIX filter_args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ In development
   default declared before a keyword-only argument without a default.
   https://github.com/joblib/joblib/issues/1731
 
+- Fix behavior of ``filter_args`` on some precise cases.
+  https://github.com/joblib/joblib/pull/1800
+
 - Fix a concurrency error that could happen with unordered generator.
   https://github.com/joblib/joblib/pull/1789
 

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -317,14 +317,14 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
 
     # If more keyword arguments are given, store them in varkwargs
     varkwargs = {k: v for k, v in kwargs.items() if k not in arg_dict}
-    if arg_varkw is None:
-        if varkwargs:
-            raise ValueError(
-                f"Too many keyword arguments for {_signature_str(name, arg_sig)}:\n"
-                f"    {_function_called_str(name, args, kwargs)} was called."
-            )
-    else:
+    if arg_varkw is not None:
         arg_dict["**"] = varkwargs
+
+    elif varkwargs:
+        raise ValueError(
+            f"Too many keyword arguments for {_signature_str(name, arg_sig)}:\n"
+            f"    {_function_called_str(name, args, kwargs)} was called."
+        )
 
     # Now remove the arguments to be ignored
     for item in ignore_lst:

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -237,22 +237,21 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
         return {"*": args, "**": kwargs}
     arg_sig = inspect.signature(func)
     arg_names = []
-    arg_defaults = []
     arg_kwonlyargs = []
     arg_varargs = None
     arg_varkw = None
+    arg_dict = dict()
     for param in arg_sig.parameters.values():
         if param.kind is param.POSITIONAL_OR_KEYWORD:
             arg_names.append(param.name)
         elif param.kind is param.KEYWORD_ONLY:
-            arg_names.append(param.name)
             arg_kwonlyargs.append(param.name)
         elif param.kind is param.VAR_POSITIONAL:
             arg_varargs = param.name
         elif param.kind is param.VAR_KEYWORD:
             arg_varkw = param.name
         if param.default is not param.empty:
-            arg_defaults.append(param.default)
+            arg_dict[param.name] = param.default
     if inspect.ismethod(func):
         # First argument is 'self', it has been removed by Python
         # we need to add it back:
@@ -269,60 +268,80 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
     # as on ndarrays.
 
     _, name = get_func_name(func, resolv_alias=False)
-    arg_dict = dict()
-    arg_position = -1
+
+    # Check positional or keyword arguments
     for arg_position, arg_name in enumerate(arg_names):
         if arg_position < len(args):
-            # Positional argument or keyword argument given as positional
-            if arg_name not in arg_kwonlyargs:
-                arg_dict[arg_name] = args[arg_position]
-            else:
+            # given as positional
+            arg_dict[arg_name] = args[arg_position]
+            if arg_name in kwargs:
                 raise ValueError(
-                    "Keyword-only parameter '%s' was passed as "
-                    "positional parameter for %s:\n"
-                    "     %s was called."
+                    "Argument %s was given both as positional and as keyword for %s:\n"
+                    "    %s was called."
                     % (
                         arg_name,
                         _signature_str(name, arg_sig),
                         _function_called_str(name, args, kwargs),
                     )
                 )
-
-        else:
-            position = arg_position - len(arg_names)
-            if arg_name in kwargs:
-                arg_dict[arg_name] = kwargs[arg_name]
-            else:
-                try:
-                    arg_dict[arg_name] = arg_defaults[position]
-                except (IndexError, KeyError) as e:
-                    # Missing argument
-                    raise ValueError(
-                        "Wrong number of arguments for %s:\n"
-                        "     %s was called."
-                        % (
-                            _signature_str(name, arg_sig),
-                            _function_called_str(name, args, kwargs),
-                        )
-                    ) from e
-
-    varkwargs = dict()
-    for arg_name, arg_value in sorted(kwargs.items()):
-        if arg_name in arg_dict:
-            arg_dict[arg_name] = arg_value
-        elif arg_varkw is not None:
-            varkwargs[arg_name] = arg_value
-        else:
-            raise TypeError(
-                "Ignore list for %s() contains an unexpected "
-                "keyword argument '%s'" % (name, arg_name)
+        elif arg_name in kwargs:
+            # given as keyword
+            arg_dict[arg_name] = kwargs[arg_name]
+        elif arg_name not in arg_dict:
+            # Missing argument
+            raise ValueError(
+                "Wrong number of arguments for %s:\n"
+                "     %s was called."
+                % (
+                    _signature_str(name, arg_sig),
+                    _function_called_str(name, args, kwargs),
+                )
             )
 
-    if arg_varkw is not None:
+    # If more positional arguments are given, store them in vargs
+    if len(args) > len(arg_names):
+        if arg_varargs is None:
+            raise ValueError(
+                "Too many arguments for %s:\n"
+                "     %s was called."
+                % (
+                    _signature_str(name, arg_sig),
+                    _function_called_str(name, args, kwargs),
+                )
+            )
+        arg_dict["*"] = args[len(arg_names) :]
+    elif arg_varargs is not None:
+        arg_dict["*"] = []
+
+    # Check keyword only arguments
+    for arg_name in arg_kwonlyargs:
+        if arg_name in kwargs:
+            arg_dict[arg_name] = kwargs[arg_name]
+        elif arg_name not in arg_dict:
+            # Missing argument
+            raise ValueError(
+                "Wrong number of arguments for %s:\n"
+                "     %s was called."
+                % (
+                    _signature_str(name, arg_sig),
+                    _function_called_str(name, args, kwargs),
+                )
+            )
+
+    # If more keyword arguments are given, store them in varkwargs
+    varkwargs = {k: v for k, v in kwargs.items() if k not in arg_dict}
+    if arg_varkw is None:
+        if varkwargs:
+            raise ValueError(
+                "Too many keyword arguments for %s:\n"
+                "     %s was called."
+                % (
+                    _signature_str(name, arg_sig),
+                    _function_called_str(name, args, kwargs),
+                )
+            )
+    else:
         arg_dict["**"] = varkwargs
-    if arg_varargs is not None:
-        varargs = args[arg_position + 1 :]
-        arg_dict["*"] = varargs
 
     # Now remove the arguments to be ignored
     for item in ignore_lst:

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -225,13 +225,13 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
         # Catch a common mistake
         raise ValueError(
             "ignore_lst must be a list of parameters to ignore "
-            "%s (type %s) was given" % (ignore_lst, type(ignore_lst))
+            f"{ignore_lst} (type {type(ignore_lst)}) was given"
         )
     # Special case for functools.partial objects
     if not inspect.ismethod(func) and not inspect.isfunction(func):
         if ignore_lst:
             warnings.warn(
-                "Cannot inspect object %s, ignore list will not work." % func,
+                f"Cannot inspect object {func}, ignore list will not work.",
                 stacklevel=2,
             )
         return {"*": args, "**": kwargs}
@@ -277,13 +277,9 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
             arg_dict[arg_name] = args[arg_position]
             if arg_name in kwargs:
                 raise ValueError(
-                    "Argument %s was given both as positional and as keyword for %s:\n"
-                    "    %s was called."
-                    % (
-                        arg_name,
-                        _signature_str(name, arg_sig),
-                        _function_called_str(name, args, kwargs),
-                    )
+                    f"Argument {arg_name} was given both as positional and as keyword"
+                    f" for {_signature_str(name, arg_sig)}:\n"
+                    f"    {_function_called_str(name, args, kwargs)} was called."
                 )
         elif arg_name in kwargs:
             # given as keyword
@@ -291,12 +287,8 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
         elif arg_name not in arg_dict:
             # Missing argument
             raise ValueError(
-                "Wrong number of arguments for %s:\n"
-                "     %s was called."
-                % (
-                    _signature_str(name, arg_sig),
-                    _function_called_str(name, args, kwargs),
-                )
+                f"Wrong number of arguments for {_signature_str(name, arg_sig)}:\n"
+                f"    {_function_called_str(name, args, kwargs)} was called."
             )
 
     # If more positional arguments are given, they correspond
@@ -304,12 +296,8 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
     if len(args) > len(arg_names):
         if arg_varargs is None:
             raise ValueError(
-                "Too many arguments for %s:\n"
-                "     %s was called."
-                % (
-                    _signature_str(name, arg_sig),
-                    _function_called_str(name, args, kwargs),
-                )
+                f"Too many arguments for {_signature_str(name, arg_sig)}:\n"
+                f"    {_function_called_str(name, args, kwargs)} was called."
             )
         arg_dict["*"] = args[len(arg_names) :]
     elif arg_varargs is not None:
@@ -323,12 +311,8 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
             # required keyword only argument that is missing,
             # raise an error
             raise ValueError(
-                "Wrong number of arguments for %s:\n"
-                "     %s was called."
-                % (
-                    _signature_str(name, arg_sig),
-                    _function_called_str(name, args, kwargs),
-                )
+                f"Wrong number of arguments for {_signature_str(name, arg_sig)}:\n"
+                f"    {_function_called_str(name, args, kwargs)} was called."
             )
 
     # If more keyword arguments are given, store them in varkwargs
@@ -336,12 +320,8 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
     if arg_varkw is None:
         if varkwargs:
             raise ValueError(
-                "Too many keyword arguments for %s:\n"
-                "     %s was called."
-                % (
-                    _signature_str(name, arg_sig),
-                    _function_called_str(name, args, kwargs),
-                )
+                f"Too many keyword arguments for {_signature_str(name, arg_sig)}:\n"
+                f"    {_function_called_str(name, args, kwargs)} was called."
             )
     else:
         arg_dict["**"] = varkwargs
@@ -352,8 +332,8 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
             arg_dict.pop(item)
         else:
             raise ValueError(
-                "Ignore list: argument '%s' is not defined for "
-                "function %s" % (item, _signature_str(name, arg_sig))
+                f"Ignore list: argument '{item}' is not defined for "
+                f"function {_signature_str(name, arg_sig)}"
             )
     # XXX: Return a sorted list of pairs?
     return arg_dict

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -269,7 +269,8 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
 
     _, name = get_func_name(func, resolv_alias=False)
 
-    # Check positional or keyword arguments
+    # Check for positional argument of the function, that can be
+    # passed either as positional or keyword arguments in the call
     for arg_position, arg_name in enumerate(arg_names):
         if arg_position < len(args):
             # given as positional
@@ -298,7 +299,8 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
                 )
             )
 
-    # If more positional arguments are given, store them in vargs
+    # If more positional arguments are given, they correspond
+    # to *args, store them in vargs
     if len(args) > len(arg_names):
         if arg_varargs is None:
             raise ValueError(
@@ -318,7 +320,8 @@ def filter_args(func, ignore_lst, args=(), kwargs=dict()):
         if arg_name in kwargs:
             arg_dict[arg_name] = kwargs[arg_name]
         elif arg_name not in arg_dict:
-            # Missing argument
+            # required keyword only argument that is missing,
+            # raise an error
             raise ValueError(
                 "Wrong number of arguments for %s:\n"
                 "     %s was called."

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -102,9 +102,7 @@ def test_filter_args_method():
 
 
 def test_filter_args_set_positional_and_keyword():
-    with raises(
-        ValueError, match="Argument x was given both as positional and as keyword for"
-    ):
+    with raises(ValueError, match="x was given both as positional and"):
         filter_args(f, [], (1,), dict(x=2))
 
 

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -227,9 +227,8 @@ def test_filter_args_edge_cases():
 
     # filter_args doesn't care about keyword-only arguments so you
     # can pass 'kw1' into *args without any problem
-    with raises(ValueError) as excinfo:
+    with raises(ValueError, match="Too many arguments for"):
         filter_args(func_with_kwonly_args, [], (1, 2, 3), {"kw2": 2})
-    excinfo.match("Too many arguments for")
 
     assert filter_args(
         func_with_kwonly_args, ["b", "kw2"], (1, 2), {"kw1": 3, "kw2": 4}

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -101,7 +101,11 @@ def test_filter_args_method():
     assert filter_args(obj.f, [], (1,)) == {"x": 1, "self": obj}
 
 
-# TODO: Test f(1, x=2)
+def test_filter_args_set_positional_and_keyword():
+    with raises(
+        ValueError, match="Argument x was given both as positional and as keyword for"
+    ):
+        filter_args(f, [], (1,), dict(x=2))
 
 
 @parametrize(

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -17,7 +17,7 @@ from joblib.func_inspect import (
 )
 from joblib.memory import Memory
 from joblib.test.common import with_numpy
-from joblib.testing import fixture, parametrize, raises
+from joblib.testing import fixture, parametrize, raises, warns
 
 
 ###############################################################################
@@ -30,7 +30,7 @@ def g(x):
     pass
 
 
-def h(x, y=0, *args, **kwargs):
+def h(x, y=0, *args, z=1, **kwargs):
     pass
 
 
@@ -101,13 +101,16 @@ def test_filter_args_method():
     assert filter_args(obj.f, [], (1,)) == {"x": 1, "self": obj}
 
 
+# TODO: Test f(1, x=2)
+
+
 @parametrize(
     "func,args,filtered_args",
     [
-        (h, [[], (1,)], {"x": 1, "y": 0, "*": [], "**": {}}),
-        (h, [[], (1, 2, 3, 4)], {"x": 1, "y": 2, "*": [3, 4], "**": {}}),
-        (h, [[], (1, 25), {"ee": 2}], {"x": 1, "y": 25, "*": [], "**": {"ee": 2}}),
-        (h, [["*"], (1, 2, 25), {"ee": 2}], {"x": 1, "y": 2, "**": {"ee": 2}}),
+        (h, [[], (1,)], {"x": 1, "y": 0, "z": 1, "*": [], "**": {}}),
+        (h, [[], (1, 2, 3, 4)], {"x": 1, "y": 2, "z": 1, "*": [3, 4], "**": {}}),
+        (h, [[], (1,), {"ee": 2}], {"x": 1, "y": 0, "z": 1, "*": [], "**": {"ee": 2}}),
+        (h, [["*"], (1, 2, 25), {"ee": 2}], {"x": 1, "y": 2, "z": 1, "**": {"ee": 2}}),
     ],
 )
 def test_filter_varargs(func, args, filtered_args):
@@ -137,8 +140,9 @@ def test_filter_args_2():
 
     ff = functools.partial(f, 1)
     # filter_args has to special-case partial
-    assert filter_args(ff, [], (1,)) == {"*": [1], "**": {}}
-    assert filter_args(ff, ["y"], (1,)) == {"*": [1], "**": {}}
+    with warns(UserWarning, match="Cannot inspect object"):
+        assert filter_args(ff, [], (1,)) == {"*": [1], "**": {}}
+        assert filter_args(ff, ["y"], (1,)) == {"*": [1], "**": {}}
 
 
 @parametrize("func,funcname", [(f, "f"), (g, "g"), (cached_func, "cached_func")])
@@ -210,7 +214,7 @@ def test_filter_args_edge_cases():
     # can pass 'kw1' into *args without any problem
     with raises(ValueError) as excinfo:
         filter_args(func_with_kwonly_args, [], (1, 2, 3), {"kw2": 2})
-    excinfo.match("Keyword-only parameter 'kw1' was passed as positional parameter")
+    excinfo.match("Too many arguments for")
 
     assert filter_args(
         func_with_kwonly_args, ["b", "kw2"], (1, 2), {"kw1": 3, "kw2": 4}

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -845,17 +845,15 @@ def test_memory_func_with_kwonly_args(tmpdir):
 
     # Making sure that providing a keyword-only argument by
     # position raises an exception
-    with raises(ValueError) as excinfo:
+    with raises(ValueError, match="Too many arguments for"):
         func_cached(1, 2, 3, kw2=4)
-    excinfo.match("Keyword-only parameter 'kw1' was passed as positional parameter")
 
     # Keyword-only parameter passed by position with cached call
     # should still raise ValueError
     func_cached(1, 2, kw1=3, kw2=4)
 
-    with raises(ValueError) as excinfo:
+    with raises(ValueError, match="Too many arguments for"):
         func_cached(1, 2, 3, kw2=4)
-    excinfo.match("Keyword-only parameter 'kw1' was passed as positional parameter")
 
     # Test 'ignore' parameter
     func_cached = memory.cache(func_with_kwonly_args, ignore=["kw2"])


### PR DESCRIPTION
`filter_args` had several issues. For instance
```python
def f(x, *args, y=1):
    pass

filter_args(f, [], (1,2), {})
```
was raising `ValueError: Keyword-only parameter 'y' was passed as positional parameter`, while `f(1, 2)` is a correct call with `x=1, args=(2,), y=1`.
This PR fixes the function.