### PR TITLE
CI Use pytest-run-parallel on free-threaded build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,9 +103,6 @@ jobs:
             os: ubuntu-latest
             PYTHON_VERSION: "3.9"
             JOBLIB_TESTS_DEFAULT_PARALLEL_BACKEND: "threading"
-          - name: python3.13-free-threaded
-            os: 'ubuntu-latest'
-            PYTHON_VERSION: "free-threaded-3.13"
           - name: python3.14-free-threaded
             os: 'ubuntu-latest'
             PYTHON_VERSION: "free-threaded-3.14"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
             PYTHON_VERSION: "3.9"
             JOBLIB_TESTS_DEFAULT_PARALLEL_BACKEND: "threading"
           # Jobs whose Python versions start with "free-threaded" will run with
-          # pytest-run-parallel to catch thread-safety issues.
+          # pytest-run-parallel to catch thread-safety issues:
           - name: python3.14-free-threaded
             os: 'ubuntu-latest'
             PYTHON_VERSION: "free-threaded-3.14"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,8 @@ jobs:
             os: ubuntu-latest
             PYTHON_VERSION: "3.9"
             JOBLIB_TESTS_DEFAULT_PARALLEL_BACKEND: "threading"
+          # Jobs whose Python versions start with "free-threaded" will run with
+          # pytest-run-parallel to catch thread-safety issues.
           - name: python3.14-free-threaded
             os: 'ubuntu-latest'
             PYTHON_VERSION: "free-threaded-3.14"

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,6 @@ import sys
 import pytest
 from _pytest.doctest import DoctestItem
 
-from joblib import Memory
 from joblib.backports import LooseVersion
 from joblib.parallel import ParallelBackendBase, mp
 
@@ -92,14 +91,6 @@ def pytest_unconfigure(config):
     # Note that we also use a shorter timeout for the per-test callback
     # configured via the pytest-timeout extension.
     faulthandler.dump_traceback_later(60, exit=True)
-
-
-@pytest.fixture(scope="function")
-def memory(tmp_path):
-    "Fixture to get an independent and self-cleaning Memory"
-    mem = Memory(location=tmp_path, verbose=0)
-    yield mem
-    mem.clear()
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -41,6 +41,10 @@ if [[ "$COVERAGE" == "true" ]]; then
     PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES coverage pytest-cov"
 fi
 
+if [[ "$PYTHON_VERSION" == free-threaded* ]]; then
+    PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES pytest-run-parallel"
+fi
+
 pip install $PIP_INSTALL_PACKAGES
 
 if [[ "$NO_LZMA" == "true" ]]; then
@@ -59,4 +63,4 @@ if [[ "$CYTHON" == "true" ]]; then
     cd ../../..
 fi
 
-pip install -v '.[test]'
+pip install -v .

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -59,4 +59,4 @@ if [[ "$CYTHON" == "true" ]]; then
     cd ../../..
 fi
 
-pip install -v .
+pip install -v '.[test]'

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -9,6 +9,8 @@
 
 set -xe
 
+ORIGINAL_PYTHON_VERSION=$PYTHON_VERSION
+
 create_new_conda_env() {
     conda config --set solver libmamba
     if [[ "$PYTHON_VERSION" == free-threaded* ]]; then
@@ -41,7 +43,7 @@ if [[ "$COVERAGE" == "true" ]]; then
     PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES coverage pytest-cov"
 fi
 
-if [[ "$PYTHON_VERSION" == free-threaded* ]]; then
+if [[ "$ORIGINAL_PYTHON_VERSION" == free-threaded* ]]; then
     PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES pytest-run-parallel"
 fi
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -65,4 +65,6 @@ if [[ "$CYTHON" == "true" ]]; then
     cd ../../..
 fi
 
+# Can't just install '.[test]' because, for example, we want some runs to omit
+# NumPy:
 pip install -v .

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -43,6 +43,8 @@ if [[ "$COVERAGE" == "true" ]]; then
     PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES coverage pytest-cov"
 fi
 
+# pytest-run-parallel is used to run the same test in parallel on free-threaded
+# test runs, to catch thread-safety issues:
 if [[ "$ORIGINAL_PYTHON_VERSION" == free-threaded* ]]; then
     PIP_INSTALL_PACKAGES="$PIP_INSTALL_PACKAGES pytest-run-parallel"
 fi

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -9,6 +9,12 @@ if [[ "$PYTHON_VERSION" == free-threaded* ]]; then
     # This is needed because for now some C extensions have not declared their
     # thread-safety with free-threaded Python, for example numpy and coverage.tracer
     export PYTHON_GIL=0
+    # For free-threaded Python, run parallel tests to validate thread-safety (at
+    # least somewhat.)
+    NUM_CORES=$(python -c "import joblib; print(joblib.cpu_count())")
+    PARALLEL_PYTEST_ARGS="--parallel-threads $NUM_CORES --iterations 1"
+else
+    PARALLEL_PYTEST_ARGS=""
 fi
 
 which python
@@ -18,7 +24,7 @@ python -c "import multiprocessing as mp; print('multiprocessing.cpu_count():', m
 python -c "import joblib; print('joblib.cpu_count():', joblib.cpu_count())"
 
 if [[ "$SKLEARN_TESTS" != "true" ]]; then
-    pytest joblib -vl --timeout=120 --cov=joblib --cov-report xml
+    pytest joblib -vl --timeout=120 --cov=joblib --cov-report xml $PARALLEL_PYTEST_ARGS
 
     # doctests are not compatile with default_backend=threading
     if [[ "$JOBLIB_TESTS_DEFAULT_PARALLEL_BACKEND" != "threading" ]]; then
@@ -37,6 +43,5 @@ else
     NEW_TEST_DIR=$(mktemp -d)
     cd $NEW_TEST_DIR
 
-    pytest -vl --maxfail=5 -p no:doctest \
-        --pyargs sklearn
+    pytest -vl --maxfail=5 -p no:doctest $PARALLEL_PYTEST_ARGS --pyargs sklearn
 fi

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -10,7 +10,7 @@ if [[ "$PYTHON_VERSION" == free-threaded* ]]; then
     # thread-safety with free-threaded Python, for example numpy and coverage.tracer
     export PYTHON_GIL=0
     # For free-threaded Python, run parallel tests to validate thread-safety (at
-    # least somewhat.)
+    # least somewhat):
     NUM_CORES=$(python -c "import joblib; print(joblib.cpu_count())")
     PARALLEL_PYTEST_ARGS="--parallel-threads $NUM_CORES --iterations 1"
 else

--- a/joblib/test/test_config.py
+++ b/joblib/test/test_config.py
@@ -1,4 +1,7 @@
 import os
+from uuid import uuid4
+
+import pytest
 
 from joblib._parallel_backends import (
     LokyBackend,
@@ -33,17 +36,22 @@ def test_global_parallel_backend(context):
 
 @parametrize("context", [parallel_config, parallel_backend])
 def test_external_backends(context):
-    def register_foo():
-        BACKENDS["foo"] = ThreadingBackend
+    backend_name = str(uuid4())
 
-    EXTERNAL_BACKENDS["foo"] = register_foo
+    def register_foo():
+        BACKENDS[backend_name] = ThreadingBackend
+
+    EXTERNAL_BACKENDS[backend_name] = register_foo
     try:
-        with context("foo"):
+        with context(backend_name):
             assert isinstance(Parallel()._backend, ThreadingBackend)
     finally:
-        del EXTERNAL_BACKENDS["foo"]
+        del EXTERNAL_BACKENDS[backend_name]
 
 
+# Thread-unsafe due to https://github.com/joblib/joblib/issues/1794 maybe? If
+# fixing that doesn't fix this, file a new issue.
+@pytest.mark.thread_unsafe
 @with_numpy
 @with_multiprocessing
 def test_parallel_config_no_backend(tmpdir):
@@ -59,6 +67,7 @@ def test_parallel_config_no_backend(tmpdir):
             assert len(os.listdir(tmpdir)) > 0
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_numpy
 @with_multiprocessing
 def test_parallel_config_params_explicit_set(tmpdir):

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -29,7 +29,6 @@ from distributed.metrics import time  # noqa: E402
 # and their dependencies.
 from distributed.utils_test import cleanup, cluster, inc  # noqa: E402, F401
 
-
 # https://github.com/joblib/joblib/issues/1818
 pytestmark = pytest.mark.thread_unsafe
 

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -30,6 +30,10 @@ from distributed.metrics import time  # noqa: E402
 from distributed.utils_test import cleanup, cluster, inc  # noqa: E402, F401
 
 
+# https://github.com/joblib/joblib/issues/1818
+pytestmark = pytest.mark.thread_unsafe
+
+
 @pytest.fixture(scope="function", autouse=True)
 def avoid_dask_env_leaks(tmp_path):
     # when starting a dask nanny, the environment variable might change.

--- a/joblib/test/test_dask.py
+++ b/joblib/test/test_dask.py
@@ -29,7 +29,8 @@ from distributed.metrics import time  # noqa: E402
 # and their dependencies.
 from distributed.utils_test import cleanup, cluster, inc  # noqa: E402, F401
 
-# https://github.com/joblib/joblib/issues/1818
+# https://github.com/joblib/joblib/issues/1818 is the tracking issue for fixing
+# this:
 pytestmark = pytest.mark.thread_unsafe
 
 

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -8,6 +8,8 @@ Test the func_inspect module.
 
 import functools
 
+import pytest
+
 from joblib.func_inspect import (
     _clean_win_chars,
     filter_args,
@@ -349,6 +351,7 @@ def _get_code():
     return get_func_code(big5_f)[0]
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 def test_func_code_consistency():
     from joblib.parallel import Parallel, delayed
 

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -1078,6 +1078,7 @@ def identity(arg):
     return arg
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize(

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -888,6 +888,7 @@ def test_child_raises_parent_exits_cleanly(backend):
     assert not os.path.exists(filename)
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize(
@@ -1226,6 +1227,7 @@ def test_weak_array_key_map_no_pickling():
         pickle.dumps(m)
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 def test_direct_mmap(tmpdir):

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import threading
 from time import sleep
+from uuid import uuid4
 
 import pytest
 
@@ -361,6 +362,8 @@ def test_pool_with_memmap(factory, tmpdir):
 )
 def test_pool_with_memmap_array_view(factory, tmpdir):
     """Check that subprocess can access and update shared memory array"""
+    tmpdir = tmpdir.mkdir(str(uuid4()))
+
     assert_array_equal = np.testing.assert_array_equal
 
     # Fork the subprocess before allocating the objects to be passed
@@ -549,6 +552,7 @@ def test_memmapping_temp_folder_thread_safety():
     assert temp_dirs_thread_1 != temp_dirs_thread_2
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1794
 @with_numpy
 @with_multiprocessing
 def test_multithreaded_parallel_termination_resource_tracker_silent():

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -293,6 +293,7 @@ def test__strided_from_memmap(tmpdir):
     assert _get_backing_memmap(memmap_backed_obj).offset == offset
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize(
@@ -481,6 +482,7 @@ def test_permission_error_windows_memmap_sent_to_parent(backend):
         assert b"resource_tracker" not in err
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize("backend", ["multiprocessing", "loky"])
@@ -665,6 +667,7 @@ def test_many_parallel_calls_on_same_object(backend):
     assert b"resource_tracker" not in err
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize("backend", ["multiprocessing", "loky"])
@@ -733,6 +736,7 @@ def test_resource_tracker_silent_when_reference_cycles(backend):
     assert "resource_tracker" not in err, err
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize(
@@ -913,6 +917,7 @@ def test_memmapping_pool_for_large_arrays_disabled(factory, tmpdir):
         del p
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @with_dev_shm
@@ -1134,6 +1139,7 @@ def test_pool_get_temp_dir_no_statvfs(tmpdir, monkeypatch):
     assert pool_folder.endswith(pool_folder_name)
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @skipif(
     sys.platform == "win32", reason="This test fails with a PermissionError on Windows"

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import threading
 from time import sleep
-from uuid import uuid4
 
 import pytest
 
@@ -362,8 +361,6 @@ def test_pool_with_memmap(factory, tmpdir):
 )
 def test_pool_with_memmap_array_view(factory, tmpdir):
     """Check that subprocess can access and update shared memory array"""
-    tmpdir = tmpdir.mkdir(str(uuid4()))
-
     assert_array_equal = np.testing.assert_array_equal
 
     # Fork the subprocess before allocating the objects to be passed

--- a/joblib/test/test_memmapping.py
+++ b/joblib/test/test_memmapping.py
@@ -980,6 +980,7 @@ def test_memmapping_on_large_enough_dev_shm(factory):
         jmr.SYSTEM_SHARED_MEM_FS_MIN_SIZE = orig_size
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1794
 @with_numpy
 @with_multiprocessing
 @with_dev_shm
@@ -1012,6 +1013,7 @@ def test_memmapping_on_too_small_dev_shm(factory):
         jmr.SYSTEM_SHARED_MEM_FS_MIN_SIZE = orig_size
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize(

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -18,6 +18,7 @@ import sys
 import textwrap
 import time
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
@@ -371,21 +372,23 @@ def test_memory_eval(tmpdir):
     assert mm(1) == 1
 
 
-def count_and_append(x=[]):
-    """A function with a side effect in its arguments.
-
-    Return the length of its argument and append one element.
-    """
-    len_x = len(x)
-    x.append(None)
-    return len_x
-
-
 def test_argument_change(tmpdir):
     """Check that if a function has a side effect in its arguments, it
     should use the hash of changing arguments.
     """
-    memory = Memory(location=tmpdir.strpath, verbose=0)
+    path = (tmpdir / str(uuid4())).strpath
+    print(path)
+    memory = Memory(location=path, verbose=0)
+
+    def count_and_append(x=[]):
+        """A function with a side effect in its arguments.
+
+        Return the length of its argument and append one element.
+        """
+        len_x = len(x)
+        x.append(None)
+        return len_x
+
     func = memory.cache(count_and_append)
     # call the function for the first time, is should cache it with
     # argument x=[]
@@ -817,11 +820,6 @@ def test_memory_file_modification(capsys, tmpdir, monkeypatch):
     assert out == "1\n2\nReloading\nx=1\n"
 
 
-def _function_to_cache(a, b):
-    # Just a place holder function to be mutated by tests
-    pass
-
-
 def _sum(a, b):
     return a + b
 
@@ -831,6 +829,10 @@ def _product(a, b):
 
 
 def test_memory_in_memory_function_code_change(tmpdir):
+    def _function_to_cache(a, b):
+        # Just a place holder function to be mutated by tests
+        pass
+
     _function_to_cache.__code__ = _sum.__code__
 
     memory = Memory(location=tmpdir.strpath, verbose=0)
@@ -1428,11 +1430,13 @@ def test_memory_pickle_dump_load(tmpdir, memory_kwargs):
     assert hash(memorized_result) == hash(memorized_result_reloaded)
 
 
+@pytest.mark.thread_unsafe  # caplog is not thread-safe
 def test_info_log(tmpdir, caplog):
     caplog.set_level(logging.INFO)
     x = 3
 
-    memory = Memory(location=tmpdir.strpath, verbose=20)
+    mem_path = (tmpdir / str(uuid4())).strpath
+    memory = Memory(location=mem_path, verbose=20)
 
     @memory.cache
     def f(x):
@@ -1442,7 +1446,7 @@ def test_info_log(tmpdir, caplog):
     assert "Querying" in caplog.text
     caplog.clear()
 
-    memory = Memory(location=tmpdir.strpath, verbose=0)
+    memory = Memory(location=mem_path, verbose=0)
 
     @memory.cache
     def f(x):
@@ -1462,15 +1466,17 @@ class TestCacheValidationCallback:
             time.sleep(delay)
         return x * 2
 
-    def test_invalid_cache_validation_callback(self, memory):
+    def test_invalid_cache_validation_callback(self, tmp_path):
         "Test invalid values for `cache_validation_callback"
+        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
         match = "cache_validation_callback needs to be callable. Got True."
         with pytest.raises(ValueError, match=match):
             memory.cache(cache_validation_callback=True)
 
     @pytest.mark.parametrize("consider_cache_valid", [True, False])
-    def test_constant_cache_validation_callback(self, memory, consider_cache_valid):
+    def test_constant_cache_validation_callback(self, tmp_path, consider_cache_valid):
         "Test expiry of old results"
+        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
         f = memory.cache(
             self.foo,
             cache_validation_callback=lambda _: consider_cache_valid,
@@ -1484,7 +1490,7 @@ class TestCacheValidationCallback:
         assert d1["run"]
         assert d2["run"] != consider_cache_valid
 
-    def test_memory_only_cache_long_run(self, memory):
+    def test_memory_only_cache_long_run(self, tmp_path):
         "Test cache validity based on run duration."
 
         def cache_validation_callback(metadata):
@@ -1492,6 +1498,7 @@ class TestCacheValidationCallback:
             if duration > 0.1:
                 return True
 
+        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
         f = memory.cache(
             self.foo, cache_validation_callback=cache_validation_callback, ignore=["d"]
         )
@@ -1510,9 +1517,9 @@ class TestCacheValidationCallback:
         assert d1["run"]
         assert not d2["run"]
 
-    def test_memory_expires_after(self, memory):
+    def test_memory_expires_after(self, tmp_path):
         "Test expiry of old cached results"
-
+        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
         f = memory.cache(
             self.foo, cache_validation_callback=expires_after(seconds=0.3), ignore=["d"]
         )
@@ -1536,9 +1543,9 @@ class TestMemorizedFunc:
         counter[x] = counter.get(x, 0) + 1
         return counter[x]
 
-    def test_call_method_memorized(self, memory):
+    def test_call_method_memorized(self, tmp_path):
         "Test calling the function"
-
+        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
         f = memory.cache(self.f, ignore=["counter"])
 
         counter = {}
@@ -1551,9 +1558,8 @@ class TestMemorizedFunc:
             "Metadata are not returned by MemorizedFunc.call."
         )
 
-    def test_call_method_not_memorized(self, memory):
+    def test_call_method_not_memorized(self):
         "Test calling the function"
-
         f = NotMemorizedFunc(self.f)
 
         counter = {}

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -376,7 +376,7 @@ def test_argument_change(tmpdir):
     """Check that if a function has a side effect in its arguments, it
     should use the hash of changing arguments.
     """
-    memory = Memory(location=tmpdir, verbose=0)
+    memory = Memory(location=tmpdir.strpath, verbose=0)
 
     def count_and_append(x=[]):
         """A function with a side effect in its arguments.
@@ -1433,7 +1433,7 @@ def test_info_log(tmpdir, caplog):
     caplog.set_level(logging.INFO)
     x = 3
 
-    memory = Memory(location=tmpdir, verbose=20)
+    memory = Memory(location=tmpdir.strpath, verbose=20)
 
     @memory.cache
     def f(x):
@@ -1443,7 +1443,7 @@ def test_info_log(tmpdir, caplog):
     assert "Querying" in caplog.text
     caplog.clear()
 
-    memory = Memory(location=tmpdir, verbose=0)
+    memory = Memory(location=tmpdir.strpath, verbose=0)
 
     @memory.cache
     def f(x):

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -92,6 +92,7 @@ def monkeypatch_cached_func_warn(func, monkeypatch_fixture):
 # Tests
 def test_memory_integration(tmpdir):
     """Simple test of memory lazy evaluation."""
+    print(tmpdir)
     accumulator = list()
 
     # Rmk: this function has the same name than a module-level function,
@@ -136,6 +137,7 @@ def test_memory_integration(tmpdir):
     memory.cache(f)(1)
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1794
 @parametrize("call_before_reducing", [True, False])
 def test_parallel_call_cached_function_defined_in_jupyter(tmpdir, call_before_reducing):
     tmpdir = tmpdir / str(uuid4())
@@ -220,8 +222,8 @@ def test_parallel_call_cached_function_defined_in_jupyter(tmpdir, call_before_re
                 # MemorizedFunc.__reduce__.
                 Parallel(n_jobs=2)(delayed(cached_f)(i) for i in [1, 2])
                 # Ensure the child process has time to close the file.
-                # Wait up to 10 seconds for slow CI runs
-                for _ in range(50):
+                # Wait up to 5 seconds for slow CI runs
+                for _ in range(25):
                     if len(os.listdir(f_cache_directory / "f")) == 3:
                         break
                     time.sleep(0.2)  # pragma: no cover

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -138,6 +138,8 @@ def test_memory_integration(tmpdir):
 
 @parametrize("call_before_reducing", [True, False])
 def test_parallel_call_cached_function_defined_in_jupyter(tmpdir, call_before_reducing):
+    tmpdir = tmpdir / str(uuid4())
+
     # Calling an interactively defined memory.cache()'d function inside a
     # Parallel call used to clear the existing cache related to the said
     # function (https://github.com/joblib/joblib/issues/1035)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -91,7 +91,6 @@ def monkeypatch_cached_func_warn(func, monkeypatch_fixture):
 # Tests
 def test_memory_integration(tmpdir):
     """Simple test of memory lazy evaluation."""
-    print(tmpdir)
     accumulator = list()
 
     # Rmk: this function has the same name than a module-level function,

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -18,7 +18,6 @@ import sys
 import textwrap
 import time
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 
@@ -140,8 +139,6 @@ def test_memory_integration(tmpdir):
 @pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1794
 @parametrize("call_before_reducing", [True, False])
 def test_parallel_call_cached_function_defined_in_jupyter(tmpdir, call_before_reducing):
-    tmpdir = tmpdir / str(uuid4())
-
     # Calling an interactively defined memory.cache()'d function inside a
     # Parallel call used to clear the existing cache related to the said
     # function (https://github.com/joblib/joblib/issues/1035)
@@ -380,9 +377,7 @@ def test_argument_change(tmpdir):
     """Check that if a function has a side effect in its arguments, it
     should use the hash of changing arguments.
     """
-    path = (tmpdir / str(uuid4())).strpath
-    print(path)
-    memory = Memory(location=path, verbose=0)
+    memory = Memory(location=tmpdir, verbose=0)
 
     def count_and_append(x=[]):
         """A function with a side effect in its arguments.
@@ -1439,8 +1434,7 @@ def test_info_log(tmpdir, caplog):
     caplog.set_level(logging.INFO)
     x = 3
 
-    mem_path = (tmpdir / str(uuid4())).strpath
-    memory = Memory(location=mem_path, verbose=20)
+    memory = Memory(location=tmpdir, verbose=20)
 
     @memory.cache
     def f(x):
@@ -1450,7 +1444,7 @@ def test_info_log(tmpdir, caplog):
     assert "Querying" in caplog.text
     caplog.clear()
 
-    memory = Memory(location=mem_path, verbose=0)
+    memory = Memory(location=tmpdir, verbose=0)
 
     @memory.cache
     def f(x):
@@ -1472,7 +1466,7 @@ class TestCacheValidationCallback:
 
     def test_invalid_cache_validation_callback(self, tmp_path):
         "Test invalid values for `cache_validation_callback"
-        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
+        memory = Memory(location=tmp_path, verbose=0)
         match = "cache_validation_callback needs to be callable. Got True."
         with pytest.raises(ValueError, match=match):
             memory.cache(cache_validation_callback=True)
@@ -1480,7 +1474,7 @@ class TestCacheValidationCallback:
     @pytest.mark.parametrize("consider_cache_valid", [True, False])
     def test_constant_cache_validation_callback(self, tmp_path, consider_cache_valid):
         "Test expiry of old results"
-        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
+        memory = Memory(location=tmp_path, verbose=0)
         f = memory.cache(
             self.foo,
             cache_validation_callback=lambda _: consider_cache_valid,
@@ -1502,7 +1496,7 @@ class TestCacheValidationCallback:
             if duration > 0.1:
                 return True
 
-        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
+        memory = Memory(location=tmp_path, verbose=0)
         f = memory.cache(
             self.foo, cache_validation_callback=cache_validation_callback, ignore=["d"]
         )
@@ -1523,7 +1517,7 @@ class TestCacheValidationCallback:
 
     def test_memory_expires_after(self, tmp_path):
         "Test expiry of old cached results"
-        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
+        memory = Memory(location=tmp_path, verbose=0)
         f = memory.cache(
             self.foo, cache_validation_callback=expires_after(seconds=0.3), ignore=["d"]
         )
@@ -1549,7 +1543,7 @@ class TestMemorizedFunc:
 
     def test_call_method_memorized(self, tmp_path):
         "Test calling the function"
-        memory = Memory(location=tmp_path / str(uuid4()), verbose=0)
+        memory = Memory(location=tmp_path, verbose=0)
         f = memory.cache(self.f, ignore=["counter"])
 
         counter = {}

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -220,8 +220,8 @@ def test_parallel_call_cached_function_defined_in_jupyter(tmpdir, call_before_re
                 # MemorizedFunc.__reduce__.
                 Parallel(n_jobs=2)(delayed(cached_f)(i) for i in [1, 2])
                 # Ensure the child process has time to close the file.
-                # Wait up to 5 seconds for slow CI runs
-                for _ in range(25):
+                # Wait up to 10 seconds for slow CI runs
+                for _ in range(50):
                     if len(os.listdir(f_cache_directory / "f")) == 3:
                         break
                     time.sleep(0.2)  # pragma: no cover

--- a/joblib/test/test_memory_async.py
+++ b/joblib/test/test_memory_async.py
@@ -28,6 +28,7 @@ async def check_identity_lazy_async(func, accumulator, location):
             assert len(accumulator) == i + 1
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.asyncio
 async def test_memory_integration_async(tmpdir):
     accumulator = list()
@@ -73,6 +74,7 @@ async def test_memory_integration_async(tmpdir):
     await memory.cache(f)(1)
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.asyncio
 async def test_no_memory_async():
     accumulator = list()
@@ -90,6 +92,7 @@ async def test_no_memory_async():
         assert len(accumulator) == current_accumulator + 1
 
 
+@pytest.mark.thread_unsafe
 @with_numpy
 @pytest.mark.asyncio
 async def test_memory_numpy_check_mmap_mode_async(tmpdir, monkeypatch):
@@ -130,6 +133,7 @@ async def test_memory_numpy_check_mmap_mode_async(tmpdir, monkeypatch):
     assert d.mode == "r"
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.asyncio
 async def test_call_and_shelve_async(tmpdir):
     async def f(x, y=1):
@@ -162,13 +166,15 @@ async def test_call_and_shelve_async(tmpdir):
         result.clear()  # Do nothing if there is no cache.
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.asyncio
-async def test_memorized_func_call_async(memory):
+async def test_memorized_func_call_async(tmp_path):
     async def ff(x, counter):
         await asyncio.sleep(0.1)
         counter[x] = counter.get(x, 0) + 1
         return counter[x]
 
+    memory = Memory(location=tmp_path, verbose=0)
     gg = memory.cache(ff, ignore=["counter"])
 
     counter = {}

--- a/joblib/test/test_memory_async.py
+++ b/joblib/test/test_memory_async.py
@@ -16,6 +16,10 @@ from joblib.testing import raises
 
 from .test_memory import corrupt_single_cache_item, monkeypatch_cached_func_warn
 
+# asyncio support in pytest isn't thread-safe, so can't run these tests in
+# parallel.
+pytestmark = pytest.mark.thread_unsafe
+
 
 async def check_identity_lazy_async(func, accumulator, location):
     """Similar to check_identity_lazy_async for coroutine functions"""
@@ -28,7 +32,6 @@ async def check_identity_lazy_async(func, accumulator, location):
             assert len(accumulator) == i + 1
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.asyncio
 async def test_memory_integration_async(tmpdir):
     accumulator = list()
@@ -74,7 +77,6 @@ async def test_memory_integration_async(tmpdir):
     await memory.cache(f)(1)
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.asyncio
 async def test_no_memory_async():
     accumulator = list()
@@ -92,7 +94,6 @@ async def test_no_memory_async():
         assert len(accumulator) == current_accumulator + 1
 
 
-@pytest.mark.thread_unsafe
 @with_numpy
 @pytest.mark.asyncio
 async def test_memory_numpy_check_mmap_mode_async(tmpdir, monkeypatch):
@@ -133,7 +134,6 @@ async def test_memory_numpy_check_mmap_mode_async(tmpdir, monkeypatch):
     assert d.mode == "r"
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.asyncio
 async def test_call_and_shelve_async(tmpdir):
     async def f(x, y=1):
@@ -166,7 +166,6 @@ async def test_call_and_shelve_async(tmpdir):
         result.clear()  # Do nothing if there is no cache.
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.asyncio
 async def test_memorized_func_call_async(tmp_path):
     async def ff(x, counter):

--- a/joblib/test/test_numpy_pickle.py
+++ b/joblib/test/test_numpy_pickle.py
@@ -15,6 +15,7 @@ import warnings
 import zlib
 from contextlib import closing
 from pathlib import Path
+from uuid import uuid4
 
 try:
     import lzma
@@ -1055,10 +1056,10 @@ def test_pickle_highest_protocol(tmpdir):
 def test_pickle_in_socket():
     # test that joblib can pickle in sockets
     test_array = np.arange(10)
-    _ADDR = ("localhost", 12345)
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    listener.bind(_ADDR)
+    listener.bind(("localhost", 0))
     listener.listen(1)
+    _ADDR = listener.getsockname()
 
     with socket.create_connection(_ADDR) as client:
         server, client_addr = listener.accept()
@@ -1101,7 +1102,7 @@ def test_load_memmap_with_big_offset(tmpdir):
 
 def test_register_compressor(tmpdir):
     # Check that registering compressor file works.
-    compressor_name = "test-name"
+    compressor_name = "test-name" + str(uuid4())
     compressor_prefix = "test-prefix"
 
     class BinaryCompressorTestFile(io.BufferedIOBase):
@@ -1162,7 +1163,7 @@ class StandardLibGzipCompressorWrapper(CompressorWrapper):
 
 def test_register_compressor_already_registered():
     # Test registration of existing compressor files.
-    compressor_name = "test-name"
+    compressor_name = "test-name" + str(uuid4())
 
     # register a test compressor
     register_compressor(compressor_name, AnotherZlibCompressorWrapper())

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -75,6 +75,11 @@ from joblib.parallel import (
     register_parallel_backend,
 )
 
+# A huge number of tests are not thread safe due to #1816 and #1743. Once those
+# are fixed, remove this and fix anything that's left.
+pytestmark = pytest.mark.thread_unsafe
+
+
 RETURN_GENERATOR_BACKENDS = BACKENDS.copy()
 RETURN_GENERATOR_BACKENDS.pop("multiprocessing", None)
 
@@ -182,7 +187,6 @@ def test_effective_n_jobs_None(context, backend_n_jobs, expected_n_jobs):
 # Test parallel
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("backend", ALL_VALID_BACKENDS)
 @parametrize("n_jobs", [1, 2, -1, -2])
 @parametrize("verbose", [2, 11, 100])
@@ -192,7 +196,6 @@ def test_simple_parallel(backend, n_jobs, verbose):
     )(delayed(square)(x) for x in range(5))
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("backend", ALL_VALID_BACKENDS)
 @parametrize("n_jobs", [1, 2])
 def test_parallel_pretty_print(backend, n_jobs):
@@ -352,7 +355,6 @@ def raise_exception(backend):
     raise ValueError
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_multiprocessing
 def test_nested_loop_with_exception_with_loky():
     with raises(ValueError):
@@ -367,7 +369,6 @@ def test_mutate_input_with_threads():
     assert q.full()
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("n_jobs", [1, 2, 3])
 def test_parallel_kwargs(n_jobs):
     """Check the keyword argument processing of pmap."""
@@ -423,7 +424,6 @@ def test_parallel_pickling():
         )
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize("byteorder", ["<", ">", "="])
@@ -469,7 +469,6 @@ def test_parallel_timeout_fail(backend):
         )
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_multiprocessing
 @parametrize("backend", set(RETURN_GENERATOR_BACKENDS) - {"sequential"})
 @parametrize("return_as", ["generator", "generator_unordered"])
@@ -491,7 +490,6 @@ def test_parallel_timeout_fail_with_generator(backend, return_as):
     )
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_multiprocessing
 @parametrize("backend", PROCESS_BACKENDS)
 def test_error_capture(backend):
@@ -564,7 +562,6 @@ def test_error_capture(backend):
         )
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_multiprocessing
 @parametrize("backend", BACKENDS)
 def test_error_in_task_iterator(backend):
@@ -704,7 +701,6 @@ def test_batching_auto_subprocesses(backend):
         assert p._backend.compute_batch_size() > 0
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 def test_exception_dispatch():
     """Make sure that exception raised during dispatch are indeed captured"""
     with raises(ValueError):
@@ -813,6 +809,8 @@ def test_register_parallel_backend():
         del BACKENDS[test_backend]
 
 
+# Changing the default backend is inherently not thread safe, so this is not a
+# problem:
 @pytest.mark.thread_unsafe
 def test_overwrite_default_backend():
     default_backend_orig = parallel.DEFAULT_BACKEND
@@ -1070,7 +1068,6 @@ def test_invalid_batch_size(batch_size):
         Parallel(batch_size=batch_size)
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize(
     "n_tasks, n_jobs, pre_dispatch, batch_size",
     [
@@ -1342,7 +1339,6 @@ def check_memmap(a):
     return a.copy()  # return a regular array instead of a memmap
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize("backend", PROCESS_BACKENDS)
@@ -1391,9 +1387,8 @@ def test_memmap_with_big_offset(tmpdir):
     np.testing.assert_array_equal(obj, result)
 
 
-@pytest.mark.thread_unsafe
 def test_warning_about_timeout_not_supported_by_backend():
-    with warnings.catch_warnings(record=True) as warninfo:
+    with pytest.warns() as warninfo:
         Parallel(n_jobs=1, timeout=1)(delayed(square)(i) for i in range(50))
     assert len(warninfo) == 1
     w = warninfo[0]
@@ -1453,7 +1448,6 @@ def _test_parallel_unordered_generator_returns_fastest_first(backend, n_jobs):
     del result
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @pytest.mark.parametrize("n_jobs", [2, 4])
 # NB: for this test to work, the backend must be allowed to process tasks
 # concurrently, so at least two jobs with a non-sequential backend are
@@ -1464,7 +1458,6 @@ def test_parallel_unordered_generator_returns_fastest_first(backend, n_jobs):
     _test_parallel_unordered_generator_returns_fastest_first(backend, n_jobs)
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @parametrize("backend", ALL_VALID_BACKENDS)
 @parametrize("n_jobs", [1, 2, -2, -1])
 def test_abort_backend(n_jobs, backend):
@@ -1496,7 +1489,6 @@ def _test_deadlock_with_generator(backend, return_as, n_jobs):
         del result
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_numpy
 @parametrize("backend", RETURN_GENERATOR_BACKENDS)
 @parametrize("return_as", ["generator", "generator_unordered"])
@@ -1505,7 +1497,6 @@ def test_deadlock_with_generator(backend, return_as, n_jobs):
     _test_deadlock_with_generator(backend, return_as, n_jobs)
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("backend", RETURN_GENERATOR_BACKENDS)
 @parametrize("return_as", ["generator", "generator_unordered"])
 @parametrize("n_jobs", [1, 2, -2, -1])
@@ -1528,7 +1519,6 @@ def test_multiple_generator_call(backend, return_as, n_jobs):
     del g
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @parametrize("backend", RETURN_GENERATOR_BACKENDS)
 @parametrize("return_as", ["generator", "generator_unordered"])
 @parametrize("n_jobs", [1, 2, -2, -1])
@@ -1551,7 +1541,6 @@ def test_multiple_generator_call_managed(backend, return_as, n_jobs):
     del g
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("backend", RETURN_GENERATOR_BACKENDS)
 @parametrize("return_as_1", ["generator", "generator_unordered"])
 @parametrize("return_as_2", ["generator", "generator_unordered"])
@@ -1575,7 +1564,6 @@ def test_multiple_generator_call_separated(backend, return_as_1, return_as_2, n_
     assert all(res == i for res, i in zip(g2, range(10, 20)))
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @parametrize(
     "backend, error",
     [
@@ -1668,7 +1656,6 @@ def test_memmapping_leaks(backend, tmpdir):
         raise AssertionError("temporary directory of Parallel was not removed")
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize(
     "backend", ([None, "threading"] if mp is None else [None, "loky", "threading"])
 )
@@ -2097,7 +2084,6 @@ def test_threadpool_limitation_in_child_context(context, n_jobs, inner_max_num_t
     )
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @parametrize("n_jobs", [2, -1])
 @parametrize("var_name", ["OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS", "OMP_NUM_THREADS"])
@@ -2137,7 +2123,6 @@ def test_threadpool_limitation_in_child_override(context, n_jobs, var_name):
             os.environ[var_name] = original_var_value
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @parametrize("n_jobs", [2, 4, -1])
 def test_loky_reuse_workers(n_jobs):
@@ -2187,7 +2172,6 @@ def _check_status(status, n_jobs, wait_workers=False):
     return pid
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @parametrize("n_jobs", [2, 4])
 @parametrize("backend", PROCESS_BACKENDS)
@@ -2207,7 +2191,6 @@ def test_initializer_context(n_jobs, backend, context):
         Parallel()(delayed(_check_status)(status, n_jobs) for i in range(100))
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @parametrize("n_jobs", [2, 4])
 @parametrize("backend", PROCESS_BACKENDS)
@@ -2225,7 +2208,6 @@ def test_initializer_parallel(n_jobs, backend):
     )(delayed(_check_status)(status, n_jobs) for i in range(100))
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @pytest.mark.parametrize("n_jobs", [2, 4])
 def test_initializer_reused(n_jobs):
@@ -2252,7 +2234,6 @@ def test_initializer_reused(n_jobs):
     )
 
 
-@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @pytest.mark.parametrize("n_jobs", [2, 4])
 def test_initializer_not_reused(n_jobs):

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -20,6 +20,7 @@ from multiprocessing import TimeoutError
 from pickle import PicklingError
 from time import sleep
 from traceback import format_exception
+from uuid import uuid4
 
 import pytest
 
@@ -181,6 +182,7 @@ def test_effective_n_jobs_None(context, backend_n_jobs, expected_n_jobs):
 # Test parallel
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("backend", ALL_VALID_BACKENDS)
 @parametrize("n_jobs", [1, 2, -1, -2])
 @parametrize("verbose", [2, 11, 100])
@@ -190,6 +192,7 @@ def test_simple_parallel(backend, n_jobs, verbose):
     )(delayed(square)(x) for x in range(5))
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("backend", ALL_VALID_BACKENDS)
 @parametrize("n_jobs", [1, 2])
 def test_parallel_pretty_print(backend, n_jobs):
@@ -349,6 +352,7 @@ def raise_exception(backend):
     raise ValueError
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_multiprocessing
 def test_nested_loop_with_exception_with_loky():
     with raises(ValueError):
@@ -363,6 +367,7 @@ def test_mutate_input_with_threads():
     assert q.full()
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("n_jobs", [1, 2, 3])
 def test_parallel_kwargs(n_jobs):
     """Check the keyword argument processing of pmap."""
@@ -418,6 +423,7 @@ def test_parallel_pickling():
         )
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize("byteorder", ["<", ">", "="])
@@ -463,6 +469,7 @@ def test_parallel_timeout_fail(backend):
         )
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_multiprocessing
 @parametrize("backend", set(RETURN_GENERATOR_BACKENDS) - {"sequential"})
 @parametrize("return_as", ["generator", "generator_unordered"])
@@ -484,6 +491,7 @@ def test_parallel_timeout_fail_with_generator(backend, return_as):
     )
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_multiprocessing
 @parametrize("backend", PROCESS_BACKENDS)
 def test_error_capture(backend):
@@ -556,6 +564,7 @@ def test_error_capture(backend):
         )
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_multiprocessing
 @parametrize("backend", BACKENDS)
 def test_error_in_task_iterator(backend):
@@ -695,6 +704,7 @@ def test_batching_auto_subprocesses(backend):
         assert p._backend.compute_batch_size() > 0
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 def test_exception_dispatch():
     """Make sure that exception raised during dispatch are indeed captured"""
     with raises(ValueError):
@@ -794,14 +804,16 @@ def test_njobs_converted_to_int(backend, n_jobs):
 
 
 def test_register_parallel_backend():
+    test_backend = "test_backend-" + str(uuid4())
     try:
-        register_parallel_backend("test_backend", FakeParallelBackend)
-        assert "test_backend" in BACKENDS
-        assert BACKENDS["test_backend"] == FakeParallelBackend
+        register_parallel_backend(test_backend, FakeParallelBackend)
+        assert test_backend in BACKENDS
+        assert BACKENDS[test_backend] == FakeParallelBackend
     finally:
-        del BACKENDS["test_backend"]
+        del BACKENDS[test_backend]
 
 
+@pytest.mark.thread_unsafe
 def test_overwrite_default_backend():
     default_backend_orig = parallel.DEFAULT_BACKEND
     assert _active_backend_type() == get_default_backend_instance()
@@ -1058,6 +1070,7 @@ def test_invalid_batch_size(batch_size):
         Parallel(batch_size=batch_size)
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize(
     "n_tasks, n_jobs, pre_dispatch, batch_size",
     [
@@ -1329,6 +1342,7 @@ def check_memmap(a):
     return a.copy()  # return a regular array instead of a memmap
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_numpy
 @with_multiprocessing
 @parametrize("backend", PROCESS_BACKENDS)
@@ -1377,6 +1391,7 @@ def test_memmap_with_big_offset(tmpdir):
     np.testing.assert_array_equal(obj, result)
 
 
+@pytest.mark.thread_unsafe
 def test_warning_about_timeout_not_supported_by_backend():
     with warnings.catch_warnings(record=True) as warninfo:
         Parallel(n_jobs=1, timeout=1)(delayed(square)(i) for i in range(50))
@@ -1438,6 +1453,7 @@ def _test_parallel_unordered_generator_returns_fastest_first(backend, n_jobs):
     del result
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @pytest.mark.parametrize("n_jobs", [2, 4])
 # NB: for this test to work, the backend must be allowed to process tasks
 # concurrently, so at least two jobs with a non-sequential backend are
@@ -1448,6 +1464,7 @@ def test_parallel_unordered_generator_returns_fastest_first(backend, n_jobs):
     _test_parallel_unordered_generator_returns_fastest_first(backend, n_jobs)
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @parametrize("backend", ALL_VALID_BACKENDS)
 @parametrize("n_jobs", [1, 2, -2, -1])
 def test_abort_backend(n_jobs, backend):
@@ -1479,6 +1496,7 @@ def _test_deadlock_with_generator(backend, return_as, n_jobs):
         del result
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @with_numpy
 @parametrize("backend", RETURN_GENERATOR_BACKENDS)
 @parametrize("return_as", ["generator", "generator_unordered"])
@@ -1487,6 +1505,7 @@ def test_deadlock_with_generator(backend, return_as, n_jobs):
     _test_deadlock_with_generator(backend, return_as, n_jobs)
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("backend", RETURN_GENERATOR_BACKENDS)
 @parametrize("return_as", ["generator", "generator_unordered"])
 @parametrize("n_jobs", [1, 2, -2, -1])
@@ -1509,6 +1528,7 @@ def test_multiple_generator_call(backend, return_as, n_jobs):
     del g
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @parametrize("backend", RETURN_GENERATOR_BACKENDS)
 @parametrize("return_as", ["generator", "generator_unordered"])
 @parametrize("n_jobs", [1, 2, -2, -1])
@@ -1531,6 +1551,7 @@ def test_multiple_generator_call_managed(backend, return_as, n_jobs):
     del g
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize("backend", RETURN_GENERATOR_BACKENDS)
 @parametrize("return_as_1", ["generator", "generator_unordered"])
 @parametrize("return_as_2", ["generator", "generator_unordered"])
@@ -1554,6 +1575,7 @@ def test_multiple_generator_call_separated(backend, return_as_1, return_as_2, n_
     assert all(res == i for res, i in zip(g2, range(10, 20)))
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1743
 @parametrize(
     "backend, error",
     [
@@ -1608,6 +1630,7 @@ def test_multiple_generator_call_separated_gc(backend, return_as_1, return_as_2,
         assert parallel._aborting
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1794
 @with_numpy
 @with_multiprocessing
 @parametrize("backend", PROCESS_BACKENDS)
@@ -1645,6 +1668,7 @@ def test_memmapping_leaks(backend, tmpdir):
         raise AssertionError("temporary directory of Parallel was not removed")
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @parametrize(
     "backend", ([None, "threading"] if mp is None else [None, "loky", "threading"])
 )
@@ -2073,6 +2097,7 @@ def test_threadpool_limitation_in_child_context(context, n_jobs, inner_max_num_t
     )
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @parametrize("n_jobs", [2, -1])
 @parametrize("var_name", ["OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS", "OMP_NUM_THREADS"])
@@ -2112,6 +2137,7 @@ def test_threadpool_limitation_in_child_override(context, n_jobs, var_name):
             os.environ[var_name] = original_var_value
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @parametrize("n_jobs", [2, 4, -1])
 def test_loky_reuse_workers(n_jobs):
@@ -2161,6 +2187,7 @@ def _check_status(status, n_jobs, wait_workers=False):
     return pid
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @parametrize("n_jobs", [2, 4])
 @parametrize("backend", PROCESS_BACKENDS)
@@ -2180,6 +2207,7 @@ def test_initializer_context(n_jobs, backend, context):
         Parallel()(delayed(_check_status)(status, n_jobs) for i in range(100))
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @parametrize("n_jobs", [2, 4])
 @parametrize("backend", PROCESS_BACKENDS)
@@ -2197,6 +2225,7 @@ def test_initializer_parallel(n_jobs, backend):
     )(delayed(_check_status)(status, n_jobs) for i in range(100))
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @pytest.mark.parametrize("n_jobs", [2, 4])
 def test_initializer_reused(n_jobs):
@@ -2223,6 +2252,7 @@ def test_initializer_reused(n_jobs):
     )
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @with_multiprocessing
 @pytest.mark.parametrize("n_jobs", [2, 4])
 def test_initializer_not_reused(n_jobs):

--- a/joblib/test/test_store_backends.py
+++ b/joblib/test/test_store_backends.py
@@ -47,6 +47,7 @@ def concurrency_safe_write_rename(to_write, filename, write_func):
     concurrency_safe_rename(temporary_filename, filename)
 
 
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
 @timeout(0)  # No timeout as this test can be long
 @with_multiprocessing
 @parametrize("backend", ["multiprocessing", "loky", "threading"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ test = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
+    "pytest-run-parallel",
     "pytest-timeout",
     "threadpoolctl",
 ]


### PR DESCRIPTION
Fixes #1813 

* Get rid of 3.13 free-threading CI, since it was only experimental. Anyone serious about free threading should use 3.14 when it was first declared stable.
* Have 3.14 free-threading job run pytest-run-parallel.
* Fix some tests so they are thread-safe.
* Mark many other tests as not thread safe, either for inherent reasons, or more often because of specific issues; I have opened a couple.

Next step would be to go fix at least some of those new and existing issues.