### PR TITLE
PERF Prevent Python worker oversaturation/oversubscription

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           - name: one-cpu
             os: ubuntu-latest
             PYTHON_VERSION: "3.12"
-            LOKY_MAX_CPU_COUNT: 1
+            ONE_CPU: "1"
           - name: default-backend-threading
             os: ubuntu-latest
             PYTHON_VERSION: "3.9"

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -13,7 +13,7 @@ fi
 
 if [[ "$ONE_CPU" == "1" ]]; then
     # Note that ONE_CPU should only be set on Linux:
-    PYTEST_PREFIX="tasket -c 0"
+    PYTEST_PREFIX="taskset -c 0"
 else
     PYTEST_PREFIX=""
 fi

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -11,6 +11,13 @@ if [[ "$PYTHON_VERSION" == free-threaded* ]]; then
     export PYTHON_GIL=0
 fi
 
+if [[ "$ONE_CPU" == "1" ]]; then
+    # Note that ONE_CPU should only be set on Linux:
+    PYTEST_PREFIX="tasket -c 0"
+else
+    PYTEST_PREFIX=""
+fi
+
 which python
 # Show python version and build information (e.g. free-threaded or not)
 python -VV
@@ -18,7 +25,7 @@ python -c "import multiprocessing as mp; print('multiprocessing.cpu_count():', m
 python -c "import joblib; print('joblib.cpu_count():', joblib.cpu_count())"
 
 if [[ "$SKLEARN_TESTS" != "true" ]]; then
-    pytest joblib -vl --timeout=120 --cov=joblib --cov-report xml
+    $PYTEST_PREFIX pytest joblib -vl --timeout=120 --cov=joblib --cov-report xml
 
     # doctests are not compatile with default_backend=threading
     if [[ "$JOBLIB_TESTS_DEFAULT_PARALLEL_BACKEND" != "threading" ]]; then
@@ -37,6 +44,6 @@ else
     NEW_TEST_DIR=$(mktemp -d)
     cd $NEW_TEST_DIR
 
-    pytest -vl --maxfail=5 -p no:doctest \
+    $PYTEST_PREFIX pytest -vl --maxfail=5 -p no:doctest \
         --pyargs sklearn
 fi

--- a/doc/user_guide/parallel.rst
+++ b/doc/user_guide/parallel.rst
@@ -70,7 +70,9 @@ extension that releases the Python Global Interpreter Lock (GIL) during
 most of its computation then it is more efficient to use threads instead
 of Python processes as concurrent workers. For instance this is the case
 if you write the CPU intensive part of your code inside a `with nogil`_
-block of a Cython function.
+block of a Cython function. However, starting with Python 3.14, there is
+a free-threaded version of Python that doesn't have a GIL, and it can benefit
+from the ``'threaded'`` backend.
 
 .. _`with nogil`: https://docs.cython.org/src/userguide/external_C_code.html#acquiring-and-releasing-the-gil
 
@@ -253,6 +255,24 @@ further hinder the performance of the computation. It is generally better to
 avoid using significantly more processes or threads than the number of CPUs on
 a machine.
 
+Nested :class:`joblib.Parallel`
+-------------------------------
+
+A nested :class:`joblib.Parallel` loop is one where the :class:`joblib.delayed`
+tasks in the top level loop create their own :class:`joblib.Parallel`. It can suffer from over-subscription if the product of the size of two worker pools is bigger than the number of available cores.
+
+Starting with version 1.6, in order to avoid over-subscription, the inner loop
+can use ``n_jobs=-1``. Each inner :class:`joblib.Parallel` will be limited to
+the number of cores divided by the outer by ``n_jobs`` in the outer
+:class:`joblib.Parallel`.
+
+For example, if you have 10 cores in your CPU, and the outer
+:class:`joblib.Parallel` has ``n_jobs=5``, a nested :class:`joblib.Parallel`
+should be set to ``n_jobs=-1``, and it will then only start 2 workers. The
+result will be 5×2=10 workers.
+
+Third-party libraries
+---------------------
 Some third-party libraries -- *e.g.* the BLAS runtime used by ``numpy`` --
 internally manage a thread-pool to perform their computations. The default
 behavior is generally to use a number of threads equals to the number of CPUs

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -64,6 +64,8 @@ class ParallelBackendBase(metaclass=ABCMeta):
         "VECLIB_MAXIMUM_THREADS",
         "NUMBA_NUM_THREADS",
         "NUMEXPR_NUM_THREADS",
+        # This sets a soft max on loky.cpu_count() in workers:
+        "LOKY_MAX_CPU_COUNT",
     ]
 
     TBB_ENABLE_IPC_VAR = "ENABLE_IPC"

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -8,6 +8,8 @@ import os
 import threading
 import warnings
 from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Callable
 
 from ._multiprocessing_helpers import mp
 from ._utils import (
@@ -538,10 +540,20 @@ class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):
         return self._pool
 
 
-def _set_env(env: dict[str, str]) -> None:
-    """Set the given environment variables."""
-    for key, value in env.items():
-        os.environ[key] = value
+@dataclass
+class _SetEnvInitializer:
+    """
+    Pickleable initializer for multiprocessing workers.
+    """
+
+    env: dict[str, str]
+    initializer: None | Callable[..., Any]
+
+    def __call__(self, *args, **kwargs) -> Any:
+        for key, value in self.env.items():
+            os.environ[key] = value
+        if self.initializer is not None:
+            return self.initializer(*args, **kwargs)
 
 
 class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin, ParallelBackendBase):
@@ -627,10 +639,13 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin, ParallelBacken
 
         # Make sure to free as much memory as possible before forking
         gc.collect()
+        initializer = _SetEnvInitializer(
+            self._prepare_worker_env(n_jobs),
+            memmapping_pool_kwargs.pop("initializer", None),
+        )
         self._pool = MemmappingPool(
             n_jobs,
-            initializer=_set_env,
-            initargs=(self._prepare_worker_env(n_jobs),),
+            initializer=initializer,
             **memmapping_pool_kwargs,
         )
         self.parallel = parallel

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -2,6 +2,8 @@
 Backends for embarrassingly parallel code.
 """
 
+from __future__ import annotations
+
 import contextlib
 import gc
 import os

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -510,6 +510,12 @@ class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):
         return self._pool
 
 
+def _set_env(env: dict[str, str]) -> None:
+    """Set the given environment variables."""
+    for key, value in env.items():
+        os.environ[key] = value
+
+
 class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin, ParallelBackendBase):
     """A ParallelBackend which will use a multiprocessing.Pool.
 
@@ -593,7 +599,12 @@ class MultiprocessingBackend(PoolManagerMixin, AutoBatchingMixin, ParallelBacken
 
         # Make sure to free as much memory as possible before forking
         gc.collect()
-        self._pool = MemmappingPool(n_jobs, **memmapping_pool_kwargs)
+        self._pool = MemmappingPool(
+            n_jobs,
+            initializer=_set_env,
+            initargs=(self._prepare_worker_env(n_jobs),),
+            **memmapping_pool_kwargs,
+        )
         self.parallel = parallel
         return n_jobs
 

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -26,6 +26,26 @@ if mp is not None:
     from .pool import MemmappingPool
 
 
+class _MaxCores(threading.local):
+    """Track the number of cores available to this thread."""
+
+    _thread_limit = None
+
+    def get(self) -> int:
+        """Number of cores available to this thread."""
+        process_limit = cpu_count()
+        if self._thread_limit is None:
+            return process_limit
+        return min(process_limit, self._thread_limit)
+
+    def set_thread_limit(self, cores: int) -> None:
+        """Set the maximum number of cores available to this thread."""
+        self._thread_limit = cores
+
+
+_MAX_CORES = _MaxCores()
+
+
 class ParallelBackendBase(metaclass=ABCMeta):
     """Helper abc which defines all methods a ParallelBackend must implement"""
 
@@ -229,7 +249,7 @@ class ParallelBackendBase(metaclass=ABCMeta):
         OpenBLAS libraries in the child processes.
         """
         explicit_n_threads = self.inner_max_num_threads
-        default_n_threads = max(cpu_count() // n_jobs, 1)
+        default_n_threads = max(_MAX_CORES.get() // n_jobs, 1)
 
         # Set the inner environment variables to self.inner_max_num_threads if
         # it is given. Else, default to cpu_count // n_jobs unless the variable
@@ -319,7 +339,7 @@ class PoolManagerMixin(object):
             # to sequential mode
             return 1
         elif n_jobs < 0:
-            n_jobs = max(cpu_count() + 1 + n_jobs, 1)
+            n_jobs = max(_MAX_CORES.get() + 1 + n_jobs, 1)
         return n_jobs
 
     def terminate(self):
@@ -505,8 +525,16 @@ class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):
         The actual pool of worker threads is only initialized at the first
         call to apply_async.
         """
+        # Import here to prevent circular import:
+        from joblib.parallel import effective_n_jobs
+
         if self._pool is None:
-            self._pool = ThreadPool(self._n_jobs)
+            available_cores = effective_n_jobs(-1)
+            cores_per_thread = max(available_cores // self._n_jobs, 1)
+            self._pool = ThreadPool(
+                self._n_jobs,
+                initializer=lambda: _MAX_CORES.set_thread_limit(cores_per_thread),
+            )
         return self._pool
 
 
@@ -698,7 +726,7 @@ class LokyBackend(AutoBatchingMixin, ParallelBackendBase):
                 )
             return 1
         elif n_jobs < 0:
-            n_jobs = max(cpu_count() + 1 + n_jobs, 1)
+            n_jobs = max(_MAX_CORES.get() + 1 + n_jobs, 1)
         return n_jobs
 
     def submit(self, func, callback=None):

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -51,6 +51,16 @@ class _MaxCores(threading.local):
 _MAX_CORES = _MaxCores()
 
 
+def set_thread_cores_limit(cores: int) -> None:
+    """
+    Set the maximum number of cores available to this thread.
+
+    Allows for other thread pool implementations to interoperate with joblib's
+    core limiting functionality.
+    """
+    _MAX_CORES.set_thread_limit(cores)
+
+
 def _split_up_cores(total_cores: int, n_jobs: int) -> int:
     """
     Given the total number of cores and a number of workers, come up with a
@@ -560,7 +570,7 @@ class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):
             cores_per_thread = _split_up_cores(available_cores, self._n_jobs)
             self._pool = ThreadPool(
                 self._n_jobs,
-                initializer=lambda: _MAX_CORES.set_thread_limit(cores_per_thread),
+                initializer=lambda: set_thread_cores_limit(cores_per_thread),
             )
         return self._pool
 

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -11,6 +11,7 @@ import threading
 import warnings
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
+from math import ceil
 from typing import Any, Callable
 
 from ._multiprocessing_helpers import mp
@@ -48,6 +49,28 @@ class _MaxCores(threading.local):
 
 
 _MAX_CORES = _MaxCores()
+
+
+def _split_up_cores(total_cores: int, n_jobs: int) -> int:
+    """
+    Given the total number of cores and a number of workers, come up with a
+    reasonable number of cores per worker.
+
+    The algorithm tries to compromise between two extremes:
+
+    With ``total_cores // n_jobs``, you can end up not using all cores.  So e.g
+    with 16 cores and 9 workers, you end up only using 9 cores instead of 16.
+
+    With ``int(ceil(total_cores / n_jobs))``, you can end up with significant
+    over-saturation.  So e.g with 16 cores and 15 workers, you end up with 30
+    assigned cores for only 16 available ones.
+    """
+    upper = max(int(ceil(total_cores / n_jobs)), 1)
+    lower = max(total_cores // n_jobs, 1)
+    if upper * n_jobs <= total_cores * 1.25:
+        return upper
+    else:
+        return lower
 
 
 class ParallelBackendBase(metaclass=ABCMeta):
@@ -253,7 +276,7 @@ class ParallelBackendBase(metaclass=ABCMeta):
         OpenBLAS libraries in the child processes.
         """
         explicit_n_threads = self.inner_max_num_threads
-        default_n_threads = max(_MAX_CORES.get() // n_jobs, 1)
+        default_n_threads = _split_up_cores(_MAX_CORES.get(), n_jobs)
 
         # Set the inner environment variables to self.inner_max_num_threads if
         # it is given. Else, default to cpu_count // n_jobs unless the variable
@@ -534,7 +557,7 @@ class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):
 
         if self._pool is None:
             available_cores = effective_n_jobs(-1)
-            cores_per_thread = max(available_cores // self._n_jobs, 1)
+            cores_per_thread = _split_up_cores(available_cores, self._n_jobs)
             self._pool = ThreadPool(
                 self._n_jobs,
                 initializer=lambda: _MAX_CORES.set_thread_limit(cores_per_thread),

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -51,16 +51,6 @@ class _MaxCores(threading.local):
 _MAX_CORES = _MaxCores()
 
 
-def set_thread_cores_limit(cores: int) -> None:
-    """
-    Set the maximum number of cores available to this thread.
-
-    Allows for other thread pool implementations to interoperate with joblib's
-    core limiting functionality.
-    """
-    _MAX_CORES.set_thread_limit(cores)
-
-
 def _split_up_cores(total_cores: int, n_jobs: int) -> int:
     """
     Given the total number of cores and a number of workers, come up with a
@@ -570,7 +560,7 @@ class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):
             cores_per_thread = _split_up_cores(available_cores, self._n_jobs)
             self._pool = ThreadPool(
                 self._n_jobs,
-                initializer=lambda: set_thread_cores_limit(cores_per_thread),
+                initializer=lambda: _MAX_CORES.set_thread_limit(cores_per_thread),
             )
         return self._pool
 

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -265,11 +265,15 @@ class parallel_config:
         of Python worker processes when ``backend="loky"`` or the size of the
         thread-pool when ``backend="threading"``.
         This argument is converted to an integer, rounded below for float.
-        If -1 is given, `joblib` tries to use all CPUs. The number of CPUs
-        ``n_cpus`` is obtained with :func:`~cpu_count`.
+        If -1 is given, `joblib` tries to use all available CPUs. The number
+        of CPUs ``n_cpus`` is obtained with :func:`~cpu_count`. ``n_cpus``
+        may be further limited if this instance is being started inside a
+        worker for another :class:`~Parallel`, to ensure the number of
+        workers (threads or processes) doesn't exceed the number of cores
+        available to the top-level process.
         For n_jobs below -1, (n_cpus + 1 + n_jobs) are used. For instance,
-        using ``n_jobs=-2`` will result in all CPUs but one being used.
-        This argument can also go above ``n_cpus``, which will cause
+        using ``n_jobs=-2`` will result in all available CPUs but one being
+        used. n_jobs can also go above ``n_cpus``, which will cause
         oversubscription. In some cases, slight oversubscription can be
         beneficial, e.g., for tasks with large I/O operations.
         If 1 is given, no parallel computing code is used at all, and the
@@ -989,11 +993,15 @@ class Parallel(Logger):
         of Python worker processes when ``backend="loky"`` or the size of
         the thread-pool when ``backend="threading"``.
         This argument is converted to an integer, rounded below for float.
-        If -1 is given, `joblib` tries to use all CPUs. The number of CPUs
-        ``n_cpus`` is obtained with :func:`~cpu_count`.
+        If -1 is given, `joblib` tries to use all available CPUs. The number
+        of CPUs ``n_cpus`` is obtained with :func:`~cpu_count`. ``n_cpus``
+        may be further limited if this instance is being started inside a
+        worker for another :class:`~Parallel`, to ensure the number of
+        workers (threads or processes) doesn't exceed the number of cores
+        available to the top-level process.
         For n_jobs below -1, (n_cpus + 1 + n_jobs) are used. For instance,
-        using ``n_jobs=-2`` will result in all CPUs but one being used.
-        This argument can also go above ``n_cpus``, which will cause
+        using ``n_jobs=-2`` will result in all available CPUs but one being
+        used. n_jobs can also go above ``n_cpus``, which will cause
         oversubscription. In some cases, slight oversubscription can be
         beneficial, e.g., for tasks with large I/O operations.
         If 1 is given, no parallel computing code is used at all, and the

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -35,7 +35,6 @@ from ._parallel_backends import (
     ParallelBackendBase,  # noqa
     SequentialBackend,
     ThreadingBackend,
-    set_thread_cores_limit,  # noqa
 )
 from ._utils import _Sentinel, eval_expr
 from .disk import memstr_to_bytes

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -35,6 +35,7 @@ from ._parallel_backends import (
     ParallelBackendBase,  # noqa
     SequentialBackend,
     ThreadingBackend,
+    set_thread_cores_limit,  # noqa
 )
 from ._utils import _Sentinel, eval_expr
 from .disk import memstr_to_bytes

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -181,7 +181,7 @@ def _measure_effective() -> tuple[int, int]:
     return effective_n_jobs(-1), effective_n_jobs(-2)
 
 
-@parametrize("backend", ALL_VALID_BACKENDS)
+@parametrize("backend", PARALLEL_BACKENDS)
 def test_negative_effective_n_jobs_affected_by_parent_pool(backend):
     n_jobs = max(cpu_count() // 2, 1)
     results = set(

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -20,12 +20,14 @@ from multiprocessing import TimeoutError
 from pickle import PicklingError
 from time import sleep
 from traceback import format_exception
+from uuid import uuid4
 
 import pytest
 
 import joblib
 from joblib import dump, load, parallel
 from joblib._multiprocessing_helpers import mp
+from joblib._parallel_backends import _SetEnvInitializer
 from joblib.test.common import (
     IS_GIL_DISABLED,
     np,
@@ -2267,3 +2269,26 @@ def test_initializer_not_reused(n_jobs):
     assert len(pids) == n_repetitions * n_jobs, (
         "The workers should not be reused when the initializer arguments change"
     )
+
+
+def test_set_env_initializer() -> None:
+    """
+    ``_SetEnvInitializer()`` sets environment variables and optionally calls an
+    initializer.
+    """
+    k1 = str(uuid4())
+    k2 = str(uuid4())
+    svi = _SetEnvInitializer({k1: "A", k2: "B"}, None)
+    assert k1 not in os.environ
+    assert k2 not in os.environ
+    svi()
+    assert os.environ[k1] == "A"
+    assert os.environ[k2] == "B"
+
+    mylist = []
+    svi = _SetEnvInitializer({k1: "C", k2: "D"}, mylist.append)
+    assert not mylist
+    svi(123)
+    assert os.environ[k1] == "C"
+    assert os.environ[k2] == "D"
+    assert mylist == [123]

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -177,6 +177,25 @@ def test_effective_n_jobs_None(context, backend_n_jobs, expected_n_jobs):
     assert effective_n_jobs(n_jobs=None) == 1
 
 
+def _measure_effective() -> tuple[int, int]:
+    return effective_n_jobs(-1), effective_n_jobs(-2)
+
+
+@parametrize("backend", ALL_VALID_BACKENDS)
+def test_negative_effective_n_jobs_affected_by_parent_pool(backend):
+    n_jobs = max(cpu_count() // 2, 1)
+    results = set(
+        Parallel(n_jobs=n_jobs, backend=backend)(
+            (delayed(_measure_effective)() for _ in range(cpu_count() * 10))
+        )
+    )
+    assert len(results) == 1
+
+    (available_in_worker, available_in_worker_minus_1) = results.pop()
+    assert available_in_worker_minus_1 == max(available_in_worker - 1, 1)
+    assert available_in_worker == max(cpu_count() // n_jobs, 1)
+
+
 ###############################################################################
 # Test parallel
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -27,7 +27,7 @@ import pytest
 import joblib
 from joblib import dump, load, parallel
 from joblib._multiprocessing_helpers import mp
-from joblib._parallel_backends import _SetEnvInitializer
+from joblib._parallel_backends import _SetEnvInitializer, _split_up_cores
 from joblib.test.common import (
     IS_GIL_DISABLED,
     np,
@@ -190,6 +190,10 @@ def _measure_effective() -> tuple[int, int]:
 
 @parametrize("backend", PARALLEL_BACKENDS)
 def test_negative_effective_n_jobs_affected_by_parent_pool(backend):
+    """
+    Nested pools get fewer workers, approximately cpu_count() divided by
+    parent's number of workers.
+    """
     n_jobs = max(cpu_count() // 2, 1)
     results = set(
         Parallel(n_jobs=n_jobs, backend=backend)(
@@ -200,7 +204,21 @@ def test_negative_effective_n_jobs_affected_by_parent_pool(backend):
 
     (available_in_worker, available_in_worker_minus_1) = results.pop()
     assert available_in_worker_minus_1 == max(available_in_worker - 1, 1)
-    assert available_in_worker == max(cpu_count() // n_jobs, 1)
+    # See _split_up_cores() for details:
+    expected = _split_up_cores(cpu_count(), n_jobs)
+    assert available_in_worker == expected
+
+
+def test_split_up_cores():
+    """
+    Test heuristic for determining number of workers in nested pool.
+    """
+    for max_cores in range(1, 100):
+        for n_jobs in range(1, max_cores + 1):
+            split = _split_up_cores(max_cores, n_jobs)
+            lower = max(max_cores // n_jobs, 1)
+            assert split in (lower, lower + 1)
+            assert split * n_jobs <= 1.25 * max_cores
 
 
 ###############################################################################

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -221,6 +221,28 @@ def test_split_up_cores():
             assert split * n_jobs <= 1.25 * max_cores
 
 
+@skipif(parallel.effective_n_jobs(-1) < 2, reason="need at least two cores")
+def test_set_thread_cores_limit() -> None:
+    """
+    Test the public API for setting per-thread limits.
+    """
+    limit = parallel.effective_n_jobs(-1)
+    new_limit = limit - 1
+
+    result = []
+
+    def run():
+        parallel.set_thread_cores_limit(new_limit)
+        result.append(parallel.effective_n_jobs(-1))
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join()
+    assert result == [new_limit]
+    # Shouldn't affect other threads!
+    assert parallel.effective_n_jobs(-1) == limit
+
+
 ###############################################################################
 # Test parallel
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -221,28 +221,6 @@ def test_split_up_cores():
             assert split * n_jobs <= 1.25 * max_cores
 
 
-@skipif(parallel.effective_n_jobs(-1) < 2, reason="need at least two cores")
-def test_set_thread_cores_limit() -> None:
-    """
-    Test the public API for setting per-thread limits.
-    """
-    limit = parallel.effective_n_jobs(-1)
-    new_limit = limit - 1
-
-    result = []
-
-    def run():
-        parallel.set_thread_cores_limit(new_limit)
-        result.append(parallel.effective_n_jobs(-1))
-
-    thread = threading.Thread(target=run)
-    thread.start()
-    thread.join()
-    assert result == [new_limit]
-    # Shouldn't affect other threads!
-    assert parallel.effective_n_jobs(-1) == limit
-
-
 ###############################################################################
 # Test parallel
 


### PR DESCRIPTION
Fixes #1824 

This also passes the third-party (OpenMP, BLAS, etc) limiting env variables to `multiprocessing` worker processes, as a side-effect of the implementation. That part is not tested, but could be.