### PR TITLE
FEAT SQL Store Backend

### DIFF
--- a/joblib/_sql_store_backend.py
+++ b/joblib/_sql_store_backend.py
@@ -5,7 +5,6 @@ import json
 import os
 import sqlite3
 import time
-from pickle import PicklingError
 
 from . import numpy_pickle
 from ._store_backends import StoreBackendBase
@@ -122,13 +121,8 @@ class SQLStoreBackend(StoreBackendBase):
             print("Persisting in %s" % path)
 
         file = io.BytesIO()
-        try:
-            numpy_pickle.dump(item, file, compress=self.compress)
-            serialized_data = file.getvalue()
-        except PicklingError as e:
-            raise RuntimeError(
-                "Unable to cache to disk: failed to pickle output."
-            ) from e
+        numpy_pickle.dump(item, file, compress=self.compress)
+        serialized_data = file.getvalue()
 
         with self.con:
             self.con.execute(

--- a/joblib/_sql_store_backend.py
+++ b/joblib/_sql_store_backend.py
@@ -1,9 +1,13 @@
 """Store Backend using SQLite"""
 
+import io
+import json
 import os
 import sqlite3
 import time
+from pickle import PicklingError
 
+from . import numpy_pickle
 from ._store_backends import StoreBackendBase
 from .logger import format_time
 
@@ -36,7 +40,15 @@ class SQLStoreBackend(StoreBackendBase):
 
         with self.con:
             self.con.execute(
-                "CREATE TABLE IF NOT EXISTS cache (path TEXT PRIMARY KEY, data BLOB)"
+                "CREATE TABLE IF NOT EXISTS cache ("
+                "path TEXT PRIMARY KEY, "
+                "data BLOB,"
+                "metadata TEXT)"
+            )
+            self.con.execute(
+                "CREATE TABLE IF NOT EXISTS func_code ("
+                "path TEXT PRIMARY KEY, "
+                "code TEXT)"
             )
 
     def load_item(self, call_id, verbose, timestamp, metadata):
@@ -86,16 +98,11 @@ class SQLStoreBackend(StoreBackendBase):
                     "Non-existing item (may have been cleared).\n"
                     f"Path {path} does not exist"
                 )
+            serialized_data = row[0]
 
-        """
-        # file-like object cannot be used when mmap_mode is set
-        if mmap_mode is None:
-            with self._open_item(filename, "rb") as f:
-                item = numpy_pickle.load(f)
-        else:
-            item = numpy_pickle.load(filename, mmap_mode=mmap_mode)
+        file = io.BytesIO(serialized_data)
+        item = numpy_pickle.load(file)
         return item
-        """
 
     def dump_item(self, call_id, item, verbose):
         """Dump an item in the store.
@@ -109,6 +116,27 @@ class SQLStoreBackend(StoreBackendBase):
         verbose: int
             The level of verbosity
         """
+        path = os.path.join(*call_id)
+
+        if verbose > 10:
+            print("Persisting in %s" % path)
+
+        file = io.BytesIO()
+        try:
+            numpy_pickle.dump(item, file, compress=self.compress)
+            serialized_data = file.getvalue()
+        except PicklingError as e:
+            raise RuntimeError(
+                "Unable to cache to disk: failed to pickle output."
+            ) from e
+
+        with self.con:
+            self.con.execute(
+                "INSERT INTO cache (path, data) "
+                "VALUES (?, ?) "
+                "ON CONFLICT(path) DO UPDATE SET data = excluded.data",
+                (path, serialized_data),
+            )
 
     def clear_item(self, call_id):
         """Clear an item from the store.
@@ -118,6 +146,9 @@ class SQLStoreBackend(StoreBackendBase):
         call_id: list of str
             id to be cleared
         """
+        path = os.path.join(*call_id)
+        with self.con:
+            self.con.execute("DELETE FROM cache WHERE path=?", path)
 
     def contains_item(self, call_id):
         """Check if the store contains an item for a given id.
@@ -127,6 +158,12 @@ class SQLStoreBackend(StoreBackendBase):
         call_id: list of str
             id of the item to be checked
         """
+        path = os.path.join(*call_id)
+        with self.con.cursor() as cursor:
+            cursor.execute(
+                "SELECT 1 FROM cache WHERE path=? and data IS NOT NULL", (path,)
+            )
+        return cursor.fetchone() is not None
 
     def get_metadata(self, call_id):
         """Return actual metadata of an item.
@@ -141,6 +178,13 @@ class SQLStoreBackend(StoreBackendBase):
         metadata: dict
             Metadata associated to the call
         """
+        path = os.path.join(*call_id)
+        with self.con.cursor() as cursor:
+            cursor.execute("SELECT metadata FROM cache WHERE path=?", (path,))
+            metadata = cursor.fetchone()
+        if metadata is None:
+            return {}
+        return json.loads(metadata)
 
     def store_metadata(self, call_id, metadata):
         """Store metadata of a computation.
@@ -152,6 +196,15 @@ class SQLStoreBackend(StoreBackendBase):
         metadata: dict
             Metadata associated to the call
         """
+        path = os.path.join(*call_id)
+        metadata_str = json.dumps(metadata)
+        with self.con:
+            self.con.execute(
+                "INSERT INTO cache (path, metadata) "
+                "VALUES (?, ?) "
+                "ON CONFLICT(path) DO UPDATE SET metadata = excluded.metadata",
+                (path, metadata_str),
+            )
 
     def get_cached_func_code(self, func_id):
         """Get the code of the cached function.
@@ -166,8 +219,12 @@ class SQLStoreBackend(StoreBackendBase):
         func_code: str
             The code of the cached function
         """
+        path = os.path.join(*func_id)
+        with self.con.cursor() as cursor:
+            cursor.execute("SELECT code FROM func_code WHERE path=?", (path,))
+            return cursor.fetchone()
 
-    def store_cached_func_code(self, func_id, func_code):
+    def store_cached_func_code(self, func_id, func_code=None):
         """Store the code of the cached function.
 
         Parameters
@@ -177,6 +234,15 @@ class SQLStoreBackend(StoreBackendBase):
         func_code: str
             The code of the cached function
         """
+        if func_code is None:
+            return
+
+        path = os.path.join(*func_id)
+        with self.con:
+            self.con.execute(
+                "INSERT OR REPLACE INTO func_code (path, code) VALUES (?, ?)",
+                (path, func_code),
+            )
 
     def clear_path(self, path_id):
         """Clear all items with a common path in the store.
@@ -186,3 +252,27 @@ class SQLStoreBackend(StoreBackendBase):
         path_id: list of str
             Prefix id of item to be cleared
         """
+        if len(path_id) == 0:
+            with self.con:
+                self.con.execute("DELETE FROM cache")
+                self.con.execute("DELETE FROM func_code")
+                self.con.execute("VACUUM")
+            return
+
+        path = os.path.join(*path_id)
+        with self.con:
+            self.con.execute("DELETE FROM cache WHERE path=?", (path,))
+            self.con.execute("DELETE FROM func_code WHERE path=?", (path,))
+
+        pattern = os.path.join(path, "")
+        pattern = pattern.replace("\\", "\\\\")
+        pattern = pattern.replace("_", "\\_")
+        pattern = pattern.replace("%", "\\%")
+        pattern += "%"
+        with self.con:
+            self.con.execute(
+                "DELETE FROM cache WHERE path LIKE ? ESCAPE '\\'", (pattern,)
+            )
+            self.con.execute(
+                "DELETE FROM func_code WHERE path LIKE ? ESCAPE '\\'", (pattern,)
+            )

--- a/joblib/_sql_store_backend.py
+++ b/joblib/_sql_store_backend.py
@@ -1,0 +1,188 @@
+"""Store Backend using SQLite"""
+
+import os
+import sqlite3
+import time
+
+from ._store_backends import StoreBackendBase
+from .logger import format_time
+
+
+class SQLStoreBackend(StoreBackendBase):
+    """TODO"""
+
+    def configure(self, location, verbose=1, backend_options=None):
+        """Configures the store.
+
+        Parameters
+        ----------
+        location: string
+            The base location used by the store. On a filesystem, this
+            corresponds to a directory.
+        verbose: int
+            The level of verbosity of the store
+        backend_options: dict
+            Options to be used. The only valid option is 'compress'.
+        """
+        if backend_options is None:
+            backend_options = {}
+
+        self.location = location
+        # self.verbose = verbose
+        self.compress = backend_options.get("compress", False)
+
+        os.makedirs(os.path.dirname(self.location), exist_ok=True)
+        self.con = sqlite3.connect(self.location)
+
+        with self.con:
+            self.con.execute(
+                "CREATE TABLE IF NOT EXISTS cache (path TEXT PRIMARY KEY, data BLOB)"
+            )
+
+    def load_item(self, call_id, verbose, timestamp, metadata):
+        """Load an item from the store.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the call
+        verbose: int
+            The level of verbosity
+        timestamp: float
+            Time of the creation of the Memory in seconds (used for verbose logs)
+        metadata: dict
+            Metadata associated to the call.
+            If it contains 'input_args', it will be used by the verbose logs.
+
+        Returns
+        -------
+        The item associated to call_id
+        """
+        path = os.path.join(*call_id)
+
+        if verbose > 1:
+            ts_string = (
+                f"{format_time(time.time() - timestamp): <16}"
+                if timestamp is not None
+                else ""
+            )
+            signature = os.path.basename(call_id[0])
+            if metadata is not None and "input_args" in metadata:
+                kwargs = ", ".join(
+                    "{}={}".format(*item) for item in metadata["input_args"].items()
+                )
+                signature += f"({kwargs})"
+            msg = f"[Memory]{ts_string}: Loading {signature}"
+            if verbose < 10:
+                print(f"{msg}...")
+            else:
+                print(f"{msg} from {self.location}::{path}")
+
+        with self.con.cursor() as cursor:
+            cursor.execute("SELECT data FROM cache WHERE path=?", (path,))
+            row = cursor.fetchone()
+            if row is None:
+                raise KeyError(
+                    "Non-existing item (may have been cleared).\n"
+                    f"Path {path} does not exist"
+                )
+
+        """
+        # file-like object cannot be used when mmap_mode is set
+        if mmap_mode is None:
+            with self._open_item(filename, "rb") as f:
+                item = numpy_pickle.load(f)
+        else:
+            item = numpy_pickle.load(filename, mmap_mode=mmap_mode)
+        return item
+        """
+
+    def dump_item(self, call_id, item, verbose):
+        """Dump an item in the store.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the call
+        item: any
+            Item to be stored
+        verbose: int
+            The level of verbosity
+        """
+
+    def clear_item(self, call_id):
+        """Clear an item from the store.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id to be cleared
+        """
+
+    def contains_item(self, call_id):
+        """Check if the store contains an item for a given id.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the item to be checked
+        """
+
+    def get_metadata(self, call_id):
+        """Return actual metadata of an item.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the call
+
+        Returns
+        -------
+        metadata: dict
+            Metadata associated to the call
+        """
+
+    def store_metadata(self, call_id, metadata):
+        """Store metadata of a computation.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the call
+        metadata: dict
+            Metadata associated to the call
+        """
+
+    def get_cached_func_code(self, func_id):
+        """Get the code of the cached function.
+
+        Parameters
+        ----------
+        func_id: list of str
+            id of the cached function
+
+        Returns
+        -------
+        func_code: str
+            The code of the cached function
+        """
+
+    def store_cached_func_code(self, func_id, func_code):
+        """Store the code of the cached function.
+
+        Parameters
+        ----------
+        func_id: list of str
+            id of the cached function
+        func_code: str
+            The code of the cached function
+        """
+
+    def clear_path(self, path_id):
+        """Clear all items with a common path in the store.
+
+        Parameters
+        ----------
+        path_id: list of str
+            Prefix id of item to be cleared
+        """

--- a/joblib/_sql_store_backend.py
+++ b/joblib/_sql_store_backend.py
@@ -13,7 +13,7 @@ from .logger import format_time
 
 
 class SQLStoreBackend(StoreBackendBase):
-    """TODO"""
+    """A StoreBackend a sqlite database."""
 
     def configure(self, location, verbose=1, backend_options=None):
         """Configures the store.
@@ -32,7 +32,6 @@ class SQLStoreBackend(StoreBackendBase):
             backend_options = {}
 
         self.location = location
-        # self.verbose = verbose
         self.compress = backend_options.get("compress", False)
 
         os.makedirs(os.path.dirname(self.location), exist_ok=True)

--- a/joblib/_sql_store_backend.py
+++ b/joblib/_sql_store_backend.py
@@ -266,11 +266,7 @@ class SQLStoreBackend(StoreBackendBase):
             Prefix id of item to be cleared
         """
         if len(path_id) == 0:
-            with self.con:
-                self.con.execute("DELETE FROM cache")
-                self.con.execute("DELETE FROM func_code")
-                self.con.execute("VACUUM")
-            return
+            return self.clear()
 
         path = os.path.join(*path_id)
         with self.con:
@@ -289,3 +285,10 @@ class SQLStoreBackend(StoreBackendBase):
             self.con.execute(
                 "DELETE FROM func_code WHERE path LIKE ? ESCAPE '\\'", (pattern,)
             )
+
+    def clear(self):
+        """Clear the whole store content."""
+        with self.con:
+            self.con.execute("DELETE FROM cache")
+            self.con.execute("DELETE FROM func_code")
+            self.con.execute("VACUUM")

--- a/joblib/_sql_store_backend.py
+++ b/joblib/_sql_store_backend.py
@@ -292,3 +292,9 @@ class SQLStoreBackend(StoreBackendBase):
             self.con.execute("DELETE FROM cache")
             self.con.execute("DELETE FROM func_code")
         self.con.execute("VACUUM")
+
+    def __del__(self):
+        if self.con is None:
+            return
+        self.con.close()
+        self.con = None

--- a/joblib/_sql_store_backend.py
+++ b/joblib/_sql_store_backend.py
@@ -103,7 +103,7 @@ class SQLStoreBackend(StoreBackendBase):
         item = numpy_pickle.load(file)
         return item
 
-    def dump_item(self, call_id, item, verbose):
+    def dump_item(self, call_id, item, verbose=1):
         """Dump an item in the store.
 
         Parameters
@@ -142,7 +142,7 @@ class SQLStoreBackend(StoreBackendBase):
         """
         path = os.path.join(*call_id)
         with self.con:
-            self.con.execute("DELETE FROM cache WHERE path=?", path)
+            self.con.execute("DELETE FROM cache WHERE path=?", (path,))
 
     def contains_item(self, call_id):
         """Check if the store contains an item for a given id.
@@ -291,4 +291,4 @@ class SQLStoreBackend(StoreBackendBase):
         with self.con:
             self.con.execute("DELETE FROM cache")
             self.con.execute("DELETE FROM func_code")
-            self.con.execute("VACUUM")
+        self.con.execute("VACUUM")

--- a/joblib/_sql_store_backend.py
+++ b/joblib/_sql_store_backend.py
@@ -90,15 +90,16 @@ class SQLStoreBackend(StoreBackendBase):
             else:
                 print(f"{msg} from {self.location}::{path}")
 
-        with self.con.cursor() as cursor:
-            cursor.execute("SELECT data FROM cache WHERE path=?", (path,))
-            row = cursor.fetchone()
-            if row is None:
-                raise KeyError(
-                    "Non-existing item (may have been cleared).\n"
-                    f"Path {path} does not exist"
-                )
-            serialized_data = row[0]
+        cursor = self.con.cursor()
+        cursor.execute("SELECT data FROM cache WHERE path=?", (path,))
+        row = cursor.fetchone()
+        cursor.close()
+        if row is None:
+            raise KeyError(
+                "Non-existing item (may have been cleared).\n"
+                f"Path {path} does not exist"
+            )
+        serialized_data = row[0]
 
         file = io.BytesIO(serialized_data)
         item = numpy_pickle.load(file)
@@ -159,10 +160,8 @@ class SQLStoreBackend(StoreBackendBase):
             id of the item to be checked
         """
         path = os.path.join(*call_id)
-        with self.con.cursor() as cursor:
-            cursor.execute(
-                "SELECT 1 FROM cache WHERE path=? and data IS NOT NULL", (path,)
-            )
+        cursor = self.con.cursor()
+        cursor.execute("SELECT 1 FROM cache WHERE path=? and data IS NOT NULL", (path,))
         return cursor.fetchone() is not None
 
     def get_metadata(self, call_id):
@@ -179,12 +178,13 @@ class SQLStoreBackend(StoreBackendBase):
             Metadata associated to the call
         """
         path = os.path.join(*call_id)
-        with self.con.cursor() as cursor:
-            cursor.execute("SELECT metadata FROM cache WHERE path=?", (path,))
-            metadata = cursor.fetchone()
+        cursor = self.con.cursor()
+        cursor.execute("SELECT metadata FROM cache WHERE path=?", (path,))
+        metadata = cursor.fetchone()
+        cursor.close()
         if metadata is None:
             return {}
-        return json.loads(metadata)
+        return json.loads(metadata[0])
 
     def store_metadata(self, call_id, metadata):
         """Store metadata of a computation.
@@ -220,9 +220,13 @@ class SQLStoreBackend(StoreBackendBase):
             The code of the cached function
         """
         path = os.path.join(*func_id)
-        with self.con.cursor() as cursor:
-            cursor.execute("SELECT code FROM func_code WHERE path=?", (path,))
-            return cursor.fetchone()
+        cursor = self.con.cursor()
+        cursor.execute("SELECT code FROM func_code WHERE path=?", (path,))
+        code = cursor.fetchone()
+        cursor.close()
+        if code is None:
+            raise IOError(f"No function with id: {func_id}, in storage {self.location}")
+        return code[0]
 
     def store_cached_func_code(self, func_id, func_code=None):
         """Store the code of the cached function.
@@ -243,6 +247,22 @@ class SQLStoreBackend(StoreBackendBase):
                 "INSERT OR REPLACE INTO func_code (path, code) VALUES (?, ?)",
                 (path, func_code),
             )
+
+    def get_cached_func_info(self, func_id):
+        """Return information related to the cached function if it exists.
+
+        Parameters
+        ----------
+        func_id: list of str
+            id of the cached function
+
+        Returns
+        -------
+        func_info: dict
+            Information concerning the function
+        """
+        path = os.path.join(*func_id)
+        return {"location": f"{self.location}::{path}"}
 
     def clear_path(self, path_id):
         """Clear all items with a common path in the store.

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -51,39 +51,7 @@ class StoreBackendBase(metaclass=ABCMeta):
     location = None
 
     @abstractmethod
-    def create_location(self, location):
-        """Creates a location on the store.
-
-        Parameters
-        ----------
-        location: string
-            The location in the store. On a filesystem, this corresponds to a
-            directory.
-        """
-
-    @abstractmethod
-    def clear_location(self, location):
-        """Clears a location on the store.
-
-        Parameters
-        ----------
-        location: string
-            The location in the store. On a filesystem, this corresponds to a
-            directory or a filename absolute path
-        """
-
-    @abstractmethod
-    def get_items(self):
-        """Returns the whole list of items available in the store.
-
-        Returns
-        -------
-        The list of items identified by their ids (e.g filename in a
-        filesystem).
-        """
-
-    @abstractmethod
-    def configure(self, location, verbose=0, backend_options=dict()):
+    def configure(self, location, verbose, backend_options):
         """Configures the store.
 
         Parameters
@@ -96,6 +64,125 @@ class StoreBackendBase(metaclass=ABCMeta):
         backend_options: dict
             Contains a dictionary of named parameters used to configure the
             store backend.
+        """
+
+    @abstractmethod
+    def load_item(self, call_id, verbose, timestamp, metadata):
+        """Load an item from the store.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the call
+        verbose: int
+            The level of verbosity
+        timestamp: float
+            Time of the creation of the Memory in seconds (used for verbose logs)
+        metadata: dict
+            Metadata associated to the call.
+            If it contains input args, they will be used by the verbose logs.
+
+        Returns
+        -------
+        The item associated to call_id
+        """
+
+    @abstractmethod
+    def dump_item(self, call_id, item, verbose):
+        """Dump an item in the store.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the call
+        item: any
+            Item to be stored
+        verbose: int
+            The level of verbosity
+        """
+
+    @abstractmethod
+    def clear_item(self, call_id):
+        """Clear an item from the store.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id to be cleared
+        """
+
+    @abstractmethod
+    def contains_item(self, call_id):
+        """Check if the store contains an item for a given id.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the item to be checked
+        """
+
+    @abstractmethod
+    def get_metadata(self, call_id):
+        """Return actual metadata of an item.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the call
+
+        Returns
+        -------
+        metadata: dict
+            Metadata associated to the call
+        """
+
+    @abstractmethod
+    def store_metadata(self, call_id, metadata):
+        """Store metadata of a computation.
+
+        Parameters
+        ----------
+        call_id: list of str
+            id of the call
+        metadata: dict
+            Metadata associated to the call
+        """
+
+    @abstractmethod
+    def get_cached_func_code(self, func_id):
+        """Get the code of the cached function.
+
+        Parameters
+        ----------
+        func_id: list of str
+            id of the cached function
+
+        Returns
+        -------
+        func_code: str
+            The code of the cached function
+        """
+
+    @abstractmethod
+    def store_cached_func_code(self, func_id, func_code):
+        """Store the code of the cached function.
+
+        Parameters
+        ----------
+        func_id: list of str
+            id of the cached function
+        func_code: str
+            The code of the cached function
+        """
+
+    @abstractmethod
+    def clear_path(self, path_id):
+        """Clear all items with a common path in the store.
+
+        Parameters
+        ----------
+        path_id: list of str
+            Prefix id of item to be cleared
         """
 
 
@@ -276,15 +363,15 @@ class StoreBackendMixin(object):
         func_path = os.path.join(self.location, *call_id)
         return self.object_exists(func_path)
 
-    def clear_path(self, call_id):
+    def clear_path(self, path_id):
         """Clear all items with a common path in the store."""
-        func_path = os.path.join(self.location, *call_id)
+        func_path = os.path.join(self.location, *path_id)
         if self._item_exists(func_path):
             self.clear_location(func_path)
 
-    def store_cached_func_code(self, call_id, func_code=None):
+    def store_cached_func_code(self, func_id, func_code=None):
         """Store the code of the cached function."""
-        func_path = os.path.join(self.location, *call_id)
+        func_path = os.path.join(self.location, *func_id)
         if not self._item_exists(func_path):
             self.create_location(func_path)
 
@@ -293,9 +380,9 @@ class StoreBackendMixin(object):
             with self._open_item(filename, "wb") as f:
                 f.write(func_code.encode("utf-8"))
 
-    def get_cached_func_code(self, call_id):
-        """Store the code of the cached function."""
-        filename = os.path.join(self.location, *call_id, "func_code.py")
+    def get_cached_func_code(self, func_id):
+        """Get the code of the cached function."""
+        filename = os.path.join(self.location, *func_id, "func_code.py")
         try:
             with self._open_item(filename, "rb") as f:
                 return f.read().decode("utf-8")

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -269,27 +269,35 @@ class StoreBackendMixin(StoreBackendBase):
 
     @abstractmethod
     def create_location(self, location):
-        """Create object location on store
+        """Creates a location on the store.
 
         Parameters
         ----------
         location:
-            The location of the object to be created
+            The location in the store. On a filesystem, this corresponds to a
+            directory.
         """
 
     @abstractmethod
     def clear_location(self, location):
-        """Delete location on store.
+        """Clears a location on the store.
 
         Parameters
         ----------
         location:
-            The location to be cleared
+            The location in the store. On a filesystem, this corresponds to a
+            directory or a filename absolute path.
         """
 
     @abstractmethod
     def get_items(self):
-        """Returns the whole list of items available in the store."""
+        """Returns the whole list of items available in the store.
+
+        Returns
+        -------
+        The list of items identified by their ids (e.g filename in a
+        filesystem).
+        """
 
     def load_item(self, call_id, verbose=1, timestamp=None, metadata=None):
         """Load an item from the store given its id as a list of str."""

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -273,7 +273,7 @@ class StoreBackendMixin(StoreBackendBase):
 
         Parameters
         ----------
-        location:
+        location: string
             The location in the store. On a filesystem, this corresponds to a
             directory.
         """
@@ -284,7 +284,7 @@ class StoreBackendMixin(StoreBackendBase):
 
         Parameters
         ----------
-        location:
+        location: string
             The location in the store. On a filesystem, this corresponds to a
             directory or a filename absolute path.
         """

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -51,56 +51,6 @@ class StoreBackendBase(metaclass=ABCMeta):
     location = None
 
     @abstractmethod
-    def _open_item(self, f, mode):
-        """Opens an item on the store and return a file-like object.
-
-        This method is private and only used by the StoreBackendMixin object.
-
-        Parameters
-        ----------
-        f: a file-like object
-            The file-like object where an item is stored and retrieved
-        mode: string, optional
-            the mode in which the file-like object is opened allowed valued are
-            'rb', 'wb'
-
-        Returns
-        -------
-        a file-like object
-        """
-
-    @abstractmethod
-    def _item_exists(self, location):
-        """Checks if an item location exists in the store.
-
-        This method is private and only used by the StoreBackendMixin object.
-
-        Parameters
-        ----------
-        location: string
-            The location of an item. On a filesystem, this corresponds to the
-            absolute path, including the filename, of a file.
-
-        Returns
-        -------
-        True if the item exists, False otherwise
-        """
-
-    @abstractmethod
-    def _move_item(self, src, dst):
-        """Moves an item from src to dst in the store.
-
-        This method is private and only used by the StoreBackendMixin object.
-
-        Parameters
-        ----------
-        src: string
-            The source location of an item
-        dst: string
-            The destination location of an item
-        """
-
-    @abstractmethod
     def create_location(self, location):
         """Creates a location on the store.
 
@@ -158,6 +108,56 @@ class StoreBackendMixin(object):
     method has to have the same signature as the builtin open and return a
     file-like object.
     """
+
+    @abstractmethod
+    def _open_item(self, f, mode):
+        """Opens an item on the store and return a file-like object.
+
+        This method is private and only used by the StoreBackendMixin object.
+
+        Parameters
+        ----------
+        f: a file-like object
+            The file-like object where an item is stored and retrieved
+        mode: string, optional
+            the mode in which the file-like object is opened allowed valued are
+            'rb', 'wb'
+
+        Returns
+        -------
+        a file-like object
+        """
+
+    @abstractmethod
+    def _item_exists(self, location):
+        """Checks if an item location exists in the store.
+
+        This method is private and only used by the StoreBackendMixin object.
+
+        Parameters
+        ----------
+        location: string
+            The location of an item. On a filesystem, this corresponds to the
+            absolute path, including the filename, of a file.
+
+        Returns
+        -------
+        True if the item exists, False otherwise
+        """
+
+    @abstractmethod
+    def _move_item(self, src, dst):
+        """Moves an item from src to dst in the store.
+
+        This method is private and only used by the StoreBackendMixin object.
+
+        Parameters
+        ----------
+        src: string
+            The source location of an item
+        dst: string
+            The destination location of an item
+        """
 
     def load_item(self, call_id, verbose=1, timestamp=None, metadata=None):
         """Load an item from the store given its id as a list of str."""

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -342,14 +342,11 @@ class StoreBackendMixin(StoreBackendBase):
 
             def write_func(to_write, dest_filename):
                 with self._open_item(dest_filename, "wb") as f:
-                    try:
-                        numpy_pickle.dump(to_write, f, compress=self.compress)
-                    except PicklingError as e:
-                        raise RuntimeError(
-                            "Unable to cache to disk: failed to pickle output."
-                        ) from e
+                    numpy_pickle.dump(to_write, f, compress=self.compress)
 
             self._concurrency_safe_write(item, filename, write_func)
+        except PicklingError:
+            raise
         except Exception as e:  # noqa: E722
             warnings.warn(
                 "Unable to cache to disk. Possibly a race condition in the "

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -176,6 +176,21 @@ class StoreBackendBase(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def get_cached_func_info(self, func_id):
+        """Return information related to the cached function if it exists.
+
+        Parameters
+        ----------
+        func_id: list of str
+            id of the cached function
+
+        Returns
+        -------
+        func_info: dict
+            Information concerning the function
+        """
+
+    @abstractmethod
     def clear_path(self, path_id):
         """Clear all items with a common path in the store.
 
@@ -415,9 +430,9 @@ class StoreBackendMixin(StoreBackendBase):
         except:  # noqa: E722
             raise
 
-    def get_cached_func_info(self, call_id):
+    def get_cached_func_info(self, func_id):
         """Return information related to the cached function if it exists."""
-        return {"location": os.path.join(self.location, *call_id)}
+        return {"location": os.path.join(self.location, *func_id)}
 
     def clear(self):
         """Clear the whole store content."""

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -80,7 +80,7 @@ class StoreBackendBase(metaclass=ABCMeta):
             Time of the creation of the Memory in seconds (used for verbose logs)
         metadata: dict
             Metadata associated to the call.
-            If it contains input args, they will be used by the verbose logs.
+            If it contains 'input_args', it will be used by the verbose logs.
 
         Returns
         -------

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -45,7 +45,7 @@ def concurrency_safe_write(object_to_write, filename, write_func):
 
 
 class StoreBackendBase(metaclass=ABCMeta):
-    """Helper Abstract Base Class which defines all methods that
+    """Abstract Base Class which defines all methods that
     a StorageBackend must implement."""
 
     location = None
@@ -186,14 +186,20 @@ class StoreBackendBase(metaclass=ABCMeta):
         """
 
 
-class StoreBackendMixin(object):
+class StoreBackendMixin(StoreBackendBase):
     """Class providing all logic for managing the store in a generic way.
 
-    The StoreBackend subclass has to implement 3 methods: create_location,
-    clear_location and configure. The StoreBackend also has to provide
-    a private _open_item, _item_exists and _move_item methods. The _open_item
-    method has to have the same signature as the builtin open and return a
-    file-like object.
+    The StoreBackend subclass has to implement 7 methods.
+    One inherit from StoreBackendBase:
+      * configure
+    Three others are private methods:
+      * _open_item
+      * _item_exists
+      * _move_item
+    The three last ones are new public methods:
+      * create_location,
+      * clear_location
+      * get_items
     """
 
     @abstractmethod
@@ -245,6 +251,30 @@ class StoreBackendMixin(object):
         dst: string
             The destination location of an item
         """
+
+    @abstractmethod
+    def create_location(self, location):
+        """Create object location on store
+
+        Parameters
+        ----------
+        location:
+            The location of the object to be created
+        """
+
+    @abstractmethod
+    def clear_location(self, location):
+        """Delete location on store.
+
+        Parameters
+        ----------
+        location:
+            The location to be cleared
+        """
+
+    @abstractmethod
+    def get_items(self):
+        """Returns the whole list of items available in the store."""
 
     def load_item(self, call_id, verbose=1, timestamp=None, metadata=None):
         """Load an item from the store given its id as a list of str."""
@@ -487,7 +517,7 @@ class StoreBackendMixin(object):
         )
 
 
-class FileSystemStoreBackend(StoreBackendBase, StoreBackendMixin):
+class FileSystemStoreBackend(StoreBackendMixin):
     """A StoreBackend used with local or network file systems."""
 
     _open_item = staticmethod(open)

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -164,7 +164,7 @@ class StoreBackendBase(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def store_cached_func_code(self, func_id, func_code):
+    def store_cached_func_code(self, func_id, func_code=None):
         """Store the code of the cached function.
 
         Parameters
@@ -330,13 +330,9 @@ class StoreBackendMixin(StoreBackendBase):
                     try:
                         numpy_pickle.dump(to_write, f, compress=self.compress)
                     except PicklingError as e:
-                        # TODO(1.5) turn into error
-                        warnings.warn(
-                            "Unable to cache to disk: failed to pickle "
-                            "output. In version 1.5 this will raise an "
-                            f"exception. Exception: {e}.",
-                            FutureWarning,
-                        )
+                        raise RuntimeError(
+                            "Unable to cache to disk: failed to pickle output."
+                        ) from e
 
             self._concurrency_safe_write(item, filename, write_func)
         except Exception as e:  # noqa: E722

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -200,6 +200,10 @@ class StoreBackendBase(metaclass=ABCMeta):
             Prefix id of item to be cleared
         """
 
+    @abstractmethod
+    def clear(self):
+        """Clear the whole store content."""
+
 
 class StoreBackendMixin(StoreBackendBase):
     """Class providing all logic for managing the store in a generic way.

--- a/joblib/memory.py
+++ b/joblib/memory.py
@@ -25,6 +25,7 @@ import warnings
 import weakref
 
 from . import hashing
+from ._sql_store_backend import SQLStoreBackend
 from ._store_backends import (
     CacheWarning,  # noqa
     FileSystemStoreBackend,
@@ -71,7 +72,7 @@ class JobLibCollisionWarning(UserWarning):
     """Warn that there might be a collision between names of functions."""
 
 
-_STORE_BACKENDS = {"local": FileSystemStoreBackend}
+_STORE_BACKENDS = {"local": FileSystemStoreBackend, "sqlite": SQLStoreBackend}
 
 
 def register_store_backend(backend_name, backend):
@@ -986,6 +987,7 @@ class Memory(Logger):
         Type of store backend for reading/writing cache files.
         The 'local' backend is using regular filesystem operations to
         manipulate data (open, mv, etc) in the backend.
+        The 'sqlite' backend is using a sqlite database.
 
     mmap_mode: {None, 'r+', 'r', 'w+', 'c'}, optional
         The memmapping mode used when loading from cache

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -347,6 +347,8 @@ def test_memory_warning_collision_detection(tmpdir):
         a1(0)
 
     L = list(warninfo)
+    if len(L) == 5:
+        x, y, z, t, w = L
     assert len(L) == 2
     assert "cannot detect" in str(warninfo[0].message).lower()
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -55,14 +55,14 @@ def f(x, y=1):
 
 ###############################################################################
 # Helper function for the tests
-def check_identity_lazy(func, accumulator, location):
+def check_identity_lazy(func, accumulator, location, backend="local"):
     """Given a function and an accumulator (a list that grows every
     time the function is called), check that the function can be
     decorated by memory to be a lazy identity.
     """
     # Call each function with several arguments, and check that it is
     # evaluated only once per argument.
-    memory = Memory(location=location, verbose=0)
+    memory = Memory(location=location, backend=backend, verbose=0)
     func = memory.cache(func)
     for i in range(3):
         for _ in range(2):
@@ -260,7 +260,8 @@ def test_no_memory():
         assert len(accumulator) == current_accumulator + 1
 
 
-def test_memory_kwarg(tmpdir):
+@parametrize("backend", ["local", "sqlite"])
+def test_memory_kwarg(tmpdir, backend):
     "Test memory with a function with keyword arguments."
     accumulator = list()
 
@@ -268,9 +269,9 @@ def test_memory_kwarg(tmpdir):
         accumulator.append(1)
         return arg1
 
-    check_identity_lazy(g, accumulator, tmpdir.strpath)
+    check_identity_lazy(g, accumulator, tmpdir.strpath, backend)
 
-    memory = Memory(location=tmpdir.strpath, verbose=0)
+    memory = Memory(location=tmpdir.strpath, backend=backend, verbose=0)
     g = memory.cache(g)
     # Smoke test with an explicit keyword argument:
     assert g(arg1=30, arg2=2) == 30
@@ -288,9 +289,10 @@ def test_memory_lambda(tmpdir):
     check_identity_lazy(lambda x: helper(x), accumulator, tmpdir.strpath)
 
 
-def test_memory_name_collision(tmpdir):
+@parametrize("backend", ["local", "sqlite"])
+def test_memory_name_collision(tmpdir, backend):
     "Check that name collisions with functions will raise warnings"
-    memory = Memory(location=tmpdir.strpath, verbose=0)
+    memory = Memory(location=tmpdir.strpath, backend=backend, verbose=0)
 
     @memory.cache
     def name_collision(x):
@@ -399,8 +401,8 @@ def test_argument_change(tmpdir):
 
 
 @with_numpy
-@parametrize("mmap_mode", [None, "r"])
-def test_memory_numpy(tmpdir, mmap_mode):
+@parametrize("backend, mmap_mode", [("local", None), ("local", "r"), ("sqlite", None)])
+def test_memory_numpy(tmpdir, backend, mmap_mode):
     "Test memory with a function with numpy arrays."
     accumulator = list()
 
@@ -408,7 +410,9 @@ def test_memory_numpy(tmpdir, mmap_mode):
         accumulator.append(1)
         return arg
 
-    memory = Memory(location=tmpdir.strpath, mmap_mode=mmap_mode, verbose=0)
+    memory = Memory(
+        location=tmpdir.strpath, backend=backend, mmap_mode=mmap_mode, verbose=0
+    )
     cached_n = memory.cache(n)
 
     rnd = np.random.RandomState(0)
@@ -481,9 +485,10 @@ def test_memorized_result_forwards_mmap_mode(tmpdir):
     assert isinstance(direct.get(), np.memmap)
 
 
-def test_memory_exception(tmpdir):
+@parametrize("backend", ["local", "sqlite"])
+def test_memory_exception(tmpdir, backend):
     """Smoketest the exception handling of Memory."""
-    memory = Memory(location=tmpdir.strpath, verbose=0)
+    memory = Memory(location=tmpdir.strpath, backend=backend, verbose=0)
 
     class MyException(Exception):
         pass

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -671,11 +671,13 @@ def test_call_and_shelve(tmpdir):
     for func, Result in zip(
         (
             MemorizedFunc(f, tmpdir.strpath),
+            MemorizedFunc(f, tmpdir.strpath + ".db", "sqlite"),
             NotMemorizedFunc(f),
-            Memory(location=tmpdir.strpath, verbose=0).cache(f),
-            Memory(location=None).cache(f),
+            Memory(tmpdir.strpath, verbose=0).cache(f),
+            Memory(tmpdir.strpath + ".bis.db", "sqlite", verbose=0).cache(f),
+            Memory(None).cache(f),
         ),
-        (MemorizedResult, NotMemorizedResult, MemorizedResult, NotMemorizedResult),
+        [MemorizedResult, MemorizedResult, NotMemorizedResult] * 2,
     ):
         assert func(2) == 5
         result = func.call_and_shelve(2)

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -21,7 +21,11 @@ from pathlib import Path
 
 import pytest
 
-from joblib._store_backends import FileSystemStoreBackend, StoreBackendBase
+from joblib._store_backends import (
+    FileSystemStoreBackend,
+    StoreBackendBase,
+    StoreBackendMixin,
+)
 from joblib.hashing import hash
 from joblib.memory import (
     _FUNCTION_HASHES,
@@ -1180,7 +1184,7 @@ class IncompleteStoreBackend(StoreBackendBase):
     pass
 
 
-class DummyStoreBackend(StoreBackendBase):
+class DummyStoreBackend(StoreBackendMixin):
     """A dummy store backend that does nothing."""
 
     def _open_item(self, *args, **kwargs):
@@ -1198,10 +1202,6 @@ class DummyStoreBackend(StoreBackendBase):
     def create_location(self, location):
         """Create location on store."""
         "Does nothing"
-
-    def exists(self, obj):
-        """Check if an object exists in the store"""
-        return False
 
     def clear_location(self, obj):
         """Clear object on store"""

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -103,25 +103,24 @@ def test_memory_integration(tmpdir):
     check_identity_lazy(f, accumulator, tmpdir.strpath)
 
     # Now test clearing
-    for compress in (False, True):
-        for mmap_mode in ("r", None):
-            memory = Memory(
-                location=tmpdir.strpath,
-                verbose=10,
-                mmap_mode=mmap_mode,
-                compress=compress,
-            )
-            # First clear the cache directory, to check that our code can
-            # handle that
-            # NOTE: this line would raise an exception, as the database file is
-            # still open; we ignore the error since we want to test what
-            # happens if the directory disappears
-            shutil.rmtree(tmpdir.strpath, ignore_errors=True)
-            g = memory.cache(f)
-            g(1)
-            g.clear(warn=False)
-            current_accumulator = len(accumulator)
-            out = g(1)
+    for compress, mmap_mode in ((False, "r"), (False, None), (True, None)):
+        memory = Memory(
+            location=tmpdir.strpath,
+            verbose=10,
+            mmap_mode=mmap_mode,
+            compress=compress,
+        )
+        # First clear the cache directory, to check that our code can
+        # handle that
+        # NOTE: this line would raise an exception, as the database file is
+        # still open; we ignore the error since we want to test what
+        # happens if the directory disappears
+        shutil.rmtree(tmpdir.strpath, ignore_errors=True)
+        g = memory.cache(f)
+        g(1)
+        g.clear(warn=False)
+        current_accumulator = len(accumulator)
+        out = g(1)
 
         assert len(accumulator) == current_accumulator + 1
         # Also, check that Memory.eval works similarly

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -346,7 +346,8 @@ def test_memory_warning_collision_detection(tmpdir):
         b1(1)
         a1(0)
 
-    assert len(list(warninfo)) == 2
+    L = list(warninfo)
+    assert len(L) == 2
     assert "cannot detect" in str(warninfo[0].message).lower()
 
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -346,7 +346,7 @@ def test_memory_warning_collision_detection(tmpdir):
         b1(1)
         a1(0)
 
-    L = list(warninfo)
+    L = list(w.message for w in warninfo)
     if len(L) == 5:
         x, y, z, t, w = L
     assert len(L) == 2

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -346,7 +346,7 @@ def test_memory_warning_collision_detection(tmpdir):
         b1(1)
         a1(0)
 
-    assert len(warninfo) == 2
+    assert len(list(warninfo)) == 2
     assert "cannot detect" in str(warninfo[0].message).lower()
 
 

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -346,10 +346,7 @@ def test_memory_warning_collision_detection(tmpdir):
         b1(1)
         a1(0)
 
-    L = list(w.message for w in warninfo)
-    if len(L) == 5:
-        x, y, z, t, w = L
-    assert len(L) == 2
+    assert len(warninfo) == 2
     assert "cannot detect" in str(warninfo[0].message).lower()
 
 

--- a/joblib/test/test_memory_async.py
+++ b/joblib/test/test_memory_async.py
@@ -40,25 +40,24 @@ async def test_memory_integration_async(tmpdir):
     await check_identity_lazy_async(f, accumulator, tmpdir.strpath)
 
     # Now test clearing
-    for compress in (False, True):
-        for mmap_mode in ("r", None):
-            memory = Memory(
-                location=tmpdir.strpath,
-                verbose=10,
-                mmap_mode=mmap_mode,
-                compress=compress,
-            )
-            # First clear the cache directory, to check that our code can
-            # handle that
-            # NOTE: this line would raise an exception, as the database
-            # file is still open; we ignore the error since we want to
-            # test what happens if the directory disappears
-            shutil.rmtree(tmpdir.strpath, ignore_errors=True)
-            g = memory.cache(f)
-            await g(1)
-            g.clear(warn=False)
-            current_accumulator = len(accumulator)
-            out = await g(1)
+    for compress, mmap_mode in ((False, "r"), (False, None), (True, None)):
+        memory = Memory(
+            location=tmpdir.strpath,
+            verbose=10,
+            mmap_mode=mmap_mode,
+            compress=compress,
+        )
+        # First clear the cache directory, to check that our code can
+        # handle that
+        # NOTE: this line would raise an exception, as the database
+        # file is still open; we ignore the error since we want to
+        # test what happens if the directory disappears
+        shutil.rmtree(tmpdir.strpath, ignore_errors=True)
+        g = memory.cache(f)
+        await g(1)
+        g.clear(warn=False)
+        current_accumulator = len(accumulator)
+        out = await g(1)
 
         assert len(accumulator) == current_accumulator + 1
         # Also, check that Memory.eval works similarly

--- a/joblib/test/test_store_backends.py
+++ b/joblib/test/test_store_backends.py
@@ -90,5 +90,5 @@ def test_warning_on_pickling_error(tmpdir):
     backend.location = tmpdir.join("test_warning_on_pickling_error").strpath
     backend.compress = None
 
-    with pytest.warns(FutureWarning, match="not picklable"):
+    with pytest.raises(PicklingError, match="not picklable"):
         backend.dump_item("testpath", UnpicklableObject())

--- a/joblib/test/test_store_backends.py
+++ b/joblib/test/test_store_backends.py
@@ -1,16 +1,12 @@
-try:
-    # Python 2.7: use the C pickle to speed up
-    # test_concurrency_safe_write which pickles big python objects
-    import cPickle as cpickle
-except ImportError:
-    import pickle as cpickle
 import functools
+import pickle
 import time
 from pickle import PicklingError
 
 import pytest
 
 from joblib import Parallel, delayed
+from joblib._sql_store_backend import SQLStoreBackend
 from joblib._store_backends import (
     CacheWarning,
     FileSystemStoreBackend,
@@ -23,14 +19,14 @@ from joblib.testing import parametrize, timeout
 
 def write_func(output, filename):
     with open(filename, "wb") as f:
-        cpickle.dump(output, f)
+        pickle.dump(output, f)
 
 
 def load_func(expected, filename):
     for i in range(10):
         try:
             with open(filename, "rb") as f:
-                reloaded = cpickle.load(f)
+                reloaded = pickle.load(f)
             break
         except (OSError, IOError):
             # On Windows you can have WindowsError ([Error 5] Access
@@ -92,3 +88,29 @@ def test_warning_on_pickling_error(tmpdir):
 
     with pytest.raises(PicklingError, match="not picklable"):
         backend.dump_item("testpath", UnpicklableObject())
+
+
+@parametrize("klass", [FileSystemStoreBackend, SQLStoreBackend])
+def test_metadata(tmpdir, klass):
+    backend = klass()
+    backend.configure(tmpdir.join("joblib").strpath)
+    call_id = ("fun", "input")
+    metadata = {"a": "b"}
+    new_metadata = {"c": "d"}
+    item = "item"
+
+    assert backend.get_metadata(call_id) == dict()
+    backend.store_metadata(call_id, metadata)
+    assert backend.get_metadata(call_id) == metadata
+    backend.dump_item(call_id, item)
+    assert backend.get_metadata(call_id) == metadata
+    backend.dump_item(call_id, "new_item")
+    assert backend.get_metadata(call_id) == metadata
+    backend.store_metadata(call_id, new_metadata)
+    assert backend.get_metadata(call_id) == new_metadata
+    backend.clear_item(call_id)
+    assert backend.get_metadata(call_id) == dict()
+    backend.store_metadata(call_id, metadata)
+    assert backend.get_metadata(call_id) == metadata
+    backend.clear_path([])
+    assert backend.get_metadata(call_id) == dict()


### PR DESCRIPTION
The issue #1806 suggests to add a new StoreBackend using a single SQL file. This PR implements such a backend using sqlite.
I edited `StoreBackendBase` such that it now requires an implementation for all methods used by `Memory`.
I added a new backend named `SQLSotreBackend` that can be used with `Memory(location="path_to_database.db", backend="sqlite")`.

Fixes: #1806 