### PR TITLE
fix: accept any os.PathLike in dump() and load(), not just pathlib.Path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,8 +23,12 @@ In development
 - Fix a concurrency error that could happen with unordered generator.
   https://github.com/joblib/joblib/pull/1789
 
-- The documentation now uses pydata sphinx theme. Furthermore, optional dependencies ``test``
-  and ``docs`` have been added to ``pyproject.toml``.
+- Fix: ``dump()`` now accepts any input ``os.PathLike`` object to be consistent with
+  ``load``.
+  https://github.com/joblib/joblib/pull/1812
+
+- The documentation now uses pydata sphinx theme. Furthermore, optional dependencies
+  ``test`` and ``docs`` have been added to ``pyproject.toml``.
   https://github.com/joblib/joblib/pull/1774
 
 Release 1.5.3 - 2025/12/15

--- a/joblib/logger.py
+++ b/joblib/logger.py
@@ -32,11 +32,40 @@ def _squeeze_time(t):
 
 
 def format_time(t):
+    """Format a duration in seconds as a human-readable string.
+
+    Returns both seconds and minutes, e.g. ``'12.3s, 0.2min'``.
+
+    Parameters
+    ----------
+    t : float
+        Duration in seconds.
+
+    Returns
+    -------
+    str
+        Formatted string showing the duration in seconds and minutes.
+    """
     t = _squeeze_time(t)
     return "%.1fs, %.1fmin" % (t, t / 60.0)
 
 
 def short_format_time(t):
+    """Format a duration in seconds as a compact human-readable string.
+
+    Returns minutes for durations over 60 seconds, otherwise seconds.
+
+    Parameters
+    ----------
+    t : float
+        Duration in seconds.
+
+    Returns
+    -------
+    str
+        Formatted string: ``' 42.0s'`` for short durations or
+        ``' 1.2min'`` for longer ones.
+    """
     t = _squeeze_time(t)
     if t > 60:
         return "%4.1fmin" % (t / 60.0)
@@ -45,6 +74,25 @@ def short_format_time(t):
 
 
 def pformat(obj, indent=0, depth=3):
+    """Return a pretty-printed string representation of an object.
+
+    Uses :func:`pprint.pformat` with numpy print options temporarily
+    reduced to keep output concise when numpy is available.
+
+    Parameters
+    ----------
+    obj : object
+        The object to format.
+    indent : int, optional
+        Indentation level passed to :func:`pprint.pformat`. Default is 0.
+    depth : int, optional
+        Maximum nesting depth passed to :func:`pprint.pformat`. Default is 3.
+
+    Returns
+    -------
+    str
+        Pretty-printed string representation of ``obj``.
+    """
     if "numpy" in sys.modules:
         import numpy as np
 

--- a/joblib/logger.py
+++ b/joblib/logger.py
@@ -32,40 +32,11 @@ def _squeeze_time(t):
 
 
 def format_time(t):
-    """Format a duration in seconds as a human-readable string.
-
-    Returns both seconds and minutes, e.g. ``'12.3s, 0.2min'``.
-
-    Parameters
-    ----------
-    t : float
-        Duration in seconds.
-
-    Returns
-    -------
-    str
-        Formatted string showing the duration in seconds and minutes.
-    """
     t = _squeeze_time(t)
     return "%.1fs, %.1fmin" % (t, t / 60.0)
 
 
 def short_format_time(t):
-    """Format a duration in seconds as a compact human-readable string.
-
-    Returns minutes for durations over 60 seconds, otherwise seconds.
-
-    Parameters
-    ----------
-    t : float
-        Duration in seconds.
-
-    Returns
-    -------
-    str
-        Formatted string: ``' 42.0s'`` for short durations or
-        ``' 1.2min'`` for longer ones.
-    """
     t = _squeeze_time(t)
     if t > 60:
         return "%4.1fmin" % (t / 60.0)
@@ -74,25 +45,6 @@ def short_format_time(t):
 
 
 def pformat(obj, indent=0, depth=3):
-    """Return a pretty-printed string representation of an object.
-
-    Uses :func:`pprint.pformat` with numpy print options temporarily
-    reduced to keep output concise when numpy is available.
-
-    Parameters
-    ----------
-    obj : object
-        The object to format.
-    indent : int, optional
-        Indentation level passed to :func:`pprint.pformat`. Default is 0.
-    depth : int, optional
-        Maximum nesting depth passed to :func:`pprint.pformat`. Default is 3.
-
-    Returns
-    -------
-    str
-        Pretty-printed string representation of ``obj``.
-    """
     if "numpy" in sys.modules:
         import numpy as np
 

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -486,7 +486,7 @@ def dump(value, filename, compress=0, protocol=None):
     ----------
     value: any Python object
         The object to store to disk.
-    filename: str, pathlib.Path, or file object.
+    filename: str, os.PathLike, or file object.
         The file object or path of the file in which it is to be stored.
         The compression method corresponding to one of the supported filename
         extensions ('.z', '.gz', '.bz2', '.xz' or '.lzma') will be used
@@ -688,7 +688,7 @@ def load(filename, mmap_mode=None, ensure_native_byte_order="auto"):
 
     Parameters
     ----------
-    filename: str, pathlib.Path, or file object.
+    filename: str, os.PathLike, or file object.
         The file object or path of the file from which to load the object
     mmap_mode: {None, 'r+', 'r', 'w+', 'c'}, optional
         If not None, the arrays are memory-mapped from the disk. This

--- a/joblib/numpy_pickle.py
+++ b/joblib/numpy_pickle.py
@@ -8,7 +8,6 @@ import io
 import os
 import pickle
 import warnings
-from pathlib import Path
 
 from .backports import make_memmap
 from .compressor import (
@@ -524,8 +523,8 @@ def dump(value, filename, compress=0, protocol=None):
 
     """
 
-    if Path is not None and isinstance(filename, Path):
-        filename = str(filename)
+    if isinstance(filename, os.PathLike):
+        filename = os.fspath(filename)
 
     is_filename = isinstance(filename, str)
     is_fileobj = hasattr(filename, "write")
@@ -730,8 +729,8 @@ def load(filename, mmap_mode=None, ensure_native_byte_order="auto"):
             f"is set to None, but got 'mmap_mode={mmap_mode}' instead."
         )
 
-    if Path is not None and isinstance(filename, Path):
-        filename = str(filename)
+    if isinstance(filename, os.PathLike):
+        filename = os.fspath(filename)
 
     if hasattr(filename, "read"):
         fobj = filename

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -1018,6 +1018,23 @@ def test_pathlib(tmpdir):
     assert numpy_pickle.load(Path(filename)) == value
 
 
+def test_dump_and_load_accept_os_pathlike(tmpdir):
+    # dump() previously only accepted str and pathlib.Path, rejecting any
+    # other os.PathLike (e.g. BIDSPath from mne-bids). load() already worked
+    # because open() accepts os.PathLike; this test ensures both are consistent.
+    class CustomPath(os.PathLike):
+        def __init__(self, path):
+            self._path = path
+
+        def __fspath__(self):
+            return str(self._path)
+
+    path = CustomPath(tmpdir.join("test_pathlike.pkl").strpath)
+    value = {"key": [1, 2, 3]}
+    numpy_pickle.dump(value, path)
+    assert numpy_pickle.load(path) == value
+
+
 @with_numpy
 def test_non_contiguous_array_pickling(tmpdir):
     filename = tmpdir.join("test.pkl").strpath


### PR DESCRIPTION
Fixes #1784.

`dump()` converted the filename to a string only when `isinstance(filename, pathlib.Path)`. Any other path-like object — such as `BIDSPath` from mne-bids, or any custom class implementing `__fspath__` — fell through to the `is_filename` check, failed it, and raised:

```
ValueError: Second argument should be a filename or a file-like object, ...
```

This was inconsistent with `load()`, which passed non-Path path-likes straight to `open()`, which accepts any `os.PathLike`.

**Fix:** Replace both `isinstance(filename, Path)` guards with `isinstance(filename, os.PathLike)` and convert via `os.fspath()`. This is the standard Python protocol for path-like objects. Remove the now-unused `from pathlib import Path` import.

**What changed:**
- `joblib/numpy_pickle.py` — two `isinstance(filename, Path)` → `isinstance(filename, os.PathLike)` with `os.fspath()`; removed unused `Path` import
- `joblib/test/test_numpy_pickle.py` — added `test_dump_and_load_accept_os_pathlike` using a minimal custom `os.PathLike` class (no external dependency needed)

Both `test_pathlib` (existing) and the new test pass.