### PR TITLE
FIX replace distributed Worker.log by Worker.story()

### DIFF
--- a/joblib/_dask.py
+++ b/joblib/_dask.py
@@ -327,7 +327,7 @@ class DaskDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
 
         return (Batch(tasks), tasks)
 
-    def apply_async(self, func, callback=None):
+    def submit(self, func, callback=None):
         cf_future = concurrent.futures.Future()
         cf_future.get = cf_future.result  # achieve AsyncResult API
 

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -88,7 +88,11 @@ class ParallelBackendBase(metaclass=ABCMeta):
 
     def apply_async(self, func, callback=None):
         """Deprecated: implement `submit` instead."""
-        raise NotImplementedError("Implement `submit` instead.")
+        warnings.warn(
+            "`apply_async` is deprecated, implement and use `submit` instead.",
+            DeprecationWarning,
+        )
+        return self.submit(func, callback)
 
     def submit(self, func, callback=None):
         """Schedule a function to be run and return a future-like object.
@@ -119,11 +123,7 @@ class ParallelBackendBase(metaclass=ABCMeta):
         future: future-like
             A future-like object to track the execution of the submitted function.
         """
-        warnings.warn(
-            "`apply_async` is deprecated, implement and use `submit` instead.",
-            DeprecationWarning,
-        )
-        return self.apply_async(func, callback)
+        raise NotImplementedError()
 
     def retrieve_result_callback(self, out):
         """Called within the callback function passed to `submit`.

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -88,11 +88,7 @@ class ParallelBackendBase(metaclass=ABCMeta):
 
     def apply_async(self, func, callback=None):
         """Deprecated: implement `submit` instead."""
-        warnings.warn(
-            "`apply_async` is deprecated, implement and use `submit` instead.",
-            DeprecationWarning,
-        )
-        return self.submit(func, callback)
+        raise NotImplementedError("Implement `submit` instead.")
 
     def submit(self, func, callback=None):
         """Schedule a function to be run and return a future-like object.
@@ -123,7 +119,11 @@ class ParallelBackendBase(metaclass=ABCMeta):
         future: future-like
             A future-like object to track the execution of the submitted function.
         """
-        raise NotImplementedError()
+        warnings.warn(
+            "`apply_async` is deprecated, implement and use `submit` instead.",
+            DeprecationWarning,
+        )
+        return self.apply_async(func, callback)
 
     def retrieve_result_callback(self, out):
         """Called within the callback function passed to `submit`.

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -59,13 +59,14 @@ def slow_raise_value_error(condition, duration=0.05):
 
 
 def count_events(event_name, client):
-    worker_events = client.run(lambda dask_worker: dask_worker.log)
-    event_counts = {}
-    for w, events in worker_events.items():
-        event_counts[w] = len(
-            [event for event in list(events) if event[1] == event_name]
-        )
-    return event_counts
+    def work(dask_worker):
+        count = 0
+        for task_state in dask_worker.state.tasks.values():
+            task_story = dask_worker.state.story(task_state)
+            count += len([event for event in task_story if event[1] == event_name])
+        return count
+
+    return client.run(work)
 
 
 def test_simple(loop):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ test = [
     "memory_profiler",
     "pytest",
     "pytest-asyncio",
+    "pytest-cov",
     "pytest-timeout",
     "threadpoolctl",
 ]


### PR DESCRIPTION
As reported in #1802, a recent update of `distributed` removed the `log` attribute which was causing some tests to fail. This PR is a fix using the `story()` method.

Closes: #1802