### PR TITLE
Reject a pre_dispatch below one

### DIFF
--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -1059,7 +1059,7 @@ class Parallel(Logger):
     timeout: float or None, default=None
         Timeout limit for each task to complete.  If any task takes longer
         a TimeOutError will be raised. Only applied when n_jobs != 1
-    pre_dispatch: {'all', integer, or expression, as in '3*n_jobs'}, default='2*n_jobs'
+    pre_dispatch: {'all', positive integer, or expression, as in '3*n_jobs'}, default='2*n_jobs'
         The number of batches (of tasks) to be pre-dispatched.
         Default is '2*n_jobs'. When batch_size="auto" this is reasonable
         default and the workers should never starve. Note that only basic

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -2072,6 +2072,11 @@ class Parallel(Logger):
             if hasattr(pre_dispatch, "endswith"):
                 pre_dispatch = eval_expr(pre_dispatch.replace("n_jobs", str(n_jobs)))
             self._pre_dispatch_amount = pre_dispatch = int(pre_dispatch)
+            if pre_dispatch < 1:
+                raise ValueError(
+                    "pre_dispatch must be 'all' or a positive number of "
+                    "batches, got: %r" % self.pre_dispatch
+                )
 
             # The main thread will consume the first pre_dispatch items and
             # the remaining items will later be lazily dispatched by async

--- a/joblib/parallel.py
+++ b/joblib/parallel.py
@@ -2075,7 +2075,7 @@ class Parallel(Logger):
             if pre_dispatch < 1:
                 raise ValueError(
                     "pre_dispatch must be 'all' or a positive number of "
-                    "batches, got: %r" % self.pre_dispatch
+                    f"batches, got: {self.pre_dispatch!r}"
                 )
 
             # The main thread will consume the first pre_dispatch items and

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1078,14 +1078,6 @@ def test_invalid_pre_dispatch(pre_dispatch):
         )
 
 
-@parametrize("pre_dispatch", [1, "2*n_jobs", "all"])
-def test_valid_pre_dispatch(pre_dispatch):
-    out = Parallel(n_jobs=2, pre_dispatch=pre_dispatch)(
-        delayed(square)(i) for i in range(4)
-    )
-    assert out == [square(i) for i in range(4)]
-
-
 @parametrize(
     "n_tasks, n_jobs, pre_dispatch, batch_size",
     [

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1068,6 +1068,7 @@ def test_invalid_batch_size(batch_size):
         Parallel(batch_size=batch_size)
 
 
+@with_multiprocessing
 @parametrize("pre_dispatch", [0, -1, "0", "0*n_jobs"])
 def test_invalid_pre_dispatch(pre_dispatch):
     """A pre_dispatch below one dispatched nothing and returned no results."""

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -1068,6 +1068,23 @@ def test_invalid_batch_size(batch_size):
         Parallel(batch_size=batch_size)
 
 
+@parametrize("pre_dispatch", [0, -1, "0", "0*n_jobs"])
+def test_invalid_pre_dispatch(pre_dispatch):
+    """A pre_dispatch below one dispatched nothing and returned no results."""
+    with raises(ValueError, match="pre_dispatch must be"):
+        Parallel(n_jobs=2, pre_dispatch=pre_dispatch)(
+            delayed(square)(i) for i in range(4)
+        )
+
+
+@parametrize("pre_dispatch", [1, "2*n_jobs", "all"])
+def test_valid_pre_dispatch(pre_dispatch):
+    out = Parallel(n_jobs=2, pre_dispatch=pre_dispatch)(
+        delayed(square)(i) for i in range(4)
+    )
+    assert out == [square(i) for i in range(4)]
+
+
 @parametrize(
     "n_tasks, n_jobs, pre_dispatch, batch_size",
     [


### PR DESCRIPTION
`Parallel(n_jobs=2, pre_dispatch=0)` returns an empty list:

```python
>>> Parallel(n_jobs=2, pre_dispatch=0)(delayed(abs)(-1) for _ in range(4))
[]
```

The amount is fed straight into `islice`, so nothing is ever dispatched and the caller gets no results and no error for work they asked to run. A negative value surfaces an `islice` error about `sys.maxsize` instead, which says nothing about the argument that was passed.

`batch_size` next to it already refuses a non-positive value, so this follows the same shape and reports the expression as it was passed (so `'0*n_jobs'` is echoed rather than the `0` it evaluated to).

Reverting the change fails the four new tests