### PR TITLE
FIX make func_code stable across processes when the source is unavailable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Release Notes
 In development
 --------------
 
+- Fix caching of functions whose source cannot be retrieved, such as functions
+  defined in a notebook cell. Their identity fell back to
+  ``str(hash(func.__code__))``, which is salted by ``PYTHONHASHSEED`` and so
+  differed between processes. A worker reading the ``func_code.py`` written by
+  another one concluded that the function had changed and wiped the whole
+  cache directory for it, discarding results computed by its peers.
+  https://github.com/joblib/joblib/issues/1694
+
 - Drop python 3.9 support. The oldest supported Python version
   is now Python 3.10.
   https://github.com/joblib/joblib/pull/1773

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ In development
   differed between processes. A worker reading the ``func_code.py`` written by
   another one concluded that the function had changed and wiped the whole
   cache directory for it, discarding results computed by its peers.
+  ``func_code.py`` is also no longer rewritten in place, so a reader can no
+  longer catch it half-written and draw the same conclusion.
   https://github.com/joblib/joblib/issues/1694
 
 - Drop python 3.9 support. The oldest supported Python version

--- a/joblib/_store_backends.py
+++ b/joblib/_store_backends.py
@@ -290,8 +290,14 @@ class StoreBackendMixin(object):
 
         if func_code is not None:
             filename = os.path.join(func_path, "func_code.py")
-            with self._open_item(filename, "wb") as f:
-                f.write(func_code.encode("utf-8"))
+
+            def write_func(to_write, dest_filename):
+                with self._open_item(dest_filename, "wb") as f:
+                    f.write(to_write.encode("utf-8"))
+
+            # Written in place, another process could read it half-written and
+            # take that for a changed function, wiping the cache (#1694)
+            self._concurrency_safe_write(func_code, filename, write_func)
 
     def get_cached_func_code(self, call_id):
         """Store the code of the cached function."""

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -7,9 +7,11 @@ My own variation on function-specific inspect-like features.
 # License: BSD Style, 3 clauses.
 
 import collections
+import hashlib
 import inspect
 import os
 import re
+import types
 import warnings
 from itertools import islice
 from tokenize import open as open_py_source
@@ -20,6 +22,50 @@ full_argspec_fields = (
     "args varargs varkw defaults kwonlyargs kwonlydefaults annotations"
 )
 full_argspec_type = collections.namedtuple("FullArgSpec", full_argspec_fields)
+
+
+def _code_fingerprint(code):
+    """Digest the contents of a code object.
+
+    ``hash(code)`` would be simpler, but it hashes the strings it is built from
+    and those are salted by PYTHONHASHSEED. This value is written to
+    func_code.py and compared by *other* processes, which then conclude the
+    function changed and wipe its cache directory (#1694).
+
+    The fields below mirror CPython's own ``code_hash()``:
+    https://github.com/python/cpython/blob/5918085bb6f4a3a48193cacb9bb99b044d4e0452/Objects/codeobject.c#L2608-L2624
+    co_localsplusnames is spelled out as varnames/cellvars/freevars, and
+    co_firstlineno and co_linetable are deliberately left out: joblib compares
+    source *text* and tracks the line number separately, so moving a function
+    without editing it must not invalidate its cache.
+    """
+    parts = [
+        code.co_name,
+        # co_code de-specializes adaptive bytecode, like _Py_GetBaseCodeUnit
+        code.co_code.hex(),
+        *code.co_names,
+        *code.co_varnames,
+        *code.co_cellvars,
+        *code.co_freevars,
+        *map(
+            repr,
+            (
+                code.co_argcount,
+                code.co_posonlyargcount,
+                code.co_kwonlyargcount,
+                code.co_flags,
+            ),
+        ),
+    ]
+    for const in code.co_consts:
+        # repr() of a nested code object embeds its address
+        if isinstance(const, types.CodeType):
+            parts.append(_code_fingerprint(const))
+        else:
+            parts.append(repr(const))
+    digest = hashlib.new("md5", usedforsecurity=False)
+    digest.update("\n".join(parts).encode("utf-8", errors="replace"))
+    return digest.hexdigest()
 
 
 def get_func_code(func):
@@ -70,7 +116,7 @@ def get_func_code(func):
         # might change from one session to another.
         if hasattr(func, "__code__"):
             # Python 3.X
-            return str(func.__code__.__hash__()), source_file, -1
+            return _code_fingerprint(func.__code__), source_file, -1
         else:
             # Weird objects like numpy ufunc don't have __code__
             # This is fragile, as quite often the id of the object is

--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -34,15 +34,19 @@ def _code_fingerprint(code):
 
     The fields below mirror CPython's own ``code_hash()``:
     https://github.com/python/cpython/blob/5918085bb6f4a3a48193cacb9bb99b044d4e0452/Objects/codeobject.c#L2608-L2624
-    co_localsplusnames is spelled out as varnames/cellvars/freevars, and
-    co_firstlineno and co_linetable are deliberately left out: joblib compares
-    source *text* and tracks the line number separately, so moving a function
-    without editing it must not invalidate its cache.
+    co_localsplusnames is spelled out as varnames/cellvars/freevars. Only the
+    position information, co_firstlineno and co_linetable, is deliberately left
+    out: joblib compares source *text* and tracks the line number separately,
+    so moving a function without editing it must not invalidate its cache. For
+    the same reason co_filename is not included, unlike ``marshal.dumps``,
+    which would key a notebook function to the cell number it last ran in.
     """
     parts = [
         code.co_name,
         # co_code de-specializes adaptive bytecode, like _Py_GetBaseCodeUnit
         code.co_code.hex(),
+        # 3.11+ moved the try/except ranges out of the bytecode and in here
+        getattr(code, "co_exceptiontable", b"").hex(),
         *code.co_names,
         *code.co_varnames,
         *code.co_cellvars,

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -383,5 +383,4 @@ def test_func_code_consistency_without_source():
     from joblib.parallel import Parallel, delayed
 
     codes = Parallel(n_jobs=2)(delayed(_get_code_no_source)() for _ in range(5))
-    assert len(set(codes)) == 1
     assert set(codes) == {_get_code_no_source()}

--- a/joblib/test/test_func_inspect.py
+++ b/joblib/test/test_func_inspect.py
@@ -357,3 +357,31 @@ def test_func_code_consistency():
 
     codes = Parallel(n_jobs=2)(delayed(_get_code)() for _ in range(5))
     assert len(set(codes)) == 1
+
+
+def _get_code_no_source():
+    # Emulate a function defined in a notebook cell: the source cannot be
+    # retrieved, so get_func_code falls back to digesting the code object.
+    ns = {}
+    exec(
+        compile(
+            "def f(x):\n    return x\n",
+            filename="<ipython-input-0-000000000000>",
+            mode="exec",
+        ),
+        None,
+        ns,
+    )
+    return get_func_code(ns["f"])[0]
+
+
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
+def test_func_code_consistency_without_source():
+    # Non-regression test for #1694: the fallback used to be
+    # str(hash(func.__code__)), which is salted per process, so workers
+    # disagreed and wiped each other's cache entries.
+    from joblib.parallel import Parallel, delayed
+
+    codes = Parallel(n_jobs=2)(delayed(_get_code_no_source)() for _ in range(5))
+    assert len(set(codes)) == 1
+    assert set(codes) == {_get_code_no_source()}

--- a/joblib/test/test_memory.py
+++ b/joblib/test/test_memory.py
@@ -14,6 +14,7 @@ import os
 import os.path
 import pickle
 import shutil
+import subprocess
 import sys
 import textwrap
 import time
@@ -240,6 +241,70 @@ def test_parallel_call_cached_function_defined_in_jupyter(tmpdir, call_before_re
             # The previous cache should not be invalidated after calling the
             # function in a new session
             assert len(os.listdir(f_cache_directory / "f")) == 4
+
+
+# Emulates a notebook cell: the source is not retrievable, so the identity of
+# the function falls back to a digest of its code object.
+_JUPYTER_SESSION = """if 1:
+    import sys
+    import textwrap
+
+    from joblib import Memory
+
+    LOCATION, WITNESS = sys.argv[1], sys.argv[2]
+
+    ns = {}
+    exec(
+        compile(
+            textwrap.dedent('''
+                def f(x):
+                    with open(WITNESS, "a") as fh:
+                        fh.write("ran\\\\n")
+                    return x * 2
+            '''),
+            filename="<ipython-input-0-000000000000>",
+            mode="exec",
+        ),
+        None,
+        ns,
+    )
+    f = ns["f"]
+    f.__module__ = "__main__"
+
+    assert Memory(location=LOCATION, verbose=0).cache(f)(21) == 42
+"""
+
+
+@pytest.mark.thread_unsafe  # https://github.com/joblib/joblib/issues/1816
+def test_cached_jupyter_function_persists_across_sessions(tmpdir):
+    # Non-regression test for gh-1498: a function defined in a notebook cell
+    # must keep the same identity in a new interpreter, so that its cache
+    # survives a kernel restart. That identity used to be hash(func.__code__),
+    # which is salted per process, so each new session decided the function
+    # had changed and wiped its cache (gh-1694).
+    location = tmpdir.join("cache").strpath
+    witness = tmpdir.join("witness").strpath
+
+    joblib_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [os.path.dirname(joblib_root), env.get("PYTHONPATH", "")]
+    )
+
+    # Two seeds stand in for two independently started interpreters, which is
+    # what makes this deterministic rather than one-in-N flaky.
+    for seed in ("1", "2"):
+        env["PYTHONHASHSEED"] = seed
+        p = subprocess.run(
+            [sys.executable, "-c", _JUPYTER_SESSION, location, witness],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert p.returncode == 0, p.stderr
+
+    with open(witness) as fh:
+        assert fh.read().count("ran") == 1, "the second session lost the cache"
 
 
 def test_no_memory():

--- a/joblib/test/test_store_backends.py
+++ b/joblib/test/test_store_backends.py
@@ -5,7 +5,6 @@ try:
 except ImportError:
     import pickle as cpickle
 import functools
-import os
 import time
 from pickle import PicklingError
 
@@ -71,25 +70,23 @@ def test_store_cached_func_code_is_not_written_in_place(tmpdir):
     # rewritten in place, so a concurrent reader could catch it half-written,
     # read that as a changed function and wipe the whole cache directory.
     backend = FileSystemStoreBackend()
-    backend.location = tmpdir.join("store").strpath
-    backend.compress = None
+    backend.configure(tmpdir.join("store").strpath)
 
     call_id = ("mod", "func")
     backend.store_cached_func_code(call_id, "# first line: 1\ndef f(): pass\n")
-    path = os.path.join(backend.location, *call_id, "func_code.py")
-    with open(path) as f:
-        original = f.read()
+    original = backend.get_cached_func_code(call_id)
 
     def exploding_open(name, mode):
         open(name, mode).close()  # truncates whatever it is pointed at
         raise RuntimeError("boom")
 
+    old_open = backend._open_item
     backend._open_item = exploding_open
     with pytest.raises(RuntimeError, match="boom"):
         backend.store_cached_func_code(call_id, "# first line: 1\ndef g(): pass\n")
 
-    with open(path) as f:
-        assert f.read() == original
+    backend._open_item = old_open
+    assert backend.get_cached_func_code(call_id) == original
 
 
 def test_warning_on_dump_failure(tmpdir):

--- a/joblib/test/test_store_backends.py
+++ b/joblib/test/test_store_backends.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     import pickle as cpickle
 import functools
+import os
 import time
 from pickle import PicklingError
 
@@ -63,6 +64,32 @@ def test_concurrency_safe_write(tmpdir, backend):
         for i in range(12)
     ]
     Parallel(n_jobs=2, backend=backend)(delayed(func)(obj, filename) for func in funcs)
+
+
+def test_store_cached_func_code_is_not_written_in_place(tmpdir):
+    # Non-regression test for #1694: func_code.py used to be truncated and
+    # rewritten in place, so a concurrent reader could catch it half-written,
+    # read that as a changed function and wipe the whole cache directory.
+    backend = FileSystemStoreBackend()
+    backend.location = tmpdir.join("store").strpath
+    backend.compress = None
+
+    call_id = ("mod", "func")
+    backend.store_cached_func_code(call_id, "# first line: 1\ndef f(): pass\n")
+    path = os.path.join(backend.location, *call_id, "func_code.py")
+    with open(path) as f:
+        original = f.read()
+
+    def exploding_open(name, mode):
+        open(name, mode).close()  # truncates whatever it is pointed at
+        raise RuntimeError("boom")
+
+    backend._open_item = exploding_open
+    with pytest.raises(RuntimeError, match="boom"):
+        backend.store_cached_func_code(call_id, "# first line: 1\ndef g(): pass\n")
+
+    with open(path) as f:
+        assert f.read() == original
 
 
 def test_warning_on_dump_failure(tmpdir):


### PR DESCRIPTION
Closes #111 (which worked toward #92)
Closes #1498
Closes #1694

I hit #1694 that while working on #1829 and used Claude Opus 5 to investigate. It noticed that the PYTHONHASHSEED [is designed to differ across processes](https://docs.python.org/3/reference/datamodel.html#object.__hash__), so we need to compute the hash without that in there.

... then there was still a failure in like 1 out of every 200 tests (Claude coming through with only the sort of patience an LLM could provide!) and I had it track it down to a *simultaneous write* issue. So that's fixed here, too.

I had it look for other places that a possible concurrent write wasn't protected but it didn't find any.