### PR TITLE
Fix eval_expr to raise ValueError on division by zero

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Release Notes
 In development
 --------------
 
+- Fix ``eval_expr`` (used to evaluate the ``pre_dispatch`` argument of
+  ``Parallel``) to raise a ``ValueError`` as documented instead of leaking a
+  ``ZeroDivisionError`` for expressions that divide or take a modulo by zero.
+  https://github.com/joblib/joblib/pull/1810
+
 - ``MemorizedResult`` now forwards ``mmap_mode`` to its store backend, so a
   cached array reconstructed from a location is memory-mapped as requested
   instead of being loaded fully into memory.

--- a/joblib/_utils.py
+++ b/joblib/_utils.py
@@ -47,7 +47,7 @@ def eval_expr(expr):
         )
     try:
         return eval_(ast.parse(expr, mode="eval").body)
-    except (TypeError, SyntaxError, OverflowError, KeyError) as e:
+    except (TypeError, SyntaxError, OverflowError, KeyError, ZeroDivisionError) as e:
         raise ValueError(
             f"{expr!r} is not a valid or supported arithmetic expression."
         ) from e

--- a/joblib/test/test_utils.py
+++ b/joblib/test/test_utils.py
@@ -13,6 +13,9 @@ from joblib._utils import eval_expr
         "1^1",
         "' ' * 10**10",
         "9. ** 10000.",
+        "1/0",
+        "1//0",
+        "1%0",
     ],
 )
 def test_eval_expr_invalid(expr):


### PR DESCRIPTION
`eval_expr` is documented to "Raise ValueError if the expression is invalid", and it's used to evaluate the `pre_dispatch` argument of `Parallel` (e.g. `Parallel(pre_dispatch="2*n_jobs")`). It catches `TypeError`, `SyntaxError`, `OverflowError` and `KeyError`, but not `ZeroDivisionError`, so an expression that divides or takes a modulo by zero leaks the raw error instead of the documented `ValueError`:

```Python
from joblib._utils import eval_expr

eval_expr("1/0")   # ZeroDivisionError: division by zero
```
This catches `ZeroDivisionError` as well, so 1/0, 1//0 and 1%0 now raise the documented `ValueError`. Added those cases to `test_eval_expr_invalid` and a `CHANGES.rst` entry.