### PR TITLE
Add "memmapping" support for GPU arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,15 @@ Release Notes
 In development
 --------------
 
+- Add experimental support for sharing GPU arrays (PyTorch tensors and CuPy
+  arrays) between worker processes without copying them through host memory,
+  using CUDA inter-process communication (IPC). This mirrors the numpy
+  memmapping mechanism and is controlled by the new ``share_gpu_arrays``
+  parameter of ``Parallel`` and ``parallel_config`` (``"auto"`` by default,
+  with ``"on"`` and ``"off"``). Sharing is forward-only (parent to worker),
+  same-machine and same-GPU, and requires a spawn-based process backend (loky
+  or a ``spawn``/``forkserver`` multiprocessing context).
+
 - ``MemorizedResult`` now forwards ``mmap_mode`` to its store backend, so a
   cached array reconstructed from a location is memory-mapped as requested
   instead of being loaded fully into memory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,10 @@ sphinx_gallery_conf = {
     "default_thumb_file": "_static/joblib_logo_examples.png",
     "doc_module": "joblib",
     "filename_pattern": "",
-    "ignore_pattern": "utils.py",
+    # GPU examples require a CUDA device and optional deps (torch, scikit-learn)
+    # that are not available in the docs build, so they are excluded from the
+    # executed gallery.
+    "ignore_pattern": "utils.py|gpu",
     "backreferences_dir": os.path.join("generated"),
     "reference_url": {"joblib": None},
 }

--- a/doc/user_guide/parallel_numpy.rst
+++ b/doc/user_guide/parallel_numpy.rst
@@ -159,6 +159,67 @@ Here is an example script on parallel processing with preallocated
 .. _CFFI: https://cffi.readthedocs.org
 
 
+Sharing GPU arrays between processes
+------------------------------------
+
+.. versionadded:: 1.6
+
+In addition to numpy memmapping, :class:`joblib.Parallel` can share GPU arrays
+(PyTorch tensors and CuPy arrays) with worker processes without copying their
+content through host memory, using CUDA inter-process communication (IPC). This
+is the GPU counterpart of the numpy memmapping described above and is controlled
+by the ``share_gpu_arrays`` parameter:
+
+.. code-block:: python
+
+    import torch
+    from joblib import Parallel, delayed
+
+    def run(weights):
+        # ``weights`` is a CUDA tensor backed by the same device memory as in
+        # the parent process: no host round-trip and no extra device copy.
+        return float(weights.sum())
+
+    weights = torch.ones(10_000, 10_000, device="cuda:0")
+    Parallel(n_jobs=4, backend="loky", share_gpu_arrays="on")(
+        delayed(run)(weights) for _ in range(4)
+    )
+
+``share_gpu_arrays`` accepts three values:
+
+- ``"auto"`` (the default): share device arrays larger than ``max_nbytes`` when
+  a spawn-based process backend is used, and silently fall back to regular
+  (host round-trip) pickling otherwise. This keeps existing code working
+  unchanged.
+- ``"on"``: share every device array regardless of ``max_nbytes`` and raise an
+  error if sharing is requested but not feasible (for instance with the
+  ``fork`` start method, which is incompatible with CUDA).
+- ``"off"``: never share; all arrays use their framework's regular pickling.
+
+This feature is experimental and comes with several constraints:
+
+- It only applies to the ``"loky"`` backend and to ``"multiprocessing"`` when
+  using a ``spawn`` (or ``forkserver``) start method. CUDA state cannot survive
+  a ``fork``.
+- Sharing is forward-only (from the parent to the workers). Arrays *returned*
+  by the workers go through the regular (host round-trip) pickling of their
+  framework.
+- The shared array stays on a single physical GPU: all workers access the same
+  device memory. This is data sharing, not multi-GPU replication.
+
+.. warning::
+
+  Shared GPU arrays must be treated as read-only inputs. Unlike numpy's
+  ``mmap_mode='r'``, this read-only contract is **not** enforced by PyTorch or
+  CuPy: writing to a shared array (or mutating it in the parent after dispatch)
+  results in undefined behavior and possible data races between workers.
+
+For PyTorch, sharing reuses ``torch.multiprocessing`` reductions, which handle
+the producer-side keep-alive and the stream synchronization. For CuPy, joblib
+keeps the source allocation alive for the duration of the ``Parallel`` call and
+synchronizes the producer stream before sharing.
+
+
 A final note: don't forget to clean up any temporary folder when you are done
 with the computation::
 

--- a/examples/gpu_array_sharing_gridsearch.py
+++ b/examples/gpu_array_sharing_gridsearch.py
@@ -1,0 +1,96 @@
+"""
+================================================================
+Sharing GPU arrays across processes in a scikit-learn GridSearch
+================================================================
+
+This example shows joblib's ``share_gpu_arrays`` feature in action through
+scikit-learn's :class:`~sklearn.model_selection.GridSearchCV` together with an
+estimator that supports the Array API (:class:`~sklearn.linear_model.Ridge`),
+operating on a PyTorch CUDA tensor.
+
+``GridSearchCV`` fans out its cross-validation fits over worker processes using
+joblib's ``loky`` backend. When the feature matrix ``X`` lives on the GPU,
+joblib shares that single device allocation with every worker via CUDA
+inter-process communication (IPC) instead of copying it through host memory and
+re-uploading it in each worker. This is the GPU counterpart of joblib's numpy
+memory-mapping.
+
+It happens **automatically**: ``share_gpu_arrays`` defaults to ``"auto"``, which
+shares device arrays larger than ``max_nbytes`` whenever a spawn-based process
+backend is used (loky is). No special configuration is required.
+
+Requirements
+------------
+- a CUDA-capable GPU and PyTorch built with CUDA,
+- scikit-learn >= 1.5,
+- the environment variable ``SCIPY_ARRAY_API=1`` set *before* scikit-learn (and
+  SciPy) are imported, which is what enables Array API dispatch end to end.
+"""
+
+# ``SCIPY_ARRAY_API`` must be set before scikit-learn / SciPy are imported.
+# Worker processes inherit this environment, so it is active there too.
+import os
+
+os.environ.setdefault("SCIPY_ARRAY_API", "1")
+
+import torch  # noqa: E402
+
+from sklearn import set_config  # noqa: E402
+from sklearn.datasets import make_regression  # noqa: E402
+from sklearn.linear_model import Ridge  # noqa: E402
+from sklearn.model_selection import GridSearchCV  # noqa: E402
+
+import joblib  # noqa: E402
+
+
+def main():
+    if not torch.cuda.is_available():
+        raise SystemExit("This example requires a CUDA-capable GPU.")
+
+    # Enable scikit-learn's Array API dispatch so estimators compute on the GPU
+    # array's namespace (here PyTorch on CUDA). scikit-learn automatically
+    # propagates this global configuration to the joblib worker processes.
+    set_config(array_api_dispatch=True)
+
+    # Build a regression problem and move the feature matrix to the GPU. We make
+    # X comfortably larger than joblib's ``max_nbytes`` (1 MB by default) so that
+    # GPU sharing kicks in: 50_000 x 100 float32 = 20 MB.
+    X_np, y_np = make_regression(
+        n_samples=50_000, n_features=100, noise=0.1, random_state=0
+    )
+    X = torch.asarray(X_np, dtype=torch.float32, device="cuda:0")
+    y = torch.asarray(y_np, dtype=torch.float32, device="cuda:0")
+    x_mb = X.element_size() * X.nelement() / 1e6
+    print(f"X: {tuple(X.shape)} float32 = {x_mb:.0f} MB on {X.device}")
+
+    search = GridSearchCV(
+        Ridge(solver="svd"),
+        param_grid={"alpha": [0.001, 0.01, 0.1, 1.0, 10.0]},
+        cv=5,
+        n_jobs=4,
+    )
+
+    # No joblib configuration is needed: with the default
+    # ``share_gpu_arrays="auto"``, the 20 MB GPU ``X`` above is shared with the
+    # worker processes via CUDA IPC automatically.
+    #
+    # To *force* sharing and get a clear error if it is not possible (e.g. a
+    # fork-based start method), wrap the fit explicitly:
+    #
+    #     with joblib.parallel_config(share_gpu_arrays="on"):
+    #         search.fit(X, y)
+    #
+    # and use ``share_gpu_arrays="off"`` to disable it entirely.
+    search.fit(X, y)
+
+    print("best params:", search.best_params_)
+    print(f"best CV score (R^2): {search.best_score_:.5f}")
+    print("best estimator coefficients on GPU:", search.best_estimator_.coef_.is_cuda)
+
+    # Release the shared CUDA tensors held by the (reused) loky workers before
+    # the process exits, to avoid a noisy PyTorch CUDA-IPC teardown warning.
+    joblib.externals.loky.get_reusable_executor().shutdown(wait=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/joblib/_gpu_array_reducer.py
+++ b/joblib/_gpu_array_reducer.py
@@ -1,0 +1,347 @@
+"""Reducers for sharing GPU arrays across processes via CUDA IPC.
+
+This module provides forward (parent -> worker) pickling reducers that share
+GPU arrays (PyTorch tensors and CuPy arrays) between processes without copying
+their content through host memory, in the same spirit as the numpy memmapping
+reducers in :mod:`joblib._memmapping_reducer`.
+
+Instead of dumping arrays to a file in shared memory, the device memory is
+shared through CUDA inter-process communication (IPC) handles:
+
+- For PyTorch, this reuses :func:`torch.multiprocessing.reductions.reduce_tensor`
+  which already implements correct CUDA IPC sharing, including the producer
+  keep-alive and the synchronization event handle.
+- For CuPy, a thin reducer is implemented on top of the low-level
+  ``cupy.cuda.runtime.ipc*`` primitives. The producer keeps the source
+  allocation alive for the duration of the call (see :class:`GpuResourcesManager`)
+  and each worker closes the IPC handle when the reconstructed array is garbage
+  collected.
+
+Sharing is forward-only: results returned by workers fall back to the regular
+(host round-trip) pickling of their framework.
+
+This module is intentionally lightweight to import: it never imports ``torch``
+or ``cupy`` at module load time. A GPU array can only exist if its framework is
+already imported in the current process, so the frameworks are looked up in
+``sys.modules`` rather than imported eagerly. This keeps ``import joblib`` cheap
+and avoids importing heavy GPU libraries for users that do not use this feature.
+"""
+
+# Author: joblib developers
+# License: BSD 3 clause
+
+import sys
+import warnings
+import weakref
+from pickle import HIGHEST_PROTOCOL, dumps, loads
+
+# Valid values for the ``share_gpu_arrays`` parameter.
+#
+# - "auto": best effort. Share device arrays above ``max_nbytes`` when a CUDA
+#   IPC-capable backend is used; silently fall back to regular pickling
+#   otherwise (e.g. no GPU framework, fork start method, sharing failure).
+# - "on": force sharing. Share every device array regardless of ``max_nbytes``
+#   and raise a clear error if sharing is requested but not feasible.
+# - "off": never share. All arrays use the regular pickling of their framework.
+VALID_SHARE_GPU_ARRAYS = ("auto", "on", "off")
+
+
+def check_share_gpu_arrays(value):
+    """Validate the value of the ``share_gpu_arrays`` parameter."""
+    if value not in VALID_SHARE_GPU_ARRAYS:
+        raise ValueError(
+            "share_gpu_arrays should be one of "
+            f"{VALID_SHARE_GPU_ARRAYS}, got {value!r} instead."
+        )
+    return value
+
+
+def _resolve_share_gpu_arrays(share_gpu_arrays, start_method=None):
+    """Resolve the effective sharing mode given the backend start method.
+
+    CUDA state cannot survive a ``fork``, so GPU array sharing is not supported
+    with the ``fork`` start method. In ``"auto"`` mode we silently fall back to
+    regular pickling (emitting a warning), while in ``"on"`` mode we raise.
+
+    The loky backend (and ``spawn`` / ``forkserver`` multiprocessing contexts)
+    pass ``start_method`` values that are considered safe.
+    """
+    mode = check_share_gpu_arrays(share_gpu_arrays)
+    if mode == "off":
+        return "off"
+
+    if start_method == "fork":
+        if mode == "on":
+            raise ValueError(
+                "share_gpu_arrays='on' is not supported with the 'fork' start "
+                "method because CUDA state cannot survive a fork. Use the loky "
+                "backend or a multiprocessing context using the 'spawn' or "
+                "'forkserver' start method."
+            )
+        # "auto": fall back to regular pickling.
+        warnings.warn(
+            "GPU array sharing is disabled because the 'fork' start method is "
+            "not compatible with CUDA. Falling back to regular pickling. Use "
+            "the loky backend or a 'spawn' multiprocessing context to enable "
+            "zero-copy GPU array sharing.",
+            UserWarning,
+            stacklevel=3,
+        )
+        return "off"
+
+    return mode
+
+
+def _regular_pickle_reduction(obj):
+    """Reduction that falls back to the framework's regular pickling.
+
+    For GPU arrays this implies a host round-trip, which preserves the array
+    type but does not share memory across processes.
+    """
+    return (loads, (dumps(obj, protocol=HIGHEST_PROTOCOL),))
+
+
+class GpuResourcesManager:
+    """Keep producer-side references to shared GPU allocations alive.
+
+    CUDA IPC requires the producer's allocation to remain valid while a consumer
+    (worker) process has it mapped. This manager anchors the source memory
+    objects, keyed by the id of the :class:`~joblib.Parallel` call that shared
+    them, and releases them when that call terminates.
+
+    The current context is set while pickling the batched calls of a given
+    Parallel object (see the reducer callback in ``joblib.parallel``), mirroring
+    the per-context behavior of
+    :class:`joblib._memmapping_reducer.TemporaryResourcesManager`.
+    """
+
+    def __init__(self, context_id=None):
+        self._anchors = {}
+        self._current_context_id = context_id
+        if context_id is not None:
+            self._anchors[context_id] = []
+
+    def set_current_context(self, context_id):
+        self._current_context_id = context_id
+        self._anchors.setdefault(context_id, [])
+
+    def anchor(self, obj):
+        """Keep a strong reference to ``obj`` for the current context."""
+        self._anchors.setdefault(self._current_context_id, []).append(obj)
+
+    def clean(self, context_id=None):
+        """Release the anchored allocations for ``context_id`` (or all)."""
+        if context_id is None:
+            self._anchors.clear()
+        else:
+            self._anchors.pop(context_id, None)
+
+
+class TorchIpcForwardReducer:
+    """Forward reducer sharing torch CUDA tensors via CUDA IPC.
+
+    CPU tensors and CUDA tensors below the ``max_nbytes`` threshold (in
+    ``"auto"`` mode) fall back to torch's regular pickling.
+    """
+
+    def __init__(self, mode, max_nbytes):
+        self._mode = mode
+        self._max_nbytes = max_nbytes
+
+    def __call__(self, tensor):
+        is_cuda = bool(getattr(tensor, "is_cuda", False))
+
+        share = False
+        if is_cuda:
+            if self._mode == "on":
+                share = True
+            elif self._max_nbytes is not None:
+                nbytes = tensor.element_size() * tensor.nelement()
+                share = nbytes > self._max_nbytes
+
+        if share:
+            try:
+                from torch.multiprocessing.reductions import reduce_tensor
+
+                # detach() shares the storage (no copy) while dropping autograd
+                # information so the shared tensor does not require grad.
+                return reduce_tensor(tensor.detach())
+            except Exception as e:
+                if self._mode == "on":
+                    raise RuntimeError(
+                        f"Failed to share torch CUDA tensor via CUDA IPC: {e}"
+                    ) from e
+                # "auto": fall back to regular pickling below.
+
+        return _regular_pickle_reduction(tensor)
+
+
+def _close_cupy_ipc_handle(base_ptr, device_id):
+    """Close a CuPy CUDA IPC handle, ignoring teardown-time errors."""
+    cupy = sys.modules.get("cupy")
+    if cupy is None:  # pragma: no cover - cupy always present in the worker
+        return
+    try:
+        with cupy.cuda.Device(device_id):
+            cupy.cuda.runtime.ipcCloseMemHandle(base_ptr)
+    except Exception:  # pragma: no cover - best effort cleanup
+        pass
+
+
+class _CupyIpcMemoryOwner:
+    """Owner object whose finalizer closes the IPC handle on GC.
+
+    A reconstructed CuPy array keeps a reference to this owner through its
+    ``UnownedMemory``. When the array (and hence this owner) is garbage
+    collected in the worker, the IPC handle is closed exactly once.
+    """
+
+    def __init__(self, base_ptr, device_id):
+        self.base_ptr = base_ptr
+        self.device_id = device_id
+        weakref.finalize(self, _close_cupy_ipc_handle, base_ptr, device_id)
+
+
+def _rebuild_cupy_ipc_array(payload):
+    """Reconstruct a CuPy array from a CUDA IPC payload in a worker process."""
+    # cupy is imported lazily (and not at module import time) to keep
+    # ``import joblib`` lightweight. This runs in a worker process where the
+    # array is being unpickled, so cupy is necessarily available.
+    import cupy
+
+    device_id = payload["device_id"]
+    with cupy.cuda.Device(device_id):
+        base_ptr = cupy.cuda.runtime.ipcOpenMemHandle(payload["handle"])
+        owner = _CupyIpcMemoryOwner(base_ptr, device_id)
+        mem = cupy.cuda.UnownedMemory(
+            base_ptr, payload["base_nbytes"], owner, device_id
+        )
+        memptr = cupy.cuda.MemoryPointer(mem, payload["offset"])
+        # cupy.ndarray accepts the dtype string directly, so numpy is not needed.
+        array = cupy.ndarray(
+            payload["shape"],
+            dtype=payload["dtype"],
+            memptr=memptr,
+            strides=payload["strides"],
+        )
+    return array
+
+
+class CupyIpcForwardReducer:
+    """Forward reducer sharing CuPy arrays via CUDA IPC.
+
+    CuPy arrays always live on a device, so every array is a sharing candidate.
+    In ``"auto"`` mode, arrays at or below ``max_nbytes`` fall back to CuPy's
+    regular (host round-trip) pickling.
+    """
+
+    def __init__(self, mode, max_nbytes, resources_manager=None):
+        self._mode = mode
+        self._max_nbytes = max_nbytes
+        self._resources_manager = resources_manager
+
+    def __call__(self, array):
+        share = self._mode == "on" or (
+            self._max_nbytes is not None and array.nbytes > self._max_nbytes
+        )
+
+        if share:
+            try:
+                return self._reduce_ipc(array)
+            except Exception as e:
+                if self._mode == "on":
+                    raise RuntimeError(
+                        f"Failed to share CuPy array via CUDA IPC: {e}"
+                    ) from e
+                # "auto": fall back to regular pickling below.
+
+        return _regular_pickle_reduction(array)
+
+    def _reduce_ipc(self, array):
+        import cupy
+
+        device_id = int(array.device.id)
+        mem = array.data.mem
+        base_ptr = int(mem.ptr)
+
+        with cupy.cuda.Device(device_id):
+            # Ensure all pending writes to the array are complete before the
+            # workers can read the shared memory (forward-only, read sharing).
+            cupy.cuda.Stream.null.synchronize()
+            handle = cupy.cuda.runtime.ipcGetMemHandle(base_ptr)
+
+        # Offset of the array data within the base allocation that the IPC
+        # handle refers to.
+        offset = int(array.data.ptr) - base_ptr
+
+        # Keep the source allocation alive on the producer side until the
+        # Parallel call that shared it terminates.
+        if self._resources_manager is not None:
+            self._resources_manager.anchor(mem)
+
+        payload = {
+            "handle": handle,
+            "offset": offset,
+            "base_nbytes": int(mem.size),
+            "shape": tuple(array.shape),
+            "strides": tuple(array.strides),
+            "dtype": array.dtype.str,
+            "device_id": device_id,
+        }
+        return (_rebuild_cupy_ipc_array, (payload,))
+
+
+def get_gpu_reducers(
+    share_gpu_arrays="auto",
+    max_nbytes=1e6,
+    start_method=None,
+    forward_reducers=None,
+    resources_manager=None,
+    **kwargs,
+):
+    """Build forward reducers sharing GPU arrays via CUDA IPC.
+
+    Parameters
+    ----------
+    share_gpu_arrays : {"auto", "on", "off"}, default="auto"
+        Sharing mode, see :data:`VALID_SHARE_GPU_ARRAYS`.
+    max_nbytes : int or None, default=1e6
+        Threshold (in bytes) above which device arrays are shared in ``"auto"``
+        mode. Ignored in ``"on"`` mode (all device arrays are shared).
+    start_method : str or None, default=None
+        Start method of the target process backend. ``"fork"`` disables GPU
+        sharing (CUDA cannot survive a fork). ``None`` (loky) and the other
+        multiprocessing start methods are considered safe.
+    forward_reducers : dict or None, default=None
+        An existing reducers dict to update in place. A new one is created if
+        not provided.
+    resources_manager : GpuResourcesManager or None, default=None
+        Manager keeping shared CuPy allocations alive on the producer side.
+
+    Returns
+    -------
+    forward_reducers : dict
+        Mapping of ``type -> reducer`` to register on the forward queue pickler.
+        Only frameworks that are already imported in the current process get a
+        reducer registered.
+    """
+    if forward_reducers is None:
+        forward_reducers = dict()
+
+    mode = _resolve_share_gpu_arrays(share_gpu_arrays, start_method)
+    if mode == "off":
+        return forward_reducers
+
+    # A GPU array can only exist if its framework is already imported, so we
+    # never import torch / cupy here to keep this code path lightweight.
+    torch = sys.modules.get("torch")
+    if torch is not None:
+        forward_reducers[torch.Tensor] = TorchIpcForwardReducer(mode, max_nbytes)
+
+    cupy = sys.modules.get("cupy")
+    if cupy is not None:
+        forward_reducers[cupy.ndarray] = CupyIpcForwardReducer(
+            mode, max_nbytes, resources_manager
+        )
+
+    return forward_reducers

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -9,6 +9,7 @@ import threading
 import warnings
 from abc import ABCMeta, abstractmethod
 
+from ._gpu_array_reducer import _resolve_share_gpu_arrays
 from ._multiprocessing_helpers import mp
 from ._utils import (
     _retrieve_traceback_capturing_wrapped_call,
@@ -589,6 +590,20 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin, ParallelBacken
             **memmapping_pool_kwargs,
         }
 
+        # Resolve the GPU array sharing mode here, before the pool (and its
+        # workers) are created. This ensures that an unsupported configuration
+        # (e.g. share_gpu_arrays='on' with the 'fork' start method) raises
+        # before any half-initialized pool is built.
+        context = memmapping_pool_kwargs.get("context", None)
+        if context is not None:
+            start_method = context.get_start_method()
+        else:
+            start_method = mp.get_start_method()
+        memmapping_pool_kwargs["share_gpu_arrays"] = _resolve_share_gpu_arrays(
+            memmapping_pool_kwargs.get("share_gpu_arrays", "auto"),
+            start_method,
+        )
+
         # Make sure to free as much memory as possible before forking
         gc.collect()
         self._pool = MemmappingPool(n_jobs, **memmapping_pool_kwargs)
@@ -716,6 +731,9 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
             self._workers._temp_folder_manager._clean_temporary_resources(
                 context_id=self.parallel._id, force=False
             )
+            # Release the GPU allocations that were kept alive on the producer
+            # side to share them with the workers during this Parallel call.
+            self._workers._gpu_resources_manager.clean(context_id=self.parallel._id)
             self._workers = None
 
         self.reset_batch_stats()

--- a/joblib/executor.py
+++ b/joblib/executor.py
@@ -8,6 +8,7 @@ copy between the parent and child processes.
 # Copyright: 2017, Thomas Moreau
 # License: BSD 3 clause
 
+from ._gpu_array_reducer import GpuResourcesManager, get_gpu_reducers
 from ._memmapping_reducer import TemporaryResourcesManager, get_memmapping_reducers
 from .externals.loky.reusable_executor import _ReusablePoolExecutor
 
@@ -37,6 +38,9 @@ class MemmappingExecutor(_ReusablePoolExecutor):
         global _executor_args
         # Check if we can reuse the executor here instead of deferring the test
         # to loky as the reducers are objects that changes at each call.
+        # ``share_gpu_arrays`` is part of the executor args so that a change of
+        # the GPU sharing mode forces the creation of a new executor (the GPU
+        # reducers, like the memmapping ones, persist across reused calls).
         executor_args = backend_args.copy()
         executor_args.update(env if env else {})
         executor_args.update(
@@ -45,7 +49,10 @@ class MemmappingExecutor(_ReusablePoolExecutor):
         reuse = _executor_args is None or _executor_args == executor_args
         _executor_args = executor_args
 
+        share_gpu_arrays = backend_args.pop("share_gpu_arrays", "auto")
+
         manager = TemporaryResourcesManager(temp_folder)
+        gpu_manager = GpuResourcesManager()
 
         # reducers access the temporary folder in which to store temporary
         # pickles through a call to manager.resolve_temp_folder_name. resolving
@@ -55,6 +62,17 @@ class MemmappingExecutor(_ReusablePoolExecutor):
             unlink_on_gc_collect=True,
             temp_folder_resolver=manager.resolve_temp_folder_name,
             **backend_args,
+        )
+
+        # Register the GPU array reducers (torch / cupy) on the forward queue,
+        # alongside the numpy memmapping reducers. The loky executor is always
+        # spawn-based, hence a safe (non-fork) start method for CUDA IPC.
+        get_gpu_reducers(
+            share_gpu_arrays,
+            max_nbytes=backend_args.get("max_nbytes", 1e6),
+            start_method=None,
+            forward_reducers=job_reducers,
+            resources_manager=gpu_manager,
         )
         _executor, executor_is_reused = super().get_reusable_executor(
             n_jobs,
@@ -73,6 +91,10 @@ class MemmappingExecutor(_ReusablePoolExecutor):
             # be re-assigned like that because it is referenced in various
             # places in the reducing machinery of the executor.
             _executor._temp_folder_manager = manager
+            # Likewise, the GPU resources manager is referenced by the GPU
+            # reducers installed on the (new) executor and must persist across
+            # reused calls.
+            _executor._gpu_resources_manager = gpu_manager
 
         if context_id is not None:
             # Only register the specified context once we know which manager

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -23,6 +23,7 @@ from multiprocessing import TimeoutError
 from numbers import Integral
 from uuid import uuid4
 
+from ._gpu_array_reducer import VALID_SHARE_GPU_ARRAYS
 from ._multiprocessing_helpers import mp
 
 # Make sure that those two classes are part of the public joblib.parallel API
@@ -99,6 +100,7 @@ default_parallel_config = {
     "temp_folder": _Sentinel(default_value=None),
     "max_nbytes": _Sentinel(default_value="1M"),
     "mmap_mode": _Sentinel(default_value="r"),
+    "share_gpu_arrays": _Sentinel(default_value="auto"),
     "prefer": _Sentinel(default_value=None),
     "require": _Sentinel(default_value=None),
 }
@@ -312,6 +314,26 @@ class parallel_config:
         https://numpy.org/doc/stable/reference/generated/numpy.memmap.html
         Also, see 'max_nbytes' parameter documentation for more details.
 
+    share_gpu_arrays: {'auto', 'on', 'off'}, default='auto'
+        Experimental. Control the sharing of GPU arrays (PyTorch tensors and
+        CuPy arrays) with worker processes through CUDA inter-process
+        communication (IPC), avoiding a copy through host memory. This is
+        the GPU counterpart of the numpy memmapping controlled by
+        ``max_nbytes`` / ``mmap_mode`` and is forward-only (parent to worker),
+        same-machine and same-GPU.
+
+        - 'auto': share device arrays larger than ``max_nbytes`` when a
+          spawn-based process backend is used; silently fall back to regular
+          (host round-trip) pickling otherwise.
+        - 'on': share every device array regardless of ``max_nbytes`` and
+          raise an error if sharing is requested but not feasible (e.g. the
+          ``fork`` start method, which is incompatible with CUDA).
+        - 'off': never share; all arrays use regular pickling.
+
+        Shared arrays must be treated as read-only inputs. Unlike numpy's
+        ``mmap_mode='r'``, this read-only contract is not enforced by the
+        framework.
+
     prefer: str in {'processes', 'threads'} or None, default=None
         Soft hint to choose the default backend.
         The default process-based backend is 'loky' and the default
@@ -369,6 +391,7 @@ class parallel_config:
         temp_folder=default_parallel_config["temp_folder"],
         max_nbytes=default_parallel_config["max_nbytes"],
         mmap_mode=default_parallel_config["mmap_mode"],
+        share_gpu_arrays=default_parallel_config["share_gpu_arrays"],
         prefer=default_parallel_config["prefer"],
         require=default_parallel_config["require"],
         inner_max_num_threads=None,
@@ -385,6 +408,7 @@ class parallel_config:
             "temp_folder": temp_folder,
             "max_nbytes": max_nbytes,
             "mmap_mode": mmap_mode,
+            "share_gpu_arrays": share_gpu_arrays,
             "prefer": prefer,
             "require": require,
             "backend": backend,
@@ -1105,6 +1129,25 @@ class Parallel(Logger):
         disable memmapping, other modes defined in the numpy.memmap doc:
         https://numpy.org/doc/stable/reference/generated/numpy.memmap.html
         Also, see 'max_nbytes' parameter documentation for more details.
+    share_gpu_arrays: {'auto', 'on', 'off'}, default='auto'
+        Experimental. Control the sharing of GPU arrays (PyTorch tensors and
+        CuPy arrays) with worker processes through CUDA inter-process
+        communication (IPC), avoiding a copy through host memory. This is the
+        GPU counterpart of the numpy memmapping controlled by ``max_nbytes`` /
+        ``mmap_mode`` and is forward-only (parent to worker), same-machine and
+        same-GPU.
+
+        - 'auto': share device arrays larger than ``max_nbytes`` when a
+          spawn-based process backend is used; silently fall back to regular
+          (host round-trip) pickling otherwise.
+        - 'on': share every device array regardless of ``max_nbytes`` and raise
+          an error if sharing is requested but not feasible (e.g. the ``fork``
+          start method, which is incompatible with CUDA).
+        - 'off': never share; all arrays use regular pickling.
+
+        Shared arrays must be treated as read-only inputs; unlike numpy's
+        ``mmap_mode='r'`` this read-only contract is not enforced. Only active
+        when ``backend="loky"`` or ``"multiprocessing"``.
     backend_kwargs: dict, optional
         Additional parameters to pass to the backend `configure` method.
 
@@ -1243,6 +1286,7 @@ class Parallel(Logger):
         temp_folder=default_parallel_config["temp_folder"],
         max_nbytes=default_parallel_config["max_nbytes"],
         mmap_mode=default_parallel_config["mmap_mode"],
+        share_gpu_arrays=default_parallel_config["share_gpu_arrays"],
         prefer=default_parallel_config["prefer"],
         require=default_parallel_config["require"],
         **backend_kwargs,
@@ -1285,12 +1329,19 @@ class Parallel(Logger):
                     (max_nbytes, "max_nbytes"),
                     (temp_folder, "temp_folder"),
                     (mmap_mode, "mmap_mode"),
+                    (share_gpu_arrays, "share_gpu_arrays"),
                     (prefer, "prefer"),
                     (require, "require"),
                     (verbose, "verbose"),
                 ]
             },
         }
+
+        if self._backend_kwargs["share_gpu_arrays"] not in VALID_SHARE_GPU_ARRAYS:
+            raise ValueError(
+                f"share_gpu_arrays={self._backend_kwargs['share_gpu_arrays']} is "
+                f"not valid, expected one of {VALID_SHARE_GPU_ARRAYS}"
+            )
 
         if isinstance(self._backend_kwargs["max_nbytes"], str):
             self._backend_kwargs["max_nbytes"] = memstr_to_bytes(
@@ -2039,9 +2090,12 @@ class Parallel(Logger):
                 # and the end of the BatchedCalls pickling. The reason is that
                 # pickling (the only place where set_current_context is used)
                 # is done from a single thread (the queue_feeder_thread).
-                self._backend._workers._temp_folder_manager.set_current_context(  # noqa
-                    self._id
-                )
+                workers = self._backend._workers
+                workers._temp_folder_manager.set_current_context(self._id)
+                # Mirror the context for GPU array sharing so that allocations
+                # shared by this Parallel call are anchored under its own id and
+                # released when this call terminates.
+                workers._gpu_resources_manager.set_current_context(self._id)
 
             self._reducer_callback = _batched_calls_reducer_callback
 

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -30,6 +30,7 @@ from io import BytesIO
 from multiprocessing.pool import Pool
 from pickle import HIGHEST_PROTOCOL, Pickler
 
+from ._gpu_array_reducer import GpuResourcesManager, get_gpu_reducers
 from ._memmapping_reducer import TemporaryResourcesManager, get_memmapping_reducers
 from ._multiprocessing_helpers import assert_spawning, mp
 
@@ -294,6 +295,7 @@ class MemmappingPool(PicklingPool):
         temp_folder=None,
         max_nbytes=1e6,
         mmap_mode="r",
+        share_gpu_arrays="auto",
         forward_reducers=None,
         backward_reducers=None,
         verbose=0,
@@ -302,6 +304,7 @@ class MemmappingPool(PicklingPool):
     ):
         manager = TemporaryResourcesManager(temp_folder)
         self._temp_folder_manager = manager
+        self._gpu_resources_manager = GpuResourcesManager(context_id=manager._id)
 
         # The usage of a temp_folder_resolver over a simple temp_folder is
         # superfluous for multiprocessing pools, as they don't get reused, see
@@ -316,6 +319,22 @@ class MemmappingPool(PicklingPool):
             verbose=verbose,
             unlink_on_gc_collect=False,
             prewarm=prewarm,
+        )
+
+        # Register the GPU array reducers (torch / cupy) on the forward queue.
+        # GPU sharing via CUDA IPC requires a non-fork start method, so detect
+        # the start method of the multiprocessing context being used.
+        context = kwargs.get("context", None)
+        if context is not None:
+            start_method = context.get_start_method()
+        else:
+            start_method = mp.get_start_method()
+        get_gpu_reducers(
+            share_gpu_arrays,
+            max_nbytes=max_nbytes,
+            start_method=start_method,
+            forward_reducers=forward_reducers,
+            resources_manager=self._gpu_resources_manager,
         )
 
         poolargs = dict(
@@ -345,6 +364,8 @@ class MemmappingPool(PicklingPool):
 
         # Clean up the temporary resources as the workers should now be off.
         self._temp_folder_manager._clean_temporary_resources()
+        # Release any GPU allocations shared with the (now terminated) workers.
+        self._gpu_resources_manager.clean()
 
     @property
     def _temp_folder(self):

--- a/joblib/test/common.py
+++ b/joblib/test/common.py
@@ -82,3 +82,41 @@ with_dev_shm = skipif(
 with_lz4 = skipif(lz4 is None, reason="Needs lz4 compression to run")
 
 without_lz4 = skipif(lz4 is not None, reason="Needs lz4 not being installed to run")
+
+
+# Decorators to run tests only when a GPU array framework is available together
+# with a CUDA-capable device, used to test the GPU array sharing feature.
+try:
+    import torch
+
+    try:
+        _torch_cuda_available = (
+            torch.cuda.is_available() and torch.cuda.device_count() > 0
+        )
+    except Exception:
+        _torch_cuda_available = False
+except ImportError:
+    torch = None
+    _torch_cuda_available = False
+
+try:
+    import cupy
+
+    try:
+        _cupy_cuda_available = cupy.cuda.runtime.getDeviceCount() > 0
+    except Exception:
+        _cupy_cuda_available = False
+except ImportError:
+    cupy = None
+    _cupy_cuda_available = False
+
+
+with_torch_cuda = skipif(
+    not _torch_cuda_available,
+    reason="Test requires PyTorch with a CUDA-capable GPU.",
+)
+
+with_cupy = skipif(
+    not _cupy_cuda_available,
+    reason="Test requires CuPy with a CUDA-capable GPU.",
+)

--- a/joblib/test/test_gpu_memmapping.py
+++ b/joblib/test/test_gpu_memmapping.py
@@ -1,0 +1,417 @@
+"""Tests for sharing GPU arrays across processes via CUDA IPC.
+
+The tests in this file are split in two groups:
+
+- Hardware-independent unit tests for the sharing-mode resolution, the reducer
+  registration and the producer-side resource manager. These run everywhere,
+  including CI without a GPU.
+- Hardware-gated integration tests (marked with ``with_torch_cuda`` /
+  ``with_cupy``) that actually share GPU arrays with worker processes and check
+  that the sharing is zero-copy.
+"""
+
+import gc
+import warnings
+import weakref
+
+import pytest
+
+from joblib import Parallel, delayed
+from joblib._gpu_array_reducer import (
+    CupyIpcForwardReducer,
+    GpuResourcesManager,
+    _rebuild_cupy_ipc_array,
+    _resolve_share_gpu_arrays,
+    check_share_gpu_arrays,
+    get_gpu_reducers,
+)
+from joblib._multiprocessing_helpers import mp
+from joblib.test.common import (
+    with_cupy,
+    with_multiprocessing,
+    with_torch_cuda,
+)
+from joblib.testing import parametrize, raises, warns
+
+_START_METHODS = mp.get_all_start_methods() if mp is not None else []
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+try:
+    import cupy
+except ImportError:
+    cupy = None
+
+
+###############################################################################
+# Hardware-independent unit tests
+
+
+@parametrize("mode", ["auto", "on", "off"])
+def test_check_share_gpu_arrays_valid(mode):
+    assert check_share_gpu_arrays(mode) == mode
+
+
+def test_check_share_gpu_arrays_invalid():
+    with raises(ValueError, match="share_gpu_arrays"):
+        check_share_gpu_arrays("bogus")
+
+
+@parametrize("mode", ["auto", "on", "off"])
+def test_resolve_spawn_is_identity(mode):
+    # With a safe start method, the mode is preserved.
+    assert _resolve_share_gpu_arrays(mode, start_method="spawn") == mode
+    assert _resolve_share_gpu_arrays(mode, start_method=None) == mode
+
+
+def test_resolve_off_with_fork_is_silent():
+    # "off" never warns, regardless of the start method.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _resolve_share_gpu_arrays("off", start_method="fork") == "off"
+
+
+def test_resolve_auto_with_fork_falls_back_with_warning():
+    with warns(UserWarning, match="fork"):
+        assert _resolve_share_gpu_arrays("auto", start_method="fork") == "off"
+
+
+def test_resolve_on_with_fork_raises():
+    with raises(ValueError, match="fork"):
+        _resolve_share_gpu_arrays("on", start_method="fork")
+
+
+def test_get_gpu_reducers_off_registers_nothing():
+    reducers = get_gpu_reducers("off", start_method="spawn")
+    assert reducers == {}
+
+
+def test_get_gpu_reducers_fork_on_raises():
+    with raises(ValueError, match="fork"):
+        get_gpu_reducers("on", start_method="fork")
+
+
+def test_get_gpu_reducers_fork_auto_registers_nothing():
+    with warns(UserWarning, match="fork"):
+        reducers = get_gpu_reducers("auto", start_method="fork")
+    assert reducers == {}
+
+
+@pytest.mark.skipif(torch is None, reason="requires torch")
+def test_get_gpu_reducers_registers_torch():
+    reducers = get_gpu_reducers("auto", start_method="spawn")
+    assert torch.Tensor in reducers
+
+
+@pytest.mark.skipif(cupy is None, reason="requires cupy")
+def test_get_gpu_reducers_registers_cupy():
+    reducers = get_gpu_reducers("auto", start_method="spawn")
+    assert cupy.ndarray in reducers
+
+
+def test_get_gpu_reducers_updates_existing_dict():
+    existing = {int: "sentinel"}
+    reducers = get_gpu_reducers("auto", start_method="spawn", forward_reducers=existing)
+    assert reducers is existing
+    assert existing[int] == "sentinel"
+
+
+def test_gpu_resources_manager_anchor_and_clean():
+    manager = GpuResourcesManager()
+    manager.set_current_context("ctx-a")
+
+    class _Dummy:
+        pass
+
+    a = _Dummy()
+    manager.anchor(a)
+    ref = weakref.ref(a)
+    del a
+
+    manager.set_current_context("ctx-b")
+    b = _Dummy()
+    manager.anchor(b)
+
+    # The anchor for ctx-a keeps the object alive even after dropping our ref.
+    gc.collect()
+    assert ref() is not None
+
+    # Cleaning ctx-a releases its anchors; ctx-b is untouched.
+    manager.clean("ctx-a")
+    gc.collect()
+    assert ref() is None
+    assert manager._anchors.get("ctx-b") == [b]
+
+    manager.clean()
+    assert manager._anchors == {}
+
+
+###############################################################################
+# Hardware-gated integration tests: PyTorch
+
+
+def _torch_probe_and_add(tensor, value):
+    """Worker function: report tensor info and mutate it in place."""
+    info = {
+        "is_cuda": bool(tensor.is_cuda),
+        "device": int(tensor.device.index) if tensor.is_cuda else -1,
+    }
+    if tensor.is_cuda:
+        tensor.add_(value)
+        torch.cuda.synchronize()
+    return info
+
+
+@with_multiprocessing
+@with_torch_cuda
+def test_torch_cuda_tensor_shared_in_place():
+    # 512x512 float32 = 1 MiB > default max_nbytes (1e6), 'on' forces sharing.
+    x = torch.zeros(512, 512, device="cuda:0")
+    out = Parallel(n_jobs=2, backend="loky", share_gpu_arrays="on")(
+        delayed(_torch_probe_and_add)(x, 1.0) for _ in range(1)
+    )
+    torch.cuda.synchronize()
+
+    assert out[0]["is_cuda"]
+    assert out[0]["device"] == 0
+    # Zero-copy sharing: the worker's in-place mutation is visible in the
+    # parent process (a host copy would not propagate back).
+    assert float(x.sum().item()) == x.numel()
+
+
+@with_multiprocessing
+@with_torch_cuda
+def test_torch_cuda_tensor_not_shared_when_off():
+    x = torch.zeros(512, 512, device="cuda:0")
+    out = Parallel(n_jobs=2, backend="loky", share_gpu_arrays="off")(
+        delayed(_torch_probe_and_add)(x, 1.0) for _ in range(1)
+    )
+    torch.cuda.synchronize()
+
+    # The worker still receives a CUDA tensor, but via a (host round-trip) copy.
+    assert out[0]["is_cuda"]
+    assert float(x.sum().item()) == 0.0
+
+
+@with_multiprocessing
+@with_torch_cuda
+def test_torch_cuda_auto_threshold():
+    # Large array (> max_nbytes) is shared in auto mode.
+    big = torch.zeros(512, 512, device="cuda:0")
+    Parallel(n_jobs=2, backend="loky", share_gpu_arrays="auto", max_nbytes=1000)(
+        delayed(_torch_probe_and_add)(big, 1.0) for _ in range(1)
+    )
+    torch.cuda.synchronize()
+    assert float(big.sum().item()) == big.numel()
+
+    # Small array (<= max_nbytes) is not shared in auto mode.
+    small = torch.zeros(8, device="cuda:0")
+    Parallel(
+        n_jobs=2, backend="loky", share_gpu_arrays="auto", max_nbytes=10_000_000
+    )(delayed(_torch_probe_and_add)(small, 1.0) for _ in range(1))
+    torch.cuda.synchronize()
+    assert float(small.sum().item()) == 0.0
+
+
+@with_multiprocessing
+@with_torch_cuda
+def test_torch_cpu_tensor_falls_back():
+    # CPU tensors are never IPC-shared, even in 'on' mode; they are passed
+    # through regular pickling and not mutated in the parent.
+    x = torch.zeros(512, 512)
+    out = Parallel(n_jobs=2, backend="loky", share_gpu_arrays="on")(
+        delayed(_torch_probe_and_add)(x, 1.0) for _ in range(1)
+    )
+    assert not out[0]["is_cuda"]
+    assert float(x.sum().item()) == 0.0
+
+
+###############################################################################
+# Hardware-gated integration tests: CuPy
+
+
+def _cupy_probe_and_add(array, value):
+    """Worker function: report array info and mutate it in place."""
+    info = {
+        "device": int(array.device.id),
+        "shape": tuple(array.shape),
+        "dtype": array.dtype.str,
+    }
+    array += value
+    cupy.cuda.Stream.null.synchronize()
+    return info
+
+
+@with_multiprocessing
+@with_cupy
+def test_cupy_array_shared_in_place():
+    with cupy.cuda.Device(0):
+        x = cupy.zeros((512, 512), dtype=cupy.float32)  # 1 MiB
+    out = Parallel(n_jobs=2, backend="loky", share_gpu_arrays="on")(
+        delayed(_cupy_probe_and_add)(x, 1.0) for _ in range(1)
+    )
+    cupy.cuda.Device(0).synchronize()
+
+    assert out[0]["device"] == 0
+    # Zero-copy sharing: the worker's in-place mutation is visible in the parent.
+    assert float(x.sum().get()) == x.size
+
+
+@with_multiprocessing
+@with_cupy
+def test_cupy_array_not_shared_when_off():
+    with cupy.cuda.Device(0):
+        x = cupy.zeros((512, 512), dtype=cupy.float32)
+    out = Parallel(n_jobs=2, backend="loky", share_gpu_arrays="off")(
+        delayed(_cupy_probe_and_add)(x, 1.0) for _ in range(1)
+    )
+    cupy.cuda.Device(0).synchronize()
+
+    assert out[0]["device"] == 0
+    assert float(x.sum().get()) == 0.0
+
+
+@with_multiprocessing
+@with_cupy
+def test_cupy_auto_threshold():
+    with cupy.cuda.Device(0):
+        big = cupy.zeros((512, 512), dtype=cupy.float32)
+    Parallel(n_jobs=2, backend="loky", share_gpu_arrays="auto", max_nbytes=1000)(
+        delayed(_cupy_probe_and_add)(big, 1.0) for _ in range(1)
+    )
+    cupy.cuda.Device(0).synchronize()
+    assert float(big.sum().get()) == big.size
+
+    with cupy.cuda.Device(0):
+        small = cupy.zeros((8,), dtype=cupy.float32)
+    Parallel(
+        n_jobs=2, backend="loky", share_gpu_arrays="auto", max_nbytes=10_000_000
+    )(delayed(_cupy_probe_and_add)(small, 1.0) for _ in range(1))
+    cupy.cuda.Device(0).synchronize()
+    assert float(small.sum().get()) == 0.0
+
+
+###############################################################################
+# Hardware-gated integration tests: CuPy producer-side lifetime
+
+
+@with_cupy
+def test_cupy_reducer_anchors_source_memory():
+    manager = GpuResourcesManager(context_id="ctx")
+    reducer = CupyIpcForwardReducer("on", max_nbytes=0, resources_manager=manager)
+
+    with cupy.cuda.Device(0):
+        x = cupy.ones((256, 256), dtype=cupy.float32)
+
+    rebuild, args = reducer(x)
+
+    # The reducer produced an IPC payload and anchored the source allocation
+    # under the current context so it stays alive while workers map it.
+    assert rebuild is _rebuild_cupy_ipc_array
+    assert manager._anchors["ctx"], "source memory was not anchored"
+
+    # Cleaning the context releases the producer-side keep-alive.
+    manager.clean("ctx")
+    assert "ctx" not in manager._anchors
+
+
+@with_multiprocessing
+@with_cupy
+def test_cupy_sharing_repeated_calls():
+    # Repeated calls reuse the loky executor; the per-call anchoring and
+    # cleanup must keep working without leaking handles or stale allocations.
+    for _ in range(3):
+        with cupy.cuda.Device(0):
+            x = cupy.zeros((512, 512), dtype=cupy.float32)
+        Parallel(n_jobs=2, backend="loky", share_gpu_arrays="on")(
+            delayed(_cupy_probe_and_add)(x, 1.0) for _ in range(1)
+        )
+        cupy.cuda.Device(0).synchronize()
+        assert float(x.sum().get()) == x.size
+        del x
+
+
+@with_multiprocessing
+@with_cupy
+def test_cupy_anchors_released_after_call():
+    with cupy.cuda.Device(0):
+        x = cupy.ones((512, 512), dtype=cupy.float32)
+
+    p = Parallel(n_jobs=2, backend="loky", share_gpu_arrays="on")
+    p(delayed(_cupy_probe_and_add)(x, 0.0) for _ in range(1))
+
+    # Recover the (reused) executor's GPU manager and check the anchors created
+    # for this Parallel call were released on termination.
+    probe = Parallel(n_jobs=2, backend="loky", share_gpu_arrays="on")
+    probe._initialize_backend()
+    try:
+        gpu_manager = probe._backend._workers._gpu_resources_manager
+        assert p._id not in gpu_manager._anchors
+    finally:
+        probe._backend.terminate()
+
+
+###############################################################################
+# Cross-backend behavior
+
+
+@with_multiprocessing
+@with_cupy
+def test_multiprocessing_spawn_shares():
+    spawn_ctx = mp.get_context("spawn")
+    with cupy.cuda.Device(0):
+        x = cupy.zeros((512, 512), dtype=cupy.float32)
+    Parallel(n_jobs=2, backend=spawn_ctx, share_gpu_arrays="on")(
+        delayed(_cupy_probe_and_add)(x, 1.0) for _ in range(1)
+    )
+    cupy.cuda.Device(0).synchronize()
+    assert float(x.sum().get()) == x.size
+
+
+@with_multiprocessing
+@pytest.mark.skipif(
+    "fork" not in _START_METHODS,
+    reason="requires the fork start method",
+)
+def test_multiprocessing_fork_on_raises():
+    # 'on' mode must refuse to run on a fork-based context (CUDA cannot survive
+    # a fork). This does not require a GPU: the error is raised when building
+    # the pool, before any worker is forked.
+    fork_ctx = mp.get_context("fork")
+    with raises(ValueError, match="fork"):
+        Parallel(n_jobs=2, backend=fork_ctx, share_gpu_arrays="on")(
+            delayed(abs)(i) for i in range(2)
+        )
+
+
+@with_multiprocessing
+@pytest.mark.skipif(
+    "fork" not in _START_METHODS,
+    reason="requires the fork start method",
+)
+def test_multiprocessing_fork_auto_falls_back_with_warning():
+    fork_ctx = mp.get_context("fork")
+    with warns(UserWarning, match="fork"):
+        out = Parallel(n_jobs=2, backend=fork_ctx, share_gpu_arrays="auto")(
+            delayed(abs)(i) for i in range(-3, 0)
+        )
+    assert out == [3, 2, 1]
+
+
+def test_threading_ignores_share_gpu_arrays():
+    # Threads share memory directly, so GPU sharing is a transparent no-op and
+    # must not interfere with the threading backend.
+    out = Parallel(n_jobs=2, backend="threading", share_gpu_arrays="on")(
+        delayed(abs)(i) for i in range(-3, 0)
+    )
+    assert out == [3, 2, 1]
+
+
+def test_sequential_ignores_share_gpu_arrays():
+    out = Parallel(n_jobs=1, share_gpu_arrays="on")(
+        delayed(abs)(i) for i in range(-3, 0)
+    )
+    assert out == [3, 2, 1]

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -763,6 +763,43 @@ def test_invalid_backend():
             pass
 
 
+def test_gpu_arrays_flag_default():
+    # By default, GPU array sharing is in "auto" mode and threaded through
+    # to the backend kwargs alongside max_nbytes / mmap_mode / temp_folder.
+    p = Parallel()
+    assert p._backend_kwargs["share_gpu_arrays"] == "auto"
+
+
+@parametrize("value", ["auto", "on", "off"])
+def test_gpu_arrays_flag_explicit(value):
+    p = Parallel(share_gpu_arrays=value)
+    assert p._backend_kwargs["share_gpu_arrays"] == value
+
+
+@parametrize("value", ["auto", "on", "off"])
+def test_gpu_arrays_flag_via_parallel_config(value):
+    with parallel_config(share_gpu_arrays=value):
+        p = Parallel()
+        assert p._backend_kwargs["share_gpu_arrays"] == value
+
+
+def test_gpu_arrays_flag_explicit_overrides_context():
+    with parallel_config(share_gpu_arrays="off"):
+        p = Parallel(share_gpu_arrays="on")
+        assert p._backend_kwargs["share_gpu_arrays"] == "on"
+
+
+def test_invalid_gpu_arrays_flag():
+    with raises(ValueError, match="share_gpu_arrays"):
+        Parallel(share_gpu_arrays="bogus")
+
+    # Like prefer/require, an invalid value set through the context manager is
+    # validated when a Parallel object is built under it, not at context entry.
+    with parallel_config(share_gpu_arrays="bogus"):
+        with raises(ValueError, match="share_gpu_arrays"):
+            Parallel()
+
+
 @parametrize("backend", ALL_VALID_BACKENDS)
 def test_invalid_njobs(backend):
     with raises(ValueError) as excinfo:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,16 @@ test = [
     "threadpoolctl",
 ]
 
+# Optional dependencies to exercise the GPU array sharing tests. These require a
+# CUDA-capable GPU and are skipped when the libraries are not installed. The
+# CuPy wheel must match your local CUDA toolkit (e.g. ``cupy-cuda12x``).
+# XXX Is there a better way to document this? You can't just
+# XXX `pip install .[gpu_test]` because of the -cuda12 suffix
+gpu_test = [
+    "torch",
+    "cupy",
+]
+
 docs = [
     "distributed",
     "lz4",


### PR DESCRIPTION
This adds the possibility to share torch/cupy arrays amongst the worker processes of a `Parallel()`. This is similar in spirit to the memmapping performed for Numpy arrays, but it isn't really memmapping. The goal is to have multiple scikit-learn estimators that are being fitted in parallel on the GPU without having multiple copies of `X` on the GPU.

Sharing between processes is a bit tricky, so there doesn't seem to be a good way to do it in a totally library agnostic way. As a result this PR contains code for torch tensors and cupy arrays, but not also jax (we'd have to add it).

The basic idea is to register custom reducers for cupy and torch. They take care of packaging up things and sending only a small amount of data to each of the worker processes. Torch has existing infrastructure for this, which this PR reuses. For cupy we have to do much more ourselves.

I asked AI to research the topic, then read about it and then asked it to implement a solution. As a waste product we get a lot of tests and some docs. This makes the diff quite big, but I think it is kind of useful. The reason I made a PR directly is that I think having the code can be interesting to discuss things, and I already had it. The docstrings and comments are a bit verbose, it might be worth editing/reducing them before merging. They are kinda useful to understand what is going on though, so I kept them for now.

I asked for the `joblib.parallel_config(share_gpu_arrays="on")` config option so that it is easy to toggle between `"auto"` (arrays are shared if possible, my preference for the default), `"on"` (arrays have to be shared, if not possible an exception is raised) and `"off"` (arrays are never shared).

I added a basic example that uses scikit-learn's `GridSearchCV` to use the new feature. Though it is a bit difficult to tell that it is working (based on the example) :-/

Based on a discussion with @tomMoral a few weeks ago at the scikit-learn maintainer meeting.

What do you all think?