### PR TITLE
DOC clarify dump/load scope in doc and SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,14 +7,32 @@
 | 1.5.3         | :white_check_mark: |
 | < 1.5.3       | :x:                |
 
+## Scope
+
+Joblib focuses on **parallelism, caching, and distributed computation**. Its
+persistence layer is built on Python's `pickle` and is designed for **trusted
+environments only** — see the
+[persistence documentation](https://joblib.readthedocs.io/en/stable/persistence.html#security-considerations)
+for the full security rationale and recommendations.
+
+**Out of scope:**
+
+- Any report whose exploit requires an attacker-controlled `.joblib` file
+  (RCE via pickle, scanner bypass, DoS from crafted files, path traversal via
+  pickle data). Joblib does not sandbox pickle deserialization — this is a
+  Python language-level property, not a bug.
+- Any report whose exploit requires the attacker to already control Python
+  function attributes (e.g. `__module__`, `__qualname__`) or process
+  environment variables (e.g. `LOKY_PICKLER`). Controlling these implies code
+  execution by other means, so the reported issue is not an escalation.
+
+**In scope:** issues exploitable through normal, trusted use of the public API
+without a malicious file — e.g. path traversal or injection driven purely by
+user-supplied function arguments to `Memory`.
+
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities by opening a new [GitHub security
-advisory](https://github.com/joblib/joblib/security/advisories/new).
-
-You can also send an email to `joblib-security@scikit-learn.org`, which is an
-alias to a subset of the joblib maintainers' team.
-
-If the security vulnerability is accepted, a patch will be crafted privately
-in order to prepare a dedicated bugfix release as timely as possible (depending
-on the complexity of the fix).
+Please open a [GitHub security advisory](https://github.com/joblib/joblib/security/advisories/new)
+or email `joblib-security@scikit-learn.org` (an alias to a subset of the
+maintainers). Accepted reports will be patched privately before a dedicated
+bugfix release.

--- a/doc/user_guide/persistence.rst
+++ b/doc/user_guide/persistence.rst
@@ -13,15 +13,57 @@ Use case
 pickle to work efficiently on arbitrary Python objects containing large data,
 in particular large numpy arrays.
 
+.. _persistence_security:
+
+Security considerations
+=======================
+
+**Joblib's persistence layer is designed for trusted environments.**
+It is intended for use cases such as caching intermediate results, sharing
+objects between worker processes, or checkpointing long computations — all
+situations where the file was written by your own code or by collaborators
+you control.
+
 .. warning::
 
-  :func:`joblib.dump` and :func:`joblib.load` are based on the Python pickle
-  serialization model, which means that arbitrary Python code can be executed
-  when loading a serialized object with :func:`joblib.load`.
+  :func:`joblib.dump` and :func:`joblib.load` are built on Python's
+  :mod:`pickle` protocol, which can execute **arbitrary Python code** during
+  deserialization. Loading a file from an untrusted source is equivalent to
+  running untrusted code. This is a fundamental property of pickle, not a
+  joblib-specific bug.
 
-  :func:`joblib.load` should therefore never be used to load objects from an
-  untrusted source or otherwise you will introduce a security vulnerability in
-  your program.
+  **Never call** :func:`joblib.load` on a file you did not produce yourself
+  or that came from a source you do not fully trust.
+
+Scope of joblib's security guarantees
+--------------------------------------
+
+Joblib focuses on **parallelism, caching, and distributed computation**.
+It does not aim to be a safe model-exchange format. Consequently:
+
+- Joblib **will not** attempt to sandbox or restrict what pickle can
+  deserialize — such restrictions are fragile by design and cannot be made
+  reliable.
+- Security reports that require an attacker-controlled joblib file as their
+  starting point are **outside joblib's threat model**: if the file is
+  malicious, the user should not have loaded it.
+- We may still fix behaviors that are surprising or unnecessarily dangerous
+  (e.g. inconsistencies in how companion files are resolved), but these fixes
+  aim for correctness, not for making untrusted-file loading safe.
+
+Sharing models securely
+------------------------
+
+If you need to **distribute or receive serialized models** across a trust
+boundary (e.g. from Hugging Face, a third-party vendor, or an end user),
+use a format that was designed for safe loading. We recommend
+`skops.io <https://skops.readthedocs.io/en/stable/modules/classes.html#module-skops.io>`_,
+which provides a pickle-free serialization format for scikit-learn compatible
+models with an explicit audit step before loading.
+
+If you must load a joblib file of uncertain provenance, inspect it first with
+a tool such as `fickling <https://github.com/trailofbits/fickling>`_ or
+`skops.io` before loading, then load it only if it is clean.
 
 .. note::
 

--- a/doc/user_guide/persistence.rst
+++ b/doc/user_guide/persistence.rst
@@ -1,28 +1,36 @@
 .. _persistence:
 
-===========
-Persistence
-===========
+==========================================
+Serialization and memory-mapped loading
+==========================================
 
 .. currentmodule:: joblib.numpy_pickle
 
 Use case
 ========
 
-:func:`joblib.dump` and :func:`joblib.load` provide a replacement for
-pickle to work efficiently on arbitrary Python objects containing large data,
-in particular large numpy arrays.
+:func:`joblib.dump` and :func:`joblib.load` provide numpy-aware serialization
+optimized for **memory-efficient loading in multiprocess environments**.
+Large numpy arrays are stored as raw binary buffers that can be
+**memory-mapped** on load, so multiple worker processes share a single copy of
+the data instead of each holding a full in-memory duplicate.
+
+The canonical use case is serving a scikit-learn model under a multiprocess
+server (e.g. gunicorn): dump the fitted model once, then each worker
+memory-maps the large coefficient arrays rather than pickling them across a
+pipe. This avoids duplicating potentially gigabytes of data per worker.
 
 .. _persistence_security:
 
 Security considerations
 =======================
 
-**Joblib's persistence layer is designed for trusted environments.**
-It is intended for use cases such as caching intermediate results, sharing
-objects between worker processes, or checkpointing long computations — all
-situations where the file was written by your own code or by collaborators
-you control.
+**Because** :func:`joblib.load` **is designed for controlled, internal
+pipelines — not for distributing models to end users — it only makes safety
+guarantees for files you produced yourself.**
+It is intended for use cases such as caching intermediate results or sharing
+objects between worker processes, where the file was written by your own code
+or by collaborators you control.
 
 .. warning::
 


### PR DESCRIPTION
Joblib is receiving a growing number of GHSA reports that assume `joblib.load` should be safe against attacker-controlled files — this is outside joblib's design goals, and the current documentation does not make that clear enough.

This PR adds a "Security considerations" section to the persistence doc explaining that `dump`/`load` are designed for trusted environments, that pickle sandboxing is not and will not be a joblib responsibility, and pointing users toward `skops.io` for safe cross-boundary model sharing. `SECURITY.md` is updated in parallel to state the scope concisely (including that controlling function attributes or environment variables is already code execution and therefore also out of scope), with a link to the persistence doc for the full rationale.