### PR TITLE
Fix bare except clauses in joblib/externals/loky/backend/context.py

### DIFF
--- a/joblib/externals/loky/backend/context.py
+++ b/joblib/externals/loky/backend/context.py
@@ -272,7 +272,7 @@ def _count_physical_cores_linux():
         cpu_info = cpu_info.stdout.splitlines()
         cpu_info = {line for line in cpu_info if not line.startswith("#")}
         return len(cpu_info)
-    except:
+    except Exception:
         pass  # fallback to /proc/cpuinfo
 
     cpu_info = subprocess.run(
@@ -293,7 +293,7 @@ def _count_physical_cores_win32():
         )
         cpu_info = cpu_info.stdout.splitlines()
         return int(cpu_info[0])
-    except:
+    except Exception:
         pass  # fallback to wmic (older Windows versions; deprecated now)
 
     cpu_info = subprocess.run(


### PR DESCRIPTION
Replace 2 bare `except:` clauses with `except Exception:` in the loky backend context.

Both bare excepts silently swallow errors when reading CPU count (fallback to /proc/cpuinfo and fallback to wmic on Windows). Using `except Exception:` preserves the fallback behavior while allowing `SystemExit` and `KeyboardInterrupt` to propagate normally.