### PR TITLE
DOC clarify pandas DataFrame hash cache misses

### DIFF
--- a/doc/user_guide/memory.rst
+++ b/doc/user_guide/memory.rst
@@ -398,9 +398,15 @@ Gotchas
   pickle representation, or objects whose representation depends on the way they
   are constructed, the cache will not work. In particular, ``pytorch.Tensor``
   are known to have non-deterministic pickle representation (see this
-  `issue <https://github.com/pytorch/pytorch/issues/32165>`_). A good way
-  to debug this is to check that two calls to the following script with ``args``
-  and ``kwargs`` being the cached function's inputs give the same output::
+  `issue <https://github.com/pytorch/pytorch/issues/32165>`_).
+  For example, two ``pandas.DataFrame`` objects with the same data, columns,
+  and index may still have different internal representations depending on how
+  they were constructed, and therefore different :func:`joblib.hash` values.
+  In that case, :class:`Memory` conservatively recomputes the result rather
+  than risk reusing a result for inputs whose serialized representations
+  differ. A good way to debug this is to check that two calls to the following
+  script with ``args`` and ``kwargs`` being the cached function's inputs give
+  the same output::
 
     from joblib import hash
 


### PR DESCRIPTION
## Summary

- document that pandas DataFrames with equal data, columns, and index can still have different internal representations
- explain that different `joblib.hash` values intentionally cause a conservative cache miss
- avoid attributing the behavior to a pandas implementation detail that is not stable across versions

## Validation

- reproduced against the current checkout: `DataFrame.equals` is true while the two `joblib.hash` values differ
- `python -m pytest -q doc/user_guide/memory.rst` — 1 passed
- `git diff --check`

The full Sphinx build was not run locally because the optional documentation dependency set is not installed; the repository's focused doctest for the edited page passed.

Closes #1611

## AI assistance disclosure

This documentation change was prepared with AI assistance. The issue discussion, current hashing implementation, all 67 open pull requests, repository policies, diff, reproduction, and validation results were reviewed before submission.
